### PR TITLE
feat(DrugTool): add custom validation

### DIFF
--- a/src/__tests__/lib/containers/drug_upload_tool/DrugUploadForm.test.tsx
+++ b/src/__tests__/lib/containers/drug_upload_tool/DrugUploadForm.test.tsx
@@ -1,41 +1,40 @@
-import * as React from 'react';
-import { shallow } from 'enzyme';
-import { Engine } from 'json-rules-engine';
+import * as React from 'react'
+import { shallow } from 'enzyme'
+import { Engine } from 'json-rules-engine'
 import $RefParser from 'json-schema-ref-parser'
+import _ from 'lodash'
 
 import DrugUploadForm, {
   DrugUploadFormProps,
-
-} from '../../../../lib/containers/drug_upload_tool/DrugUploadForm';
+} from '../../../../lib/containers/drug_upload_tool/DrugUploadForm'
 
 import {
-   mockFormSchema as formSchema,
-  mockNavSchema as  formNavSchema,
+  mockFormSchema as formSchema,
+  mockNavSchema as formNavSchema,
   mockFormData as submissionData,
   mockUiSchema as formUiSchema,
-} from '../../../../mocks/mock_drug_tool_data';
-import { NavActionEnum, Step } from 'lib/containers/drug_upload_tool/types';
+  mockInvalidScreenData as inVivoData,
+} from '../../../../mocks/mock_drug_tool_data'
+import { NavActionEnum, Step } from 'lib/containers/drug_upload_tool/types'
 
-const formTitle = 'my submission';
-
+const formTitle = 'my submission'
 
 const newFormData = {
   metadata: {
- formSchemaVersion: '01',
- uiSchemaVersion: '01',
- navSchemaVersion: '01',
-}
+    formSchemaVersion: '01',
+    uiSchemaVersion: '01',
+    navSchemaVersion: '01',
+  },
 }
 
 const createShallowComponent = async (props: DrugUploadFormProps) => {
+  const schema = await $RefParser.dereference(props.schema)
+  const _props = { ...props, ...{ schema } }
+  const wrapper = shallow<DrugUploadForm>(<DrugUploadForm {..._props} />, {})
 
-  const schema = await $RefParser.dereference(props.schema) 
-  const _props = { ...props, ...{ schema} }
-  const wrapper = shallow<DrugUploadForm>(<DrugUploadForm {..._props} />, {});
-
-  const instance = wrapper.instance();
-  return { wrapper, instance };
-};
+  const instance = wrapper.instance()
+  return { wrapper, instance }
+}
 
 const mock = {
   submitFn: jest.fn(() => 'ok'),
@@ -43,10 +42,10 @@ const mock = {
   formRef: {
     current: {
       submit: jest.fn(() => ''),
-      setState: jest.fn(() => '')
-    }
-  }
-};
+      setState: jest.fn(() => ''),
+    },
+  },
+}
 
 const props: DrugUploadFormProps = {
   schema: formSchema,
@@ -58,118 +57,223 @@ const props: DrugUploadFormProps = {
   onSubmit: mock.submitFn,
   onSave: mock.saveFn,
   formTitle: formTitle,
-  isWizardMode: false
-};
+  isWizardMode: false,
+}
 
