### PR TITLE
PORTALS-978: set nav buttons z-index so that they can be clicked on

### DIFF
--- a/src/lib/style/Core.scss
+++ b/src/lib/style/Core.scss
@@ -792,6 +792,7 @@ div.SRC-userImg {
   height: 30px;
   position: absolute;
   right: 15px;
+  z-index: 99;
 }
 
 .SRC-loadingContainer {


### PR DESCRIPTION
(parent element is not properly wrapping due to the absolute positioning).