### PR TITLE
got rid of includes method 

### DIFF
--- a/src/lib/containers/UserCardSmall.tsx
+++ b/src/lib/containers/UserCardSmall.tsx
@@ -38,7 +38,7 @@ export const UserCardSmall: React.SFC<UserCardSmallProps> = (
     } else if (userProfile.firstName && userProfile.lastName) {
       label += (`${userProfile.firstName} ${userProfile.lastName}`)
     }
-    if (userProfile.userName && !userProfile.userName.includes('TEMPORARY-')) {
+    if (userProfile.userName) {
       label += ` (${userProfile.userName})`
     }
     if (userProfile.position) {


### PR DESCRIPTION
Includes isn't supported in IE11, additionally we no longer user 'TEMPORARY-' in usernames so the check is not needed