### PR TITLE
SWC-4765: set flex grow to 0 so that item does not take up entire row

### DIFF
--- a/src/demo/containers/playground/UserCardDemo.tsx
+++ b/src/demo/containers/playground/UserCardDemo.tsx
@@ -120,7 +120,7 @@ export default class UserBadgeSmallDemo extends React.Component<any, any> {
         <h3> User Card Medium Wrapping Example </h3>
         <div className="SRC-card-grid-row">
           {
-            [1, 2, 3, 4, 5, 6].map(
+            [1, 2, 3, 4, 5].map(
               (_el, index) => {
                 return (
                   <div className="SRC-grid-item" key={index}>

--- a/src/lib/style/Portal.css
+++ b/src/lib/style/Portal.css
@@ -781,24 +781,28 @@ svg.SRC-userImg {
 
 .SRC-grid-item {
   height: 120px;
-  flex-basis: 31%;
-  flex-grow: 1;
+  flex-grow: 0;
+  flex-shrink: 1;
   margin: 10px 10px;
   width: 350px;
   position: relative;
   box-sizing: border-box; }
 
-@media (max-width: 1333px) {
+@media (min-width: 1501px) {
   .SRC-grid-item {
-    flex-basis: 33.33%; } }
+    flex-basis: 32%; } }
+
+@media (max-width: 1500px) {
+  .SRC-grid-item {
+    flex-basis: 31%; } }
 
 @media (max-width: 1073px) {
   .SRC-grid-item {
-    flex-basis: 33.33%; } }
+    flex-basis: 30%; } }
 
 @media (max-width: 815px) {
   .SRC-grid-item {
-    flex-basis: 50%; } }
+    flex-basis: 45%; } }
 
 @media (max-width: 555px) {
   .SRC-grid-item {

--- a/src/lib/style/Portal.scss
+++ b/src/lib/style/Portal.scss
@@ -961,27 +961,32 @@ svg.SRC-userImg {
 
 .SRC-grid-item {
   height: 120px;
-  flex-basis: 31%;
-  flex-grow: 1;
+  flex-grow: 0;
+  flex-shrink: 1;
   margin: 10px 10px;
   width: 350px;
   position: relative;
   box-sizing: border-box;
 }
 
-@media(max-width: 1333px) {
+@media(min-width: 1501px) {
   .SRC-grid-item {
-    flex-basis: 33.33%;
+    flex-basis: 32%;
+  }
+}
+@media(max-width: 1500px) {
+  .SRC-grid-item {
+    flex-basis: 31%;
   }
 }
 @media(max-width: 1073px) {
    .SRC-grid-item {
-    flex-basis: 33.33%;
+    flex-basis: 30%;
   }
 }
 @media(max-width: 815px) {
   .SRC-grid-item {
-    flex-basis: 50%;
+    flex-basis: 45%;
   }
 }
 @media(max-width: 555px) {


### PR DESCRIPTION
fiddle with flex-basis based on width to maximize area (tricky with margin).
also update card demo so that it has an odd number, to demo SWC-4765 bug.