-Engine.run = jest.fn(() => Promise.resolve('restrictions'));
+Engine.run = jest.fn(() => Promise.resolve('restrictions'))
 
 describe('initialization tests', () => {
   it('intialize for new submission', async () => {
-    const { instance, wrapper } = await createShallowComponent(props);
+    const { instance, wrapper } = await createShallowComponent(props)
 
-    expect(wrapper).toBeDefined();
-    expect(instance.state.steps.length).toBe(props.navSchema.steps.length);
-    expect(instance.state.formData).toEqual(newFormData);
-    expect(instance.state.currentStep.id).toBe(props.navSchema.steps[0].id);
-    expect(Object.keys(props.schema.properties!).length).toBeGreaterThan(1);
-    const schema = instance.getSchema(instance.state.currentStep);
-    expect(Object.keys(schema.properties).length).toBe(1);
+    expect(wrapper).toBeDefined()
+    expect(instance.state.steps.length).toBe(props.navSchema.steps.length)
+    expect(instance.state.formData).toEqual(newFormData)
+    expect(instance.state.currentStep.id).toBe(props.navSchema.steps[0].id)
+    expect(Object.keys(props.schema.properties!).length).toBeGreaterThan(1)
+    const schema = instance.getSchema(instance.state.currentStep)
+    expect(Object.keys(schema.properties).length).toBe(1)
     expect(Object.keys(schema.properties)[0]).toEqual(
-      Object.keys(props.schema.properties!)[0]
-    );
-  });
+      Object.keys(props.schema.properties!)[0],
+    )
+  })
 
   it('intialize for existing submission', async () => {
-    const _props = { ...props, ...{ formData: submissionData } };
-    const { instance, wrapper } = await createShallowComponent(_props);
-   
-    expect(wrapper).toBeDefined();
+    const _props = { ...props, ...{ formData: submissionData } }
+    const { instance, wrapper } = await createShallowComponent(_props)
+
+    expect(wrapper).toBeDefined()
     expect(instance.state.formData['naming']['first_name']).toBe(
-      submissionData.naming.first_name
-    );
-  });
-});
+      submissionData.naming.first_name,
+    )
+  })
+})
 
 describe('action tests', () => {
-  let instance : any
-  let  wrapper : any 
+  let instance: any
+  let wrapper: any
   beforeEach(async () => {
-    ({ instance, wrapper } = await createShallowComponent(props));
-    instance.formRef = mock.formRef;
-  });
+    ;({ instance, wrapper } = await createShallowComponent(props))
+    instance.formRef = mock.formRef
+  })
 
   it('go to next step', async () => {
-    const submitSpy = jest.spyOn(instance, 'onSubmit');
-    const saveState = jest.spyOn(instance, 'saveStepState');
+    const submitSpy = jest.spyOn(instance, 'onSubmit')
+    const saveState = jest.spyOn(instance, 'saveStepState')
     const getNextStepFn = jest
       .spyOn(instance, 'getNextStepId')
-      .mockReturnValue(Promise.resolve('measurements'));
-    expect(wrapper).toBeDefined();
-    expect(instance.state.currentStep).toEqual(instance.state.steps[0]);
-    instance.triggerAction(NavActionEnum.NEXT);
-    expect(submitSpy).toHaveBeenCalled;
-    const oldStepId = instance.state.currentStep.id;
-    await instance.performAction(NavActionEnum.NEXT, false);
+      .mockReturnValue(Promise.resolve('measurements'))
+    expect(wrapper).toBeDefined()
+    expect(instance.state.currentStep).toEqual(instance.state.steps[0])
+    instance.triggerAction(NavActionEnum.NEXT)
+    expect(submitSpy).toHaveBeenCalled
+    const oldStepId = instance.state.currentStep.id
+    await instance.performAction(NavActionEnum.NEXT, false)
 
     expect(getNextStepFn).toHaveBeenCalledWith(
       jasmine.objectContaining({ id: oldStepId }),
       instance.state.formData,
-      undefined
-    );
+      undefined,
+    )
     const nextStep = instance.state.steps.find(
-      (step: Step) => (step.id === 'measurements')
-    );
-    expect(saveState).toBeCalledTimes(1);
-    expect(instance.state.currentStep.id).toEqual(nextStep!.id);
-  });
+      (step: Step) => step.id === 'measurements',
+    )
+    expect(saveState).toBeCalledTimes(1)
+    expect(instance.state.currentStep.id).toEqual(nextStep!.id)
+  })
 
   it('go to predetermined step', async () => {
-    const submitSpy = jest.spyOn(instance, 'onSubmit');
-    const saveState = jest.spyOn(instance, 'saveStepState');
-    const getNextStepFn = jest.spyOn(instance, 'getNextStepId');
+    const submitSpy = jest.spyOn(instance, 'onSubmit')
+    const saveState = jest.spyOn(instance, 'saveStepState')
+    const getNextStepFn = jest.spyOn(instance, 'getNextStepId')
 
-    expect(instance.state.currentStep).toEqual(instance.state.steps[0]);
-    instance.nextStep = instance.state.steps[3];
+    expect(instance.state.currentStep).toEqual(instance.state.steps[0])
+    instance.nextStep = instance.state.steps[3]
 
-    instance.triggerAction(NavActionEnum.GO_TO_STEP);
-    expect(submitSpy).toHaveBeenCalled;
-    const oldStepId = instance.state.currentStep.id;
-    await instance.performAction(NavActionEnum.GO_TO_STEP, false);
+    instance.triggerAction(NavActionEnum.GO_TO_STEP)
+    expect(submitSpy).toHaveBeenCalled
+    const oldStepId = instance.state.currentStep.id
+    await instance.performAction(NavActionEnum.GO_TO_STEP, false)
 
     expect(getNextStepFn).toHaveBeenCalledWith(
       jasmine.objectContaining({ id: oldStepId }),
       instance.state.formData,
-      instance.state.steps[3].id
-    );
+      instance.state.steps[3].id,
+    )
 
-    expect(saveState).toBeCalledTimes(1);
-    expect(instance.state.currentStep.id).toEqual(instance.state.steps[3].id);
-  });
+    expect(saveState).toBeCalledTimes(1)
+    expect(instance.state.currentStep.id).toEqual(instance.state.steps[3].id)
+  })
 
   it('go to previous numerical step if not wizard', async () => {
-    instance.nextStep = instance.state.steps[3];
-    await instance.performAction(NavActionEnum.GO_TO_STEP, false);
-    expect(instance.state.currentStep.id).toEqual(instance.state.steps[3].id);
-    await instance.performAction(NavActionEnum.PREVIOUS, false);
-    expect(instance.state.currentStep.id).toEqual(instance.state.steps[2].id);
-  });
+    instance.nextStep = instance.state.steps[3]
+    await instance.performAction(NavActionEnum.GO_TO_STEP, false)
+    expect(instance.state.currentStep.id).toEqual(instance.state.steps[3].id)
+    await instance.performAction(NavActionEnum.PREVIOUS, false)
+    expect(instance.state.currentStep.id).toEqual(instance.state.steps[2].id)
+  })
 
   it('go to previous visited step if  wizard', async () => {
-    const _props = { ...props, ...{ isWizard: true } };
-    let { instance } = await createShallowComponent(_props);
-    instance.formRef = mock.formRef;
-    instance.nextStep = instance.state.steps[3];
-    await instance.performAction(NavActionEnum.GO_TO_STEP, false);
-    expect(instance.state.currentStep.id).toEqual(instance.state.steps[3].id);
-    await instance.performAction(NavActionEnum.PREVIOUS, false);
-    expect(instance.state.currentStep.id).toEqual(instance.state.steps[2].id);
-  });
-
-  it('trigger validation', async () => {
-    //TODO
-  });
+    const _props = { ...props, ...{ isWizard: true } }
+    let { instance } = await createShallowComponent(_props)
+    instance.formRef = mock.formRef
+    instance.nextStep = instance.state.steps[3]
+    await instance.performAction(NavActionEnum.GO_TO_STEP, false)
+    expect(instance.state.currentStep.id).toEqual(instance.state.steps[3].id)
+    await instance.performAction(NavActionEnum.PREVIOUS, false)
+    expect(instance.state.currentStep.id).toEqual(instance.state.steps[2].id)
+  })
 
   it('show warning when excluding a screen', async () => {
-    //TODO
-  });
-});
+    instance.nextStep = instance.state.steps[4]
+    const excludeSpy = jest.spyOn(instance, 'showExcludeStateWarningModal')
+    await instance.performAction(NavActionEnum.GO_TO_STEP, false)
+    expect(instance.state.currentStep.id).toEqual(instance.state.steps[4].id)
+    wrapper.find('.step-exclude-directions button').simulate('click')
+    expect(excludeSpy).toHaveBeenCalled()
+  })
+})
+
+describe('custom validation tests', () => {
+  let instance: any
+  let wrapper: any
+  const updatedData = _.cloneDeep(submissionData)
+  updatedData['in_vivo_data'] = inVivoData.in_vivo_data
+  beforeEach(async () => {
+    ;({ instance, wrapper } = await createShallowComponent({
+      ...props,
+      ...{ formData: updatedData },
+    }))
+    instance.formRef = mock.formRef
+  })
+
+  it('check custom validation before submitting the form', async () => {
+    const submitSpy = jest.spyOn(instance, 'onSubmit')
+    const customValidation = jest.spyOn(instance, 'runCustomValidation')
+    instance.nextStep = instance.state.steps[3]
+    instance.triggerAction(NavActionEnum.GO_TO_STEP)
+    await instance.performAction(NavActionEnum.GO_TO_STEP, false)
+    expect(submitSpy).toHaveBeenCalled
+    expect(customValidation).toHaveBeenCalled
+  })
+
+  it('only run custom validation on all sections if the state is final', async () => {
+    const currentStep = instance.state.steps[instance.state.steps.length - 1]
+    expect(currentStep.final).toBe(true)
+    expect(currentStep.validationRules).toBeUndefined()
+    const errors = await instance.runCustomValidation(
+      updatedData,
+      currentStep,
+      instance.state.steps,
+    )
+    expect(errors).toHaveLength(5)
+  })
+
+  it('run custom validation on a single  section if the step is not final', async () => {
+    const currentStep = instance.state.steps[0]
+    expect(currentStep.final).toBeFalsy()
+    expect(currentStep.validationRules.length).toBe(2)
+    const errors = await instance.runCustomValidation(
+      updatedData,
+      currentStep,
+      instance.state.steps,
+    )
+    expect(errors).toHaveLength(1)
+  })
+
+  it('should generate additional rules if the the rule is specified with [*]', async () => {
+    const currentStep = instance.state.steps[6]
+    expect(currentStep.final).toBeFalsy()
+    expect(currentStep.validationRules.length).toBe(2)
+    expect(
+      currentStep.validationRules[0].event.params.property.indexOf('[*]'),
+    ).not.toBe(-1)
+    expect(
+      currentStep.validationRules[1].event.params.property.indexOf('[*]'),
+    ).not.toBe(-1)
+    expect(
+      updatedData.in_vivo_data.experiments[0].age_range.age_range_min,
+    ).toBeGreaterThan(
+      updatedData.in_vivo_data.experiments[0].age_range.age_range_max,
+    )
+    expect(
+      updatedData.in_vivo_data.experiments[1].age_range.age_range_min,
+    ).toBeGreaterThan(
+      updatedData.in_vivo_data.experiments[1].age_range.age_range_max,
+    )
+    expect(
+      updatedData.in_vivo_data.experiments[0].dose_range.dose_range_min,
+    ).toBeGreaterThan(
+      updatedData.in_vivo_data.experiments[0].dose_range.dose_range_max,
+    )
+    expect(
+      updatedData.in_vivo_data.experiments[1].dose_range.dose_range_min,
+    ).toBeGreaterThan(
+      updatedData.in_vivo_data.experiments[1].dose_range.dose_range_max,
+    )
+
+    expect(updatedData['in_vivo_data']['experiments']).toHaveLength(2)
+    let errors = await instance.runCustomValidation(
+      updatedData,
+      currentStep,
+      instance.state.steps,
+    )
+    expect(errors).toHaveLength(4)
+    updatedData.in_vivo_data.experiments[0].age_range.age_range_min = 2
+    updatedData.in_vivo_data.experiments[0].dose_range.dose_range_min = 1
+    errors = await instance.runCustomValidation(
+      updatedData,
+      currentStep,
+      instance.state.steps,
+    )
+    expect(errors).toHaveLength(2)
+    updatedData.in_vivo_data.experiments[1].age_range.age_range_min = 2
+    updatedData.in_vivo_data.experiments[1].dose_range.dose_range_min = 1
+    errors = await instance.runCustomValidation(
+      updatedData,
+      currentStep,
+      instance.state.steps,
+    )
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/src/lib/containers/drug_upload_tool/types.ts
+++ b/src/lib/containers/drug_upload_tool/types.ts
@@ -3,25 +3,26 @@ export enum StepStateEnum {
   PROGRESS,
   COMPLETED,
   EXCLUDED,
-  ERROR
+  ERROR,
 }
 
 export type Step = {
-  id: string;
-  title: string;
-  order: number;
-  state: StepStateEnum;
-  inProgress: boolean;
-  rules: any[];
-  default: string;
-  excluded?: boolean;
-  final?: boolean;
-  description?: string;
-  copy?: string;
-  static?: boolean;
-  child?: boolean;
-  children?: string[];
-};
+  id: string
+  title: string
+  order: number
+  state: StepStateEnum
+  inProgress: boolean
+  rules?: any[]
+  validationRules?: any[]
+  default: string
+  excluded?: boolean
+  final?: boolean
+  description?: string
+  copy?: string
+  static?: boolean
+  child?: boolean
+  children?: string[]
+}
 
 export enum NavActionEnum {
   PREVIOUS,
@@ -30,7 +31,7 @@ export enum NavActionEnum {
   SAVE,
   SUBMIT,
   VALIDATE,
-  NONE
+  NONE,
 }
 
 export enum StatusEnum {
@@ -38,16 +39,44 @@ export enum StatusEnum {
   ERROR,
   SAVE_SUCCESS,
   SUBMIT_SUCCESS,
-  ERROR_CRITICAL
+  ERROR_CRITICAL,
 }
 
 export interface SummaryFormat {
-  screen: Step;
-  label: string;
-  value: string;
+  screen: Step
+  label: string
+  value: string
 }
 
 export type FormSchema = {
   properties?: any
   definitions?: any
+}
+
+export interface IRulesEvent {
+  type: string
+  params: any
+}
+export interface IRulesNavigationEvent extends IRulesEvent {
+  params: {
+    next: string
+  }
+}
+
+export interface IRulesValidationEvent extends IRulesEvent {
+  params: {
+    message: string
+    name: string
+    property: string
+  }
+}
+
+export type RulesResult = {
+  events: IRulesNavigationEvent[] | IRulesValidationEvent[]
+}
+
+export interface IAdditionalError {
+  screen: string
+  field: string
+  message: string
 }

--- a/src/mocks/mockDrugToolFormData.json
+++ b/src/mocks/mockDrugToolFormData.json
@@ -1,76 +1,75 @@
 {
-    "efficacy": {
-      "cell_line_efficacy": [
-        {
-          "name": "somename",
-          "cell_line": "Cell Line Efficacy Value",
-          "reference": "Non sunt aut suscip",
-          "assay_description": "Quam explicabo Dele",
-          "outcome_measures": "Voluptas omnis et ve",
-          "efficacy_measure": "Necessitatibus paria",
-          "efficacy_measure_type": "EC50"
-        },
-        {
-          "name": "Abel Murphy",
-          "cell_line": "Minima nisi repudian",
-          "reference": "Fugiat minus invento",
-          "assay_description": "Accusamus in fugit ",
-          "outcome_measures": "Quia neque anim aliq",
-          "efficacy_measure": "Voluptatem qui exce",
-          "efficacy_measure_type": "EC50"
-        }
-      ]
-    },
-    "binding": {
-      "cell_line_binding": [
-        {
-          "name": "Mollie Dyer",
-          "cell_line": "Et natus hic necessi",
-          "reference": "Adipisicing cupidata",
-          "binding_affinity": "Et tenetur sed quibu",
-          "assay_description": "Nulla aut dolores ex",
-          "binding_affinity_constant": "Kd"
-        }
-      ]
-    },
-    "measurements": {
-      "is_solution": false,
-      "molecular_weight": 40,
-      "compound_availability": 44
-    },
-    "naming": {
-      "data_sharing": false,
-      "is_off_label": false,
-      "compound_name": "Submission_Name",
-      "first_name": "Hall",
-      "last_name": "Dennis",
-      "role_title": "Ullamco harum est vo",
-      "institution": "Ipsam eu quis conseq",
-      "email": "koqyh@mailinator.net",
-      "other_applicants": "Ad omnis maxime aute",
-      "chemical_name": "some chemical",
-      "common_name": "Francesca Dillon",
-      "iupac_name": "Isabella Bean",
-      "CAS_number": "752",
-      "drug_class": "Dolor aut ea earum e"
-    },
-    "basic": {
-        "molecular_target": "sadasd",
-        "moa_description": "asd",
-        "therapeutic_approach": "symptomatic",
-        "therapeutic_indication_description": "asdasd",
-        "water_soluble": "unknown",
-        "route": [
-          "sublingual",
-          "injection",
-          "transdermal"
-        ],
-        "orally_active": "no"
+  "efficacy": {
+    "cell_line_efficacy": [
+      {
+        "name": "somename",
+        "cell_line": "Cell Line Efficacy Value",
+        "reference": "Non sunt aut suscip",
+        "assay_description": "Quam explicabo Dele",
+        "outcome_measures": "Voluptas omnis et ve",
+        "efficacy_measure": "Necessitatibus paria",
+        "efficacy_measure_type": "EC50"
       },
-  
-    "metadata": {
-      "formSchemaVersion": 154,
-      "uiSchemaVersion": 80,
-      "navSchemaVersion": 35
-    }
+      {
+        "name": "Abel Murphy",
+        "cell_line": "Minima nisi repudian",
+        "reference": "Fugiat minus invento",
+        "assay_description": "Accusamus in fugit ",
+        "outcome_measures": "Quia neque anim aliq",
+        "efficacy_measure": "Voluptatem qui exce",
+        "efficacy_measure_type": "EC50"
+      }
+    ]
+  },
+  "binding": {
+    "cell_line_binding": [
+      {
+        "name": "Mollie Dyer",
+        "cell_line": "Et natus hic necessi",
+        "reference": "Adipisicing cupidata",
+        "binding_affinity": "Et tenetur sed quibu",
+        "assay_description": "Nulla aut dolores ex",
+        "binding_affinity_constant": "Kd"
+      }
+    ]
+  },
+  "measurements": {
+    "is_solution": false,
+    "molecular_weight": 40,
+    "compound_availability": 44
+  },
+  "naming": {
+    "data_sharing": false,
+    "is_off_label": false,
+    "compound_name": "Submission_Name",
+    "first_name": "bob",
+    "last_name": "Dennis",
+    "role_title": "Ullamco harum est vo",
+    "institution": "Ipsam eu quis conseq",
+    "email": "koqyh@mailinator.net",
+    "other_applicants": "Ad omnis maxime aute",
+    "chemical_name": "some chemical",
+    "common_name": "Francesca Dillon",
+    "iupac_name": "Isabella Bean",
+    "CAS_number": "752",
+    "drug_class": "Dolor aut ea earum e"
+  },
+  "basic": {
+    "molecular_target": "sadasd",
+    "moa_description": "asd",
+    "therapeutic_approach": "symptomatic",
+    "therapeutic_indication_description": "asdasd",
+    "water_soluble": "unknown",
+    "route": ["sublingual", "injection", "transdermal"],
+    "orally_active": "no"
+  },
+  "in_vivo_data": {
+
+  },
+
+  "metadata": {
+    "formSchemaVersion": 154,
+    "uiSchemaVersion": 80,
+    "navSchemaVersion": 35
   }
+}

--- a/src/mocks/mockDrugToolFormDataComplexInvalid.json
+++ b/src/mocks/mockDrugToolFormDataComplexInvalid.json
@@ -1,0 +1,58 @@
+{
+    "in_vivo_data": {
+        "experiments": [
+            {
+                "age_range": {
+                    "age_range_min": 119,
+                    "age_range_max": 18
+                },
+                "dose_range": {
+                    "dose_range_min": 36,
+                    "dose_range_max": 9
+                },
+                "drug_formulation": "Culpa veniam nostru",
+                "name": "Ina Rhodes",
+                "reference": "Fugiat voluptatem iu",
+                "strain": "Tempora labore delen",
+                "ed50": "Possimus consequat",
+                "pretreatment_time": "Porro natus quo non ",
+                "outcome_measures": "Harum reiciendis des",
+                "assay_description": "Vel quae facere erro",
+                "adverse_events_description": "Illo explicabo Sit",
+                "species": "rabbit",
+                "route": [
+                    "formulated_in_drinking_water"
+                ],
+                "dose_regimen": "sub_chronic",
+                "sex": "female"
+            },
+            {
+                "age_range": {
+                    "age_range_min": 107,
+                    "age_range_max": 33
+                },
+                "dose_range": {
+                    "dose_range_min": 87,
+                    "dose_range_max": 10
+                },
+                "name": "Yvette Terrell",
+                "reference": "Est et ipsum proiden",
+                "strain": "Nam fugit non tenet",
+                "ed50": "Nam ab quo rerum del",
+                "pretreatment_time": "Officiis optio sapi",
+                "outcome_measures": "Unde consequatur mi",
+                "assay_description": "Id ut sint facilis l",
+                "drug_formulation": "Non quisquam non quo",
+                "adverse_events_description": "Duis iste voluptatem",
+                "species": "dog",
+                "route": [
+                    "transdermal",
+                    "formulated_in_food",
+                    "formulated_in_drinking_water"
+                ],
+                "sex": "both",
+                "dose_regimen": "chronic"
+            }
+        ]
+    }
+}

--- a/src/mocks/mockDrugToolFormNavSchema.json
+++ b/src/mocks/mockDrugToolFormNavSchema.json
@@ -1,11 +1,61 @@
 {
-    "steps": [
+  "steps": [
     {
       "id": "naming",
       "order": 5,
       "title": "Naming",
       "default": "measurements",
-      "child": true
+      "child": true,
+      "validationRules": [
+        {
+          "conditions": {
+            "all": [
+              {
+                "fact": "naming",
+                "operator": "equal",
+                "path": ".first_name",
+                "value": "bob"
+              }
+            ]
+          },
+          "event": {
+            "type": "validation",
+            "params": {
+              "message": "is bad",
+              "name": "bad",
+              "property": ".naming.first_name"
+            }
+          },
+          "priority:": 9
+        },
+        {
+          "conditions": {
+            "all": [
+              {
+                "fact": "naming",
+                "operator": "notEqual",
+                "path": ".first_name",
+                "value": "jane"
+              },
+              {
+                "fact": "naming",
+                "operator": "equal",
+                "path": ".last_name",
+                "value": "doe"
+              }
+            ]
+          },
+          "event": {
+            "type": "validation",
+            "params": {
+              "message": "is bad2 last",
+              "name": "bad",
+              "property": ".naming.last_name"
+            }
+          },
+          "priority:": 10
+        }
+      ]
     },
     {
       "id": "measurements",
@@ -21,45 +71,102 @@
       "default": "in_vitro",
       "child": true
     },
-    
-  
-      {
-        "id": "in_vitro",
-        "order": 20,
-        "title": "In Vitro",
-        "default": "binding",
-        "static": "true",
-        "copy": "<p>Use this section to enter results from any in vitro binding and efficacy studies that have been performed on this compound, including which cell lines were used, the binding affinity, and the IC50 or EC50. If this data is not yet available for this compound,  you can select “Exclude” from the Binding and Efficacy sub menus.</p>",
-        "children": ["binding", "efficacy"]
-      },
-      {
-        "id": "binding",
-        "order": 21,
-        "title": "Binding",
-        "child": true,
-        "excluded": false,
-        "default": "efficacy",
-        "rules": []
-      },
-      {
-        "id": "efficacy",
-        "order": 22,
-        "title": "Efficacy",
-        "child": true,
-        "excluded": false,
-        "default": "submission",
-        "rules": []
-      },
-     
-      {
-        "id": "submission",
-        "order": 80,
-        "title": "Submit",
-        "description": "<p>You are about to submit the form. Once you submit, you will no longer be able to edit the submission. If you are not ready to submit, you can save and revisit the form at a later time.</p>",
-        "default": null,
-        "final": true,
-        "rules": []
-      }
-    ]
-  }
-  
+    {
+      "id": "in_vitro",
+      "order": 20,
+      "title": "In Vitro",
+      "default": "binding",
+      "static": "true",
+      "copy": "<p>Use this section to enter results from any in vitro binding and efficacy studies that have been performed on this compound, including which cell lines were used, the binding affinity, and the IC50 or EC50. If this data is not yet available for this compound,  you can select “Exclude” from the Binding and Efficacy sub menus.</p>",
+      "children": [
+        "binding",
+        "efficacy"
+      ]
+    },
+    {
+      "id": "binding",
+      "order": 21,
+      "title": "Binding",
+      "child": true,
+      "excluded": false,
+      "default": "efficacy",
+      "rules": []
+    },
+    {
+      "id": "efficacy",
+      "order": 22,
+      "title": "Efficacy",
+      "child": true,
+      "excluded": false,
+      "default": "in_vivo_data",
+      "rules": []
+    },
+    {
+      "id": "in_vivo_data",
+      "order": 40,
+      "title": "In Vivo Data",
+      "default": "submission",
+      "excluded": false,
+      "child": true,
+      "validationRules": [
+        {
+          "conditions": {
+            "all": [
+              {
+                "fact": "in_vivo_data",
+                "operator": "greaterThan",
+                "path": ".experiments[*].age_range.age_range_min",
+                "value": {
+                  "fact": "in_vivo_data",
+                  "path": ".experiments[*].age_range.age_range_max"
+                }
+              }
+            ]
+          },
+          "event": {
+            "type": "validation",
+            "params": {
+              "message": "minimum age should be less than maximum age",
+              "name": "range",
+              "property": ".in_vivo_data.experiments[*].age_range"
+            }
+          },
+          "priority:": 1
+        },
+        {
+          "conditions": {
+            "all": [
+              {
+                "fact": "in_vivo_data",
+                "operator": "greaterThan",
+                "path": ".experiments[*].dose_range.dose_range_min",
+                "value": {
+                  "fact": "in_vivo_data",
+                  "path": ".experiments[*].dose_range.dose_range_max"
+                }
+              }
+            ]
+          },
+          "event": {
+            "type": "validation",
+            "params": {
+              "message": "minimum dose should be less than maximum dose ",
+              "name": "range",
+              "property": ".in_vivo_data.experiments[*].dose_range"
+            }
+          },
+          "priority:": 1
+        }
+      ]
+    },
+    {
+      "id": "submission",
+      "order": 80,
+      "title": "Submit",
+      "description": "<p>You are about to submit the form. Once you submit, you will no longer be able to edit the submission. If you are not ready to submit, you can save and revisit the form at a later time.</p>",
+      "default": null,
+      "final": true,
+      "rules": []
+    }
+  ]
+}

--- a/src/mocks/mockDrugToolFormSchema.json
+++ b/src/mocks/mockDrugToolFormSchema.json
@@ -27,12 +27,15 @@
         "binding_affinity_constant": {
           "type": "string",
           "title": "Binding Affinity Constant",
-          "enum": ["Ki", "Kd", "Km"],
+          "enum": [
+            "Ki",
+            "Kd",
+            "Km"
+          ],
           "uniqueItems": true
         }
       }
     },
-
     "efficacy_item": {
       "type": "object",
       "required": [],
@@ -64,13 +67,18 @@
         "efficacy_measure_type": {
           "type": "string",
           "title": "Efficacy Measure",
-          "enum": ["EC50", "IC50"],
-          "enumNames": ["EC50 (mg/kg)", "IC50 (nmol/L)"],
+          "enum": [
+            "EC50",
+            "IC50"
+          ],
+          "enumNames": [
+            "EC50 (mg/kg)",
+            "IC50 (nmol/L)"
+          ],
           "uniqueItems": true
         }
       }
     },
-
     "naming": {
       "type": "object",
       "required": [
@@ -113,16 +121,28 @@
         "data_sharing": {
           "type": "boolean",
           "default": false,
-          "enum": [true, false],
-          "enumNames": ["I agree to data sharing", "I want to discuss further"],
+          "enum": [
+            true,
+            false
+          ],
+          "enumNames": [
+            "I agree to data sharing",
+            "I want to discuss further"
+          ],
           "uniqueItems": true,
           "title": "Data Sharing"
         },
         "is_off_label": {
           "type": "boolean",
           "default": false,
-          "enum": [true, false],
-          "enumNames": ["Yes", "No"],
+          "enum": [
+            true,
+            false
+          ],
+          "enumNames": [
+            "Yes",
+            "No"
+          ],
           "uniqueItems": true,
           "title": "Is this compound available for off label use?"
         },
@@ -150,7 +170,11 @@
     },
     "measurements": {
       "type": "object",
-      "required": ["compound_availability", "molecular_weight", "is_solution"],
+      "required": [
+        "compound_availability",
+        "molecular_weight",
+        "is_solution"
+      ],
       "properties": {
         "compound_availability": {
           "title": "Available compound amount (mg)",
@@ -164,8 +188,14 @@
         "is_solution": {
           "title": "Is the compound a solution?",
           "type": "boolean",
-          "enum": [true, false],
-          "enumNames": ["Yes", "No"],
+          "enum": [
+            true,
+            false
+          ],
+          "enumNames": [
+            "Yes",
+            "No"
+          ],
           "default": false
         }
       },
@@ -175,14 +205,18 @@
             {
               "properties": {
                 "is_solution": {
-                  "enum": [false]
+                  "enum": [
+                    false
+                  ]
                 }
               }
             },
             {
               "properties": {
                 "is_solution": {
-                  "enum": [true]
+                  "enum": [
+                    true
+                  ]
                 },
                 "compound_concentration": {
                   "title": "Concentration (mg/ml)",
@@ -221,8 +255,18 @@
         },
         "therapeutic_approach": {
           "type": "string",
-          "enum": ["prophylactic", "symptomatic", "both", "unknown"],
-          "enumNames": ["Prophylactic", "Symptomatic", "Both", "Unknown"],
+          "enum": [
+            "prophylactic",
+            "symptomatic",
+            "both",
+            "unknown"
+          ],
+          "enumNames": [
+            "Prophylactic",
+            "Symptomatic",
+            "Both",
+            "Unknown"
+          ],
           "uniqueItems": true,
           "title": "What is the therapeutic approach?"
         },
@@ -244,8 +288,16 @@
         },
         "water_soluble": {
           "type": "string",
-          "enum": ["yes", "no", "unknown"],
-          "enumNames": ["Yes", "No", "Unknown"],
+          "enum": [
+            "yes",
+            "no",
+            "unknown"
+          ],
+          "enumNames": [
+            "Yes",
+            "No",
+            "Unknown"
+          ],
           "uniqueItems": true,
           "title": "Is the compound water soluble?"
         },
@@ -279,8 +331,16 @@
         },
         "orally_active": {
           "type": "string",
-          "enum": ["yes", "no", "unknown"],
-          "enumNames": ["Yes", "No", "Unknown"],
+          "enum": [
+            "yes",
+            "no",
+            "unknown"
+          ],
+          "enumNames": [
+            "Yes",
+            "No",
+            "Unknown"
+          ],
           "uniqueItems": true,
           "title": "Is the drug orally active?"
         }
@@ -291,7 +351,10 @@
             {
               "properties": {
                 "water_soluble": {
-                  "enum": ["no", "unknown"]
+                  "enum": [
+                    "no",
+                    "unknown"
+                  ]
                 }
               },
               "required": []
@@ -299,14 +362,219 @@
             {
               "properties": {
                 "water_soluble": {
-                  "enum": ["yes"]
+                  "enum": [
+                    "yes"
+                  ]
                 },
                 "solubility_limitations": {
                   "type": "string",
                   "title": "Describe any solubility limitations"
                 }
               },
-              "required": ["solubility_limitations"]
+              "required": [
+                "solubility_limitations"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "in_vivo_data_item": {
+      "type": "object",
+      "required": [
+        "species",
+        "strain",
+        "outcome_measures",
+        "assay_description",
+        "age_range",
+        "sex",
+        "dose_range",
+        "dose_regimen",
+        "route",
+        "drug_formulation"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Experiment Name"
+        },
+        "reference": {
+          "type": "string",
+          "title": "If this study has been published, please provide a reference."
+        },
+        "species": {
+          "type": "string",
+          "title": "Species",
+          "enum": [
+            "mouse",
+            "rat",
+            "non_human_primate",
+            "dog",
+            "ferret",
+            "rabbit",
+            "other"
+          ],
+          "enumNames": [
+            "Mouse",
+            "Rat",
+            "Non Human Primate",
+            "Dog",
+            "Ferret",
+            "Rabbit",
+            "Other"
+          ],
+          "uniqueItems": true
+        },
+        "strain": {
+          "type": "string",
+          "title": "Model Strain"
+        },
+        "outcome_measures": {
+          "type": "string",
+          "title": "Outcome Measure"
+        },
+        "assay_description": {
+          "type": "string",
+          "title": "Assay Description"
+        },
+        "age_range": {
+          "type": "object",
+          "title": "Subject Age (months)",
+          "properties": {
+            "age_range_min": {
+              "title": "Minimum",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 130
+            },
+            "age_range_max": {
+              "title": "Maximum",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 130
+            }
+          }
+        },
+        "sex": {
+          "type": "string",
+          "title": "Subject Sex",
+          "enum": [
+            "male",
+            "female",
+            "both"
+          ],
+          "enumNames": [
+            "Male",
+            "Female",
+            "Both"
+          ]
+        },
+        "ed50": {
+          "type": "string",
+          "title": "ED50 (mg/kg)"
+        },
+        "dose_range": {
+          "type": "object",
+          "title": "Dose Range (mg/kg)",
+          "properties": {
+            "dose_range_min": {
+              "title": "Minimum",
+              "type": "number"
+            },
+            "dose_range_max": {
+              "title": "Maximum",
+              "type": "number"
+            }
+          }
+        },
+        "dose_regimen": {
+          "type": "string",
+          "title": "Dosing Regimen",
+          "enum": [
+            "acute",
+            "chronic",
+            "sub_chronic"
+          ],
+          "enumNames": [
+            "Acute",
+            "Chronic",
+            "Sub Chronic"
+          ]
+        },
+        "pretreatment_time": {
+          "type": "string",
+          "title": "Pre-treatment Time "
+        },
+        "route": {
+          "type": "array",
+          "title": "Route of Administration",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "oral",
+              "sublingual",
+              "nasal",
+              "injection",
+              "transdermal",
+              "intrathecal",
+              "formulated_in_food",
+              "formulated_in_drinking_water"
+            ],
+            "enumNames": [
+              "Oral",
+              "Sublingual",
+              "Nasal",
+              "Injection (Intravenous, Intramuscular, Intraperitoneal, Subcutaneous, Intraocular)",
+              "Transdermal",
+              "Intrathecal",
+              "Formulated in Food",
+              "Formulated in Drinking Water"
+            ]
+          }
+        },
+        "drug_formulation": {
+          "type": "string",
+          "title": "Drug Formulation"
+        },
+        "adverse_events_description": {
+          "type": "string",
+          "title": "Adverse events"
+        }
+      },
+      "dependencies": {
+        "species": {
+          "oneOf": [
+            {
+              "properties": {
+                "species": {
+                  "enum": [
+                    "mouse",
+                    "rat",
+                    "non_human_primate",
+                    "dog",
+                    "ferret",
+                    "rabbit"
+                  ]
+                }
+              },
+              "required": []
+            },
+            {
+              "properties": {
+                "species": {
+                  "enum": [
+                    "other"
+                  ]
+                },
+                "species_other": {
+                  "title": "Other Species",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "species_other"
+              ]
             }
           ]
         }
@@ -324,7 +592,6 @@
         }
       }
     },
-
     "efficacy": {
       "type": "object",
       "properties": {
@@ -334,6 +601,17 @@
           "items": {
             "$ref": "#/definitions/efficacy_item"
           }
+        }
+      }
+    }
+  },
+  "in_vivo_data": {
+    "type": "object",
+    "properties": {
+      "experiments": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/in_vivo_data_item"
         }
       }
     }
@@ -352,7 +630,6 @@
       "title": "Basic",
       "$ref": "#/definitions/basic"
     },
-
     "binding": {
       "title": "Binding",
       "$ref": "#/definitions/binding"

--- a/src/mocks/mock_drug_tool_data.ts
+++ b/src/mocks/mock_drug_tool_data.ts
@@ -5,10 +5,12 @@ import _mockFormData from './mockDrugToolFormData.json'
 import _mockNavSchema from './mockDrugToolFormNavSchema.json'
 import _mockFormSchema from './mockDrugToolFormSchema.json'
 import _mockUiSchema from './mockDrugToolFormUiSchema.json'
+import _mockFormDataComplexInvalid from './mockDrugToolFormDataComplexInvalid.json'
 export const mockFormData = _mockFormData
 export const mockFormSchema = _mockFormSchema
 export const mockNavSchema = _mockNavSchema
 export const mockUiSchema = _mockUiSchema
+export const mockInvalidScreenData = _mockFormDataComplexInvalid 
 export const steps: Step[] = [
   {
     id: 'toxicology _data',
@@ -132,6 +134,66 @@ export const stepsWithUserData: Step[] = [
     rules: [],
   },
 ]
+export const stepWithCustomValidationRules: Step = {
+  id: 'in_vivo_data',
+  order: 40,
+  title: 'In Vivo Data!',
+  default: 'pharmacokinetics',
+  excluded: false,
+  inProgress: true,
+  child: true,
+  state: StepStateEnum.PROGRESS,
+  validationRules: [
+    {
+      conditions: {
+        all: [
+          {
+            fact: 'in_vivo_data',
+            operator: 'greaterThan',
+            path: '.experiments[*].age_range.age_range_min',
+            value: {
+              fact: 'in_vivo_data',
+              path: '.experiments[*].age_range.age_range_max',
+            },
+          },
+        ],
+      },
+      event: {
+        type: 'validation',
+        params: {
+          message: 'minimum age should be less than maximum age',
+          name: 'range',
+          property: '.in_vivo_data.experiments[*].age_range',
+        },
+      },
+      'priority:': 1,
+    },
+    {
+      conditions: {
+        all: [
+          {
+            fact: 'in_vivo_data',
+            operator: 'greaterThan',
+            path: '.experiments[*].dose_range.dose_range_min',
+            value: {
+              fact: 'in_vivo_data',
+              path: '.experiments[*].dose_range.dose_range_max',
+            },
+          },
+        ],
+      },
+      event: {
+        type: 'validation',
+        params: {
+          message: 'minimum dose should be less than maximum dose ',
+          name: 'range',
+          property: '.in_vivo_data.experiments[*].dose_range',
+        },
+      },
+      'priority:': 1,
+    },
+  ],
+}
 
 export const formListDataInProgress: ListResponse = {
   nextPageToken: '123',


### PR DESCRIPTION
This commit allows us to define custom validations i.e. validation beyond of what JSON schema provides.
It relies on [json-rules-engine](https://github.com/CacheControl/json-rules-engine) library which we are already using for conditional navigation between the steps.
The validation rules are defined in the in the preexisting 'navSchema' file which is responsible for navigating between the screens and storing all the configuration beyond that is provided by json-schema forms library
We are adding a single optional property [validationRules]( https://github.com/Sage-Bionetworks/Synapse-React-Client/compare/master...conundrumgirl:develop?expand=1#diff-ccfd60b0048ee2e3e3e2ab501b77a371R9)  to each step.
Before we submit the form we run those rules through the validation engine with the form data (the data and the rules are screen-specific unless we are on the submit screen).
The library has a limitation that you can not define a rule to apply to all members of a given array and you have specify the index directly. Those rules are defined with [*] index [example here](https://github.com/Sage-Bionetworks/Synapse-React-Client/compare/master...conundrumgirl:develop?expand=1#diff-ccfd60b0048ee2e3e3e2ab501b77a371R118) and in the code the rules are generated at run time for each data item