### PR TITLE
feat(filedDownload): display modal if user not logged in

### DIFF
--- a/src/__tests__/lib/containers/DownloadLoginModal.test.tsx
+++ b/src/__tests__/lib/containers/DownloadLoginModal.test.tsx
@@ -28,7 +28,7 @@ function init(overrides?: DownloadLoginModalProps) {
 beforeEach(() => init())
 
 describe('basic function', () => {
-  it('should render with explanqtory links and without login', () => {
+  it('should render with explanatory links and without login', () => {
     expect(wrapper.find('ModalHeader')).toHaveLength(1)
     expect(wrapper.find('ModalFooter').find('button')).toHaveLength(2)
     expect(
@@ -65,7 +65,6 @@ describe('basic function', () => {
     wrapper = wrapper.update()
     expect(wrapper.find('ModalFooter').find('button')).toHaveLength(1)
     expect(wrapper.find('Login')).toHaveLength(1)
-    const but = wrapper.find('Login').find('button')
     expect(
       wrapper
         .find('Login')

--- a/src/__tests__/lib/containers/DownloadLoginModal.test.tsx
+++ b/src/__tests__/lib/containers/DownloadLoginModal.test.tsx
@@ -1,0 +1,82 @@
+import { ReactWrapper, mount } from 'enzyme'
+import * as React from 'react'
+import {
+  DownloadLoginModal,
+  DownloadLoginModalProps,
+} from '../../../lib/containers/table/table-top/DownloadLoginModal'
+
+const mockCallback = jest.fn()
+
+function createTestProps(
+  overrides?: DownloadLoginModalProps,
+): DownloadLoginModalProps {
+  return {
+    showModal: true,
+    onHide: mockCallback,
+    ...overrides,
+  }
+}
+
+let wrapper: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>
+let props: DownloadLoginModalProps
+
+function init(overrides?: DownloadLoginModalProps) {
+  props = createTestProps(overrides)
+  wrapper = mount(<DownloadLoginModal {...props} />)
+}
+
+beforeEach(() => init())
+
+describe('basic function', () => {
+  it('should render with explanqtory links and without login', () => {
+    expect(wrapper.find('ModalHeader')).toHaveLength(1)
+    expect(wrapper.find('ModalFooter').find('button')).toHaveLength(2)
+    expect(
+      wrapper
+        .find('ModalFooter')
+        .find('button')
+        .at(0)
+        .text(),
+    ).toBe('CANCEL')
+    expect(
+      wrapper
+        .find('ModalFooter')
+        .find('button')
+        .at(1)
+        .text(),
+    ).toBe('Sign in')
+    expect(wrapper.find('a')).toHaveLength(2)
+    expect(wrapper.find('Login')).toHaveLength(0)
+  })
+
+  it('should display Login  and hide header and it\'s "sign-in" button when "Sign in" is clicked', () => {
+    expect(
+      wrapper
+        .find('ModalFooter')
+        .find('button')
+        .findWhere(n => n.text() === 'Sign in' && n.type() === 'button'),
+    ).toHaveLength(1)
+
+    wrapper
+      .find('ModalFooter')
+      .find('button')
+      .at(1)
+      .simulate('click')
+    wrapper = wrapper.update()
+    expect(wrapper.find('ModalFooter').find('button')).toHaveLength(1)
+    expect(wrapper.find('Login')).toHaveLength(1)
+    const but = wrapper.find('Login').find('button')
+    expect(
+      wrapper
+        .find('Login')
+        .find('button')
+        .findWhere(n => n.text() === 'Sign in' && n.type() === 'button'),
+    ).toHaveLength(1)
+    expect(
+      wrapper
+        .find('ModalFooter')
+        .find('button')
+        .findWhere(n => n.text() === 'Sign in' && n.type() === 'button'),
+    ).toHaveLength(0)
+  })
+})

--- a/src/lib/containers/table/table-top/DownloadLoginModal.tsx
+++ b/src/lib/containers/table/table-top/DownloadLoginModal.tsx
@@ -12,16 +12,18 @@ export const DownloadLoginModal: React.FunctionComponent<DownloadLoginModalProps
   const [showLogin, setShowLogin] = useState(false)
 
   const getModalContent = (isShowLogin: boolean): JSX.Element => {
-    if (!isShowLogin) {
+    if (isShowLogin) {
+      return <Login token={''} theme={'light'} icon={true} />
+    } else {
       return (
         <>
           <p>
-            Anyone can browse public content on the Synapse we site, but in
-            order todownload and create content you will need to register for an
-            account using an email address
+            Anyone can browse public content on the Synapse website, but in
+            order to download and create content you will need to register for
+            an account using an email address.
           </p>
           <p>
-            To find out more see, see{' '}
+            To find out more see&nbsp;
             <a
               href="https://docs.synapse.org/articles/user_profiles.html"
               target="_blank"
@@ -34,12 +36,10 @@ export const DownloadLoginModal: React.FunctionComponent<DownloadLoginModalProps
               target="_blank"
             >
               Governance Overview
-            </a>
+            </a>.
           </p>
         </>
       )
-    } else {
-      return <Login token={''} theme={'light'} icon={true} />
     }
   }
   return (

--- a/src/lib/containers/table/table-top/DownloadLoginModal.tsx
+++ b/src/lib/containers/table/table-top/DownloadLoginModal.tsx
@@ -1,0 +1,78 @@
+import { Modal, ModalBody, ModalFooter, Button } from 'react-bootstrap'
+import Login from '../../Login'
+import ModalHeader from 'react-bootstrap/ModalHeader'
+import React, { useState } from 'react'
+
+export type DownloadLoginModalProps = {
+  showModal?: boolean
+  onHide: Function
+}
+
+export const DownloadLoginModal: React.FunctionComponent<DownloadLoginModalProps> = props => {
+  const [showLogin, setShowLogin] = useState(false)
+
+  const getModalContent = (isShowLogin: boolean): JSX.Element => {
+    if (!isShowLogin) {
+      return (
+        <>
+          <p>
+            Anyone can browse public content on the Synapse we site, but in
+            order todownload and create content you will need to register for an
+            account using an email address
+          </p>
+          <p>
+            To find out more see, see{' '}
+            <a
+              href="https://docs.synapse.org/articles/user_profiles.html"
+              target="_blank"
+            >
+              User Accounts
+            </a>
+            <span> and </span>
+            <a
+              href="https://docs.synapse.org/articles/governance.html"
+              target="_blank"
+            >
+              Governance Overview
+            </a>
+          </p>
+        </>
+      )
+    } else {
+      return <Login token={''} theme={'light'} icon={true} />
+    }
+  }
+  return (
+    <Modal
+      animation={false}
+      centered={true}
+      show={true}
+      onHide={() => props.onHide()}
+    >
+      {!showLogin && (
+        <ModalHeader closeButton>
+          <span
+            style={{ fontWeight: 'bold', color: '#515359', fontSize: '1.5em' }}
+          >
+            Sign In Required
+          </span>
+        </ModalHeader>
+      )}
+      <ModalBody>{getModalContent(showLogin)}</ModalBody>
+      <ModalFooter>
+        <Button variant="secondary" onClick={() => props.onHide()}>
+          CANCEL
+        </Button>
+        {!showLogin && (
+          <Button
+            className="SRC-primary-button"
+            variant="primary"
+            onClick={() => setShowLogin(true)}
+          >
+            Sign in
+          </Button>
+        )}
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/src/lib/containers/table/table-top/DownloadOptions.tsx
+++ b/src/lib/containers/table/table-top/DownloadOptions.tsx
@@ -1,3 +1,4 @@
+import { DownloadLoginModal } from './DownloadLoginModal'
 import * as React from 'react'
 import { Dropdown } from 'react-bootstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -17,7 +18,9 @@ export const DOWNLOAD_FILES_MENU_TEXT = 'Download Files'
 const tooltipDownloadId = 'download'
 
 export const DownloadOptions: React.FunctionComponent<DownloadOptionsProps> = props => {
+  const [showModal, setShowModal] = React.useState(false)
   const { onDownloadFiles, onExportMetadata } = props
+
   return (
     <React.Fragment>
       <Dropdown style={{ padding: 5 }}>
@@ -41,10 +44,9 @@ export const DownloadOptions: React.FunctionComponent<DownloadOptionsProps> = pr
           </Dropdown.Item>
           {props.isFileView && (
             <Dropdown.Item
-              className={props.isUnauthenticated ? 'SRC-deemphasized-text' : ''}
-              disabled={props.isUnauthenticated}
-              // @ts-ignore
-              onClick={onDownloadFiles}
+              onClick={() =>
+                props.isUnauthenticated ? setShowModal(true) : onDownloadFiles()
+              }
             >
               {DOWNLOAD_FILES_MENU_TEXT}
             </Dropdown.Item>
@@ -58,6 +60,12 @@ export const DownloadOptions: React.FunctionComponent<DownloadOptionsProps> = pr
         effect="solid"
         id={tooltipDownloadId}
       />
+      {showModal && (
+        <DownloadLoginModal
+          showModal={showModal}
+          onHide={() => setShowModal(false)}
+        ></DownloadLoginModal>
+      )}
     </React.Fragment>
   )
 }

--- a/src/lib/containers/table/table-top/EllipsisDropdown.tsx
+++ b/src/lib/containers/table/table-top/EllipsisDropdown.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
 import { TOOLTIP_DELAY_SHOW } from '../SynapseTableConstants'
+import { DownloadLoginModal } from './DownloadLoginModal'
 import ReactTooltip from 'react-tooltip'
 
 library.add(faEllipsisV)
@@ -28,6 +29,7 @@ export const EllipsisDropdown: React.FunctionComponent<EllipsisDropdownProps> = 
     onFullScreen,
     isExpanded,
   } = props
+  const [showModal, setShowModal] = React.useState(false)
   return (
     <>
       <Dropdown>
@@ -44,22 +46,30 @@ export const EllipsisDropdown: React.FunctionComponent<EllipsisDropdownProps> = 
           alignRight={true}
         >
           {!props.isGroupedQuery && [
-           props.isFileView && <Dropdown.Item key='download_files'
-              onClick={() => onDownloadFiles()}
-              className={props.isUnauthenticated ? 'SRC-deemphasized-text' : ''}
-              disabled={props.isUnauthenticated}
+            props.isFileView && (
+              <Dropdown.Item
+                key="download_files"
+                onClick={() =>
+                  props.isUnauthenticated
+                    ? setShowModal(true)
+                    : onDownloadFiles()
+                }
+              >
+                Download Files
+              </Dropdown.Item>
+            ),
+            <Dropdown.Item
+              key="download_tables"
+              onClick={() => onDownloadTableOnly()}
             >
-              Download Files
-            </Dropdown.Item>,
-            <Dropdown.Item key='download_tables' onClick={() => onDownloadTableOnly()}>
               Download Table Only
             </Dropdown.Item>,
-            <Dropdown.Divider  key='divider1'/>,
+            <Dropdown.Divider key="divider1" />,
           ]}
-          <Dropdown.Item  key='show_columns' onClick={() => onShowColumns()}>
+          <Dropdown.Item key="show_columns" onClick={() => onShowColumns()}>
             Show Columns
           </Dropdown.Item>
-          <Dropdown.Item key='expand' onClick={() => onFullScreen()}>
+          <Dropdown.Item key="expand" onClick={() => onFullScreen()}>
             {isExpanded ? 'Shrink' : 'Full Screen'}
           </Dropdown.Item>
         </Dropdown.Menu>
@@ -71,6 +81,12 @@ export const EllipsisDropdown: React.FunctionComponent<EllipsisDropdownProps> = 
         effect="solid"
         id={tooltipEllipsis}
       />
+      {showModal && (
+        <DownloadLoginModal
+          showModal={showModal}
+          onHide={() => setShowModal(false)}
+        ></DownloadLoginModal>
+      )}
     </>
   )
 }

--- a/src/lib/template_style/_Theme.scss
+++ b/src/lib/template_style/_Theme.scss
@@ -61,8 +61,9 @@
   }
 }
 
-.SRC-primary-button {
+.SRC-primary-button,  .SRC-primary-button.btn.btn-primary {
   background: $primary-action-color;
+  border: none;
   color: white !important;
   &:hover {
     @extend %hoverFade;


### PR DESCRIPTION
[PORTALS-970](https://sagebionetworks.jira.com/browse/PORTALS-970)

When downloading files from table, if you are not logged in the menu option is not enabled. User has no idea why. We should handle that case by showing information dialog explaining why its disable and what they can do to remedy that (log in).

![image](https://user-images.githubusercontent.com/5190623/72191048-e9a19780-33b5-11ea-9fe3-f5e0deda1d1b.png)
