### PR TITLE
fix(SRC): hide new download implementation for now

### DIFF
--- a/src/demo/containers/Demo.tsx
+++ b/src/demo/containers/Demo.tsx
@@ -47,6 +47,7 @@ class Demo extends React.Component<{}, DemoState> {
         tableConfiguration: {
           title: 'title',
           synapseId: 'syn16787123',
+          enableDownloadConfirmation: true,
         },
         menuConfig: [
           {
@@ -68,10 +69,16 @@ class Demo extends React.Component<{}, DemoState> {
             sql: 'SELECT name, grant FROM syn11346063',
           },
           {
+            title: 'File Add To List Demo',
+            facetDisplayValue: 'Group By Grant',
+            facet: 'grant',
+            sql: 'SELECT name, grant FROM syn11346063 Group by grant',
+          },
+          {
             title: 'File Add To List Demo with Where Clause',
             facetDisplayValue: 'Name',
             facet: 'consortium',
-            sql: 'SELECT name, grant FROM syn11346063 WHERE ( ( "consortium" IS NULL ) )',
+            sql: 'SELECT name, grant FROM syn11346063 WHERE ( ( "consortium" = \'AMP-AD\') )',
           },
         ],
         rgbIndex: 2,

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -117,6 +117,7 @@ export type SynapseTableProps = {
   loadingScreen?: JSX.Element
   showAccessColumn?: boolean
   markdownColumns?: string[] // array of column names which should render as markdown
+  enableDownloadConfirmation?: boolean
 }
 
 
@@ -501,11 +502,12 @@ export default class SynapseTable extends React.Component<
     const onExpandArguments = {
       isExpanded: !isExpanded,
     }
+    const queryRequest = this.props.getLastQueryRequest!()
     return (
       <div className="SRC-centerContent" style={{ background, padding: 8 }}>
         <h3 className="SRC-tableHeader"> {title}</h3>
         <span className="SRC-inlineFlex" style={{ marginLeft: 'auto' }}>
-          {!isGroupByInSql(this.props.getLastQueryRequest!().query.sql) && (
+          {!isGroupByInSql(queryRequest.query.sql) && (
             <>
               <span
                 tabIndex={0}
@@ -541,7 +543,8 @@ export default class SynapseTable extends React.Component<
           onShowColumns={() => this.setState({ showColumnSelection: true })}
           onFullScreen={() => this.setState(onExpandArguments)}
           isExpanded={isExpanded}
-          isUnauthenticated = {!this.props.token}
+          isUnauthenticated={!this.props.token}
+          isGroupedQuery={isGroupByInSql(queryRequest.query.sql)}
         />
       </div>
     )
@@ -1020,7 +1023,11 @@ export default class SynapseTable extends React.Component<
 
 
   private showDownload(event: React.SyntheticEvent) {
-    this.setState({isDownloadConfirmationOpen : true})
+    if(this.props.enableDownloadConfirmation) {
+      this.setState({ isDownloadConfirmationOpen: true })
+    } else {
+      this.advancedSearch(event)
+    }
   }
 
   private getLengthOfPropsData() {

--- a/src/lib/containers/table/table-top/EllipsisDropdown.tsx
+++ b/src/lib/containers/table/table-top/EllipsisDropdown.tsx
@@ -15,6 +15,7 @@ type EllipsisDropdownProps = {
   onFullScreen: Function
   isExpanded: boolean
   isUnauthenticated?: boolean
+  isGroupedQuery?: boolean
 }
 const tooltipEllipsis = 'tooltip-ellipsis'
 
@@ -41,21 +42,23 @@ export const EllipsisDropdown: React.FunctionComponent<EllipsisDropdownProps> = 
           className="SRC-primary-color-hover-dropdown"
           alignRight={true}
         >
-          <Dropdown.Item
-            onClick={() => onDownloadFiles()}
-            className={props.isUnauthenticated ? 'SRC-deemphasized-text' : ''}
-            disabled={props.isUnauthenticated}
-          >
-            Download Files
-          </Dropdown.Item>
-          <Dropdown.Item onClick={() => onDownloadTableOnly()}>
-            Download Table Only
-          </Dropdown.Item>
-          <Dropdown.Divider />
-          <Dropdown.Item onClick={() => onShowColumns()}>
+          {!props.isGroupedQuery && [
+            <Dropdown.Item key='download_files'
+              onClick={() => onDownloadFiles()}
+              className={props.isUnauthenticated ? 'SRC-deemphasized-text' : ''}
+              disabled={props.isUnauthenticated}
+            >
+              Download Files
+            </Dropdown.Item>,
+            <Dropdown.Item key='download_tables' onClick={() => onDownloadTableOnly()}>
+              Download Table Only
+            </Dropdown.Item>,
+            <Dropdown.Divider  key='divider1'/>,
+          ]}
+          <Dropdown.Item  key='show_columns' onClick={() => onShowColumns()}>
             Show Columns
           </Dropdown.Item>
-          <Dropdown.Item onClick={() => onFullScreen()}>
+          <Dropdown.Item key='expand' onClick={() => onFullScreen()}>
             {isExpanded ? 'Shrink' : 'Full Screen'}
           </Dropdown.Item>
         </Dropdown.Menu>


### PR DESCRIPTION
1. `enableDownloadConfirmation` prop has to be explicitly set to `true` for new implementation to work

2. added `isGroupedQuery` prop to EllipsisDropdown to hide download for grouped queries
Filter and download icon are  already hidden in table header

