### PR TITLE
cleaned up event handling with markdown synapse

### DIFF
--- a/src/demo/containers/playground/MarkdownSynapseDemo.tsx
+++ b/src/demo/containers/playground/MarkdownSynapseDemo.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import MarkdownSynapse from '../../../lib/containers/MarkdownSynapse'
+
+export const MarkdownSynapseDemo:React.SFC = () => {
+  return (
+    <div className="container">
+      {/* with details tag */}
+      <MarkdownSynapse
+        ownerId={'syn12666371'}
+        wikiId={'585317'}
+      />
+      {/*  with references */}
+      <MarkdownSynapse
+        ownerId={'syn17100797'}
+        wikiId={'587923'}
+      />
+      {/* with  toc */}
+      <MarkdownSynapse
+        ownerId={'syn18380882'}
+        wikiId={'588827'}
+      />
+    </div>
+  )
+}

--- a/src/demo/containers/playground/Playground.tsx
+++ b/src/demo/containers/playground/Playground.tsx
@@ -4,6 +4,7 @@ import QueryWrapperMenuDemo from './QueryWrapperMenuDemo'
 import CardContainerLogicDemo from './CardContainerLogicDemo'
 import SearchDemo from './SearchDemo'
 import UserCardDemo from './UserCardDemo'
+import { MarkdownSynapseDemo } from './MarkdownSynapseDemo'
 
 /**
  * Demo of features that can be used from src/demo/utils/SynapseClient
@@ -25,6 +26,9 @@ const App = ({ match }: { match: match }) => {
           </li>
           <li>
             <Link to={`${match.url}/UserBadgeDemo`}>UserBadgeDemo</Link>
+          </li>
+          <li>
+            <Link to={`${match.url}/MarkdownSynapseDemo`}>MarkdownSynapseDemo</Link>
           </li>
         </ul>
 
@@ -54,6 +58,13 @@ const App = ({ match }: { match: match }) => {
           path={`${match.url}/UserBadgeDemo`}
           // tslint:disable-next-line:jsx-no-lambda
           component={() => <UserCardDemo/>}
+        />
+
+        <Route
+          exact={true}
+          path={`${match.url}/MarkdownSynapseDemo`}
+          // tslint:disable-next-line:jsx-no-lambda
+          component={() => <MarkdownSynapseDemo/>}
         />
 
         <Route


### PR DESCRIPTION
Fixed bug with click handler in markdown component preventing all default events, also added target  as whitelisted attribute to anchor tag