### PR TITLE
fix(style): Study Page: Header card alignment to page

### DIFF
--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -19,6 +19,7 @@ export type CardContainerProps = {
   data?: QueryResultBundle
   limit?: number
   isHeader?: boolean
+  isAlignToLeftNav?: boolean
   title?: string
   facetAliases?: {}
   getLastQueryRequest?: () => QueryBundleRequest

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -56,6 +56,7 @@ export type CardContainerLogicProps = {
   facet?: string
   backgroundColor?: string
   isHeader?: boolean
+  isAlignToLeftNav?: boolean
   sql: string
 } & CardConfiguration
 

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -39,6 +39,7 @@ export type GenericCardProps = {
   iconOptions?: IconOptions
   backgroundColor?: string
   isHeader?: boolean
+  isAlignToLeftNav?: boolean
   schema: any
   data: any
 } & CommonCardProps
@@ -170,6 +171,7 @@ export default class GenericCard extends React.Component<
       titleLinkConfig,
       labelConfig,
       facetAliases = {},
+      isAlignToLeftNav = false
     } = this.props
     // GenericCard inherits properties from CommonCardProps so that the properties have the same name
     // and type, but theres one nuance which is that we can't override if one specific property will be
@@ -232,6 +234,7 @@ export default class GenericCard extends React.Component<
           iconValue={iconValue}
           iconOptions={iconOptions}
           values={values}
+          isAlignToLeftNav = {isAlignToLeftNav}
           secondaryLabelLimit={secondaryLabelLimit}
         />
       )

--- a/src/lib/containers/HeaderCard.tsx
+++ b/src/lib/containers/HeaderCard.tsx
@@ -14,6 +14,7 @@ export type HeaderCardProps = {
   iconValue: string
   secondaryLabelLimit?: number
   values?: string[][]
+  isAlignToLeftNav?: boolean
 }
 
 const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
@@ -26,18 +27,19 @@ const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
   backgroundColor,
   values,
   secondaryLabelLimit,
+  isAlignToLeftNav
 }) => {
   const style: React.CSSProperties = {
     background: backgroundColor,
   }
   return (
-    <div style={style} className="SRC-portalCardHeader">
+    <div style={style} className={`SRC-portalCardHeader${isAlignToLeftNav ? ' isAlignToLeftNav': ''}`}>
       <div className="container-fluid">
         <div className="row">
-          <div className="col-md-1 iconContainer">
+          <div className={`iconContainer${isAlignToLeftNav ? ' col-md-offset-1 col-md-2': ' col-md-1'}`}>
             <Icon value={iconValue} iconOptions={iconOptions} type={type} />
           </div>
-          <div className="SRC-cardContent col-md-10">
+          <div className={`SRC-cardContent${isAlignToLeftNav ? ' col-md-8': ' col-md-10'}`}>
             <div className="SRC-type">{type}</div>
             <div>
               <h3

--- a/src/lib/style/Cards.scss
+++ b/src/lib/style/Cards.scss
@@ -306,4 +306,18 @@ img.iconImg.SRC-datasetIcon {
       padding-bottom: $baseline-grid / 2;
     }
   }
+  &.isAlignToLeftNav {
+    .iconContainer {
+      @media (min-width: 992px) {
+        text-align: right;
+        padding-right: 40px;
+      }
+    }
+
+    .SRC-cardContent {
+      @media (min-width: 992px) {
+        padding-left: 32px;
+      }
+    }
+  }
 }


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/PORTALS-709

Potential solution: 
adding optional  `isAlignToLeftNav` parameter to HeaderCard. 



variant without left nav:
![image](https://user-images.githubusercontent.com/5190623/70187324-c0993300-16a2-11ea-88fa-8eecb67cab13.png)

variant with left nav
![image](https://user-images.githubusercontent.com/5190623/70187359-d73f8a00-16a2-11ea-9289-d85a2d1104b8.png)
