### PR TITLE
remove page reload calls and add callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "eslint-plugin-react-hooks": "^2.3.0",
     "npm": "^6.9.0",
     "npm-run-all": "^4.1.3",
+    "react-cookie": "^4.0.3",
     "regenerator-runtime": "^0.13.2",
     "rollup": "^1.16.0",
     "rollup-plugin-babel": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "eslint-plugin-react-hooks": "^2.3.0",
     "npm": "^6.9.0",
     "npm-run-all": "^4.1.3",
-    "react-cookie": "^4.0.3",
+    "universal-cookie": "^4.0.3",
     "regenerator-runtime": "^0.13.2",
     "rollup": "^1.16.0",
     "rollup-plugin-babel": "^4.3.3",

--- a/src/__tests__/lib/containers/DownloadLoginModal.test.tsx
+++ b/src/__tests__/lib/containers/DownloadLoginModal.test.tsx
@@ -48,34 +48,4 @@ describe('basic function', () => {
     expect(wrapper.find('a')).toHaveLength(2)
     expect(wrapper.find('Login')).toHaveLength(0)
   })
-
-  it('should display Login  and hide header and it\'s "sign-in" button when "Sign in" is clicked', () => {
-    expect(
-      wrapper
-        .find('ModalFooter')
-        .find('button')
-        .findWhere(n => n.text() === 'Sign in' && n.type() === 'button'),
-    ).toHaveLength(1)
-
-    wrapper
-      .find('ModalFooter')
-      .find('button')
-      .at(1)
-      .simulate('click')
-    wrapper = wrapper.update()
-    expect(wrapper.find('ModalFooter').find('button')).toHaveLength(1)
-    expect(wrapper.find('Login')).toHaveLength(1)
-    expect(
-      wrapper
-        .find('Login')
-        .find('button')
-        .findWhere(n => n.text() === 'Sign in' && n.type() === 'button'),
-    ).toHaveLength(1)
-    expect(
-      wrapper
-        .find('ModalFooter')
-        .find('button')
-        .findWhere(n => n.text() === 'Sign in' && n.type() === 'button'),
-    ).toHaveLength(0)
-  })
 })

--- a/src/__tests__/lib/containers/QueryWrapper.test.tsx
+++ b/src/__tests__/lib/containers/QueryWrapper.test.tsx
@@ -76,22 +76,25 @@ describe('basic functionality', () => {
     const { instance, wrapper } = await createShallowComponent(lastQueryRequest)
 
     const newToken = '123'
-    const spy = jest.spyOn(instance, 'executeInitialQueryRequest')
+    const spyOnExecuteQueryRequest = jest.spyOn(instance, 'executeQueryRequest')
 
     // test login
     wrapper.setProps({
       token: newToken,
     })
-    expect(spy).toHaveBeenCalled()
+    expect(spyOnExecuteQueryRequest).toHaveBeenCalled()
 
+    const spyOnExecuteInitQueryRequest = jest.spyOn(
+      instance,
+      'executeInitialQueryRequest',
+    )
     const newQueryRequest = cloneDeep(lastQueryRequest)
     newQueryRequest.query.sql = 'SELECT * FROM NEW_TABLE'
     // test new query lastQueryRequest
-    spy.mockReset()
     wrapper.setProps({
       initQueryRequest: newQueryRequest,
     })
-    expect(spy).toHaveBeenCalled()
+    expect(spyOnExecuteInitQueryRequest).toHaveBeenCalled()
   })
 
   it('returns the last query lastQueryRequest correctly ', async () => {

--- a/src/demo/containers/App.tsx
+++ b/src/demo/containers/App.tsx
@@ -44,7 +44,7 @@ export default class App extends React.Component<{}, AppState> {
       })
   }
 
-  establishSession = () => {
+  getSession = () => {
     SynapseClient.detectSSOCode()
     SynapseClient.getSessionTokenFromCookie()
       .then(sessionToken => this.handleChange({ token: sessionToken }))
@@ -59,7 +59,7 @@ export default class App extends React.Component<{}, AppState> {
         You are logged in.&nbsp;
         <button
           onClick={() => {
-            SynapseClient.signOut(this.establishSession)
+            SynapseClient.signOut(this.getSession)
           }}
         >
           <span aria-hidden="true">Sign out</span>
@@ -74,7 +74,7 @@ export default class App extends React.Component<{}, AppState> {
           token={
             SynapseClient.IS_OUTSIDE_SYNAPSE_ORG ? token : this.state.token
           }
-          sessionCallback={this.establishSession}
+          sessionCallback={this.getSession}
           theme={'light'}
           icon={true}
         />
@@ -86,7 +86,7 @@ export default class App extends React.Component<{}, AppState> {
             token={
               SynapseClient.IS_OUTSIDE_SYNAPSE_ORG ? token : this.state.token
             }
-            sessionCallback={this.establishSession}
+            sessionCallback={this.getSession}
             theme={'dark'}
             icon={true}
             googleRedirectUrl={

--- a/src/demo/containers/App.tsx
+++ b/src/demo/containers/App.tsx
@@ -44,13 +44,22 @@ export default class App extends React.Component<{}, AppState> {
       })
   }
 
+  establishSession = () => {
+    SynapseClient.detectSSOCode()
+    SynapseClient.getSessionTokenFromCookie()
+      .then(sessionToken => this.handleChange({ token: sessionToken }))
+      .catch((error: any) => {
+        console.error(error)
+      })
+  }
+
   renderLoginAndSignout(token: string): JSX.Element {
     const signedInState = (
       <div className="bg-success text-center" role="alert">
         You are logged in.&nbsp;
         <button
           onClick={() => {
-            SynapseClient.signOut()
+            SynapseClient.signOut(this.establishSession)
           }}
         >
           <span aria-hidden="true">Sign out</span>
@@ -65,6 +74,7 @@ export default class App extends React.Component<{}, AppState> {
           token={
             SynapseClient.IS_OUTSIDE_SYNAPSE_ORG ? token : this.state.token
           }
+          sessionCallback={this.establishSession}
           theme={'light'}
           icon={true}
         />
@@ -76,6 +86,7 @@ export default class App extends React.Component<{}, AppState> {
             token={
               SynapseClient.IS_OUTSIDE_SYNAPSE_ORG ? token : this.state.token
             }
+            sessionCallback={this.establishSession}
             theme={'dark'}
             icon={true}
             googleRedirectUrl={

--- a/src/lib/containers/Login.tsx
+++ b/src/lib/containers/Login.tsx
@@ -22,7 +22,7 @@ type Props = {
   icon: boolean
   googleRedirectUrl?: string
   redirectUrl?: string // will redirect here after a successful login. if unset, reload the current page url.
-  sessionCallback?: Function // Callback is invoked after login
+  sessionCallback: Function // Callback is invoked after login
 }
 
 /**
@@ -77,7 +77,6 @@ class Login extends React.Component<Props, State> {
    * @param {*} clickEvent Userclick event
    */
   public async handleLogin(clickEvent: React.FormEvent<HTMLElement>) {
-    const { redirectUrl } = this.props
     clickEvent.preventDefault() // avoid page refresh
     try {
       // get last valid receipt
@@ -99,12 +98,6 @@ class Login extends React.Component<Props, State> {
         this.authenticationReceiptKey,
         data.authenticationReceipt,
       )
-      // on session change, reload the page so that all components get the new token from the cookie
-      if (redirectUrl) {
-        // note that setting the href in SPA's (where just the hash fragment changes) does not cause a page reload (so we still do this below)
-        window.location.href = redirectUrl
-      }
-      // window.location.reload()
     } catch (err) {
       console.log('Error on login: ', err.reason)
       this.setState({

--- a/src/lib/containers/Login.tsx
+++ b/src/lib/containers/Login.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import ButtonContent from '../assets/ButtonContent'
 import GoogleIcon from '../assets/GoogleIcon'
 import { SynapseClient } from '../utils'
-import { ReactCookieProps } from 'react-cookie'
 import {
   getEndpoint,
   BackendDestinationEnum,
@@ -23,7 +22,6 @@ type Props = {
   icon: boolean
   googleRedirectUrl?: string
   redirectUrl?: string // will redirect here after a successful login. if unset, reload the current page url.
-  cookies?: ReactCookieProps['cookies'] // use the cookies object in case the component calling this wants to
   // have a change listener subscribe to if the cookie changes
   sessionCallback?: Function
 }
@@ -60,7 +58,7 @@ class Login extends React.Component<Props, State> {
     this.handleChange = this.handleChange.bind(this)
     this.handleLogin = this.handleLogin.bind(this)
     this.getLoginFailureView = this.getLoginFailureView.bind(this)
-    this.onSignIn = this.onSignIn.bind(this)
+    this.onGoogleSignIn = this.onGoogleSignIn.bind(this)
   }
   /**
    * Updates internal state with the event that was triggered
@@ -95,7 +93,6 @@ class Login extends React.Component<Props, State> {
       // now get session token from cookie has to be called in the portals repo
       await SynapseClient.setSessionTokenCookie(
         data.sessionToken,
-        this.props.cookies,
         this.props.sessionCallback,
       )
       // Set the new receipt
@@ -159,7 +156,7 @@ class Login extends React.Component<Props, State> {
     }
     return false
   }
-  public onSignIn(event: React.MouseEvent<HTMLButtonElement>) {
+  public onGoogleSignIn(event: React.MouseEvent<HTMLButtonElement>) {
     // save current route (so that we can go back here after SSO)
     localStorage.setItem('after-sso-login-url', window.location.href)
     event.preventDefault()
@@ -188,7 +185,7 @@ class Login extends React.Component<Props, State> {
       >
         <form>
           <button
-            onClick={this.onSignIn}
+            onClick={this.onGoogleSignIn}
             className={`SRC-google-button ${googleTheme} SRC-marginBottomTen`}
           >
             <GoogleIcon key={1} active={true} />

--- a/src/lib/containers/Login.tsx
+++ b/src/lib/containers/Login.tsx
@@ -2,7 +2,11 @@ import * as React from 'react'
 import ButtonContent from '../assets/ButtonContent'
 import GoogleIcon from '../assets/GoogleIcon'
 import { SynapseClient } from '../utils'
-import { getEndpoint, BackendDestinationEnum } from '../utils/functions/getEndpoint'
+import { ReactCookieProps } from 'react-cookie'
+import {
+  getEndpoint,
+  BackendDestinationEnum,
+} from '../utils/functions/getEndpoint'
 
 type State = {
   username: string
@@ -19,6 +23,9 @@ type Props = {
   icon: boolean
   googleRedirectUrl?: string
   redirectUrl?: string // will redirect here after a successful login. if unset, reload the current page url.
+  cookies?: ReactCookieProps['cookies'] // use the cookies object in case the component calling this wants to
+  // have a change listener subscribe to if the cookie changes
+  sessionCallback?: Function
 }
 
 /**
@@ -85,7 +92,12 @@ class Login extends React.Component<Props, State> {
         this.state.password,
         authenticationReceipt,
       )
-      await SynapseClient.setSessionTokenCookie(data.sessionToken)
+      // now get session token from cookie has to be called in the portals repo
+      await SynapseClient.setSessionTokenCookie(
+        data.sessionToken,
+        this.props.cookies,
+        this.props.sessionCallback,
+      )
       // Set the new receipt
       localStorage.setItem(
         this.authenticationReceiptKey,
@@ -96,7 +108,7 @@ class Login extends React.Component<Props, State> {
         // note that setting the href in SPA's (where just the hash fragment changes) does not cause a page reload (so we still do this below)
         window.location.href = redirectUrl
       }
-      window.location.reload()
+      // window.location.reload()
     } catch (err) {
       console.log('Error on login: ', err.reason)
       this.setState({
@@ -117,8 +129,7 @@ class Login extends React.Component<Props, State> {
       return (
         <div>
           <small className="form-text text-danger">
-            {' '}
-            {this.state.errorMessage}{' '}
+            {this.state.errorMessage}
           </small>
           <div className="invalid-feedback" />
         </div>
@@ -232,7 +243,9 @@ class Login extends React.Component<Props, State> {
         </form>
         <div>
           <a
-            href={`${getEndpoint(BackendDestinationEnum.PORTAL_ENDPOINT)}#!PasswordReset:0`}
+            href={`${getEndpoint(
+              BackendDestinationEnum.PORTAL_ENDPOINT,
+            )}#!PasswordReset:0`}
             className="SRC-floatLeft SRC-primary-text-color"
           >
             Forgot password?
@@ -241,7 +254,9 @@ class Login extends React.Component<Props, State> {
             &nbsp;It's free!
           </span>
           <a
-            href={`${getEndpoint(BackendDestinationEnum.PORTAL_ENDPOINT)}#!RegisterAccount:0`}
+            href={`${getEndpoint(
+              BackendDestinationEnum.PORTAL_ENDPOINT,
+            )}#!RegisterAccount:0`}
             className="SRC-floatRight SRC-primary-text-color"
           >
             Register

--- a/src/lib/containers/Login.tsx
+++ b/src/lib/containers/Login.tsx
@@ -22,8 +22,7 @@ type Props = {
   icon: boolean
   googleRedirectUrl?: string
   redirectUrl?: string // will redirect here after a successful login. if unset, reload the current page url.
-  // have a change listener subscribe to if the cookie changes
-  sessionCallback?: Function
+  sessionCallback?: Function // Callback is invoked after login
 }
 
 /**

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -140,7 +140,7 @@ export default class QueryWrapper extends React.Component<
       this.executeInitialQueryRequest()
     } else if (loadNow && this.props.token && !prevProps.token) {
       // if loadNow is true and they've logged in with a token that is not undefined, null, or an empty string when it was before
-      this.executeInitialQueryRequest()
+      this.executeQueryRequest(this.getLastQueryRequest())
     } else if (
       prevProps.initQueryRequest.query.sql !==
       this.props.initQueryRequest!.query.sql

--- a/src/lib/containers/table/table-top/DownloadLoginModal.tsx
+++ b/src/lib/containers/table/table-top/DownloadLoginModal.tsx
@@ -1,7 +1,6 @@
 import { Modal, ModalBody, ModalFooter, Button } from 'react-bootstrap'
-import Login from '../../Login'
 import ModalHeader from 'react-bootstrap/ModalHeader'
-import React, { useState } from 'react'
+import React from 'react'
 
 export type DownloadLoginModalProps = {
   showModal?: boolean
@@ -9,40 +8,6 @@ export type DownloadLoginModalProps = {
 }
 
 export const DownloadLoginModal: React.FunctionComponent<DownloadLoginModalProps> = props => {
-  const [showLogin, setShowLogin] = useState(false)
-
-  const getModalContent = (isShowLogin: boolean): JSX.Element => {
-    if (isShowLogin) {
-      return <Login token={''} theme={'light'} icon={true} />
-    } else {
-      return (
-        <>
-          <p>
-            Anyone can browse public content on the Synapse website, but in
-            order to download and create content you will need to register for
-            an account using an email address.
-          </p>
-          <p>
-            To find out more see&nbsp;
-            <a
-              href="https://docs.synapse.org/articles/user_profiles.html"
-              target="_blank"
-            >
-              User Accounts
-            </a>
-            <span> and </span>
-            <a
-              href="https://docs.synapse.org/articles/governance.html"
-              target="_blank"
-            >
-              Governance Overview
-            </a>
-            .
-          </p>
-        </>
-      )
-    }
-  }
   return (
     <Modal
       animation={false}
@@ -50,29 +15,50 @@ export const DownloadLoginModal: React.FunctionComponent<DownloadLoginModalProps
       show={true}
       onHide={() => props.onHide()}
     >
-      {!showLogin && (
-        <ModalHeader closeButton>
-          <span
-            style={{ fontWeight: 'bold', color: '#515359', fontSize: '1.5em' }}
+      <ModalHeader closeButton>
+        <span
+          style={{ fontWeight: 'bold', color: '#515359', fontSize: '1.5em' }}
+        >
+          Sign In Required
+        </span>
+      </ModalHeader>
+      <ModalBody>
+        <p>
+          Anyone can browse public content on the Synapse website, but in order
+          to download and create content you will need to register for an
+          account using an email address.
+        </p>
+        <p>
+          To find out more see&nbsp;
+          <a
+            href="https://docs.synapse.org/articles/user_profiles.html"
+            target="_blank"
+            rel="noopener noreferrer"
           >
-            Sign In Required
-          </span>
-        </ModalHeader>
-      )}
-      <ModalBody>{getModalContent(showLogin)}</ModalBody>
+            User Accounts
+          </a>
+          <span> and </span>
+          <a
+            href="https://docs.synapse.org/articles/governance.html"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Governance Overview
+          </a>
+          .
+        </p>
+      </ModalBody>
       <ModalFooter>
         <Button variant="secondary" onClick={() => props.onHide()}>
           CANCEL
         </Button>
-        {!showLogin && (
-          <Button
-            className="SRC-primary-button"
-            variant="primary"
-            onClick={() => setShowLogin(true)}
-          >
-            Sign in
-          </Button>
-        )}
+        <Button
+          className="SRC-primary-button SRC-SIGN-IN-CLASS"
+          variant="primary"
+          onClick={() => props.onHide()}
+        >
+          Sign in
+        </Button>
       </ModalFooter>
     </Modal>
   )

--- a/src/lib/containers/table/table-top/DownloadLoginModal.tsx
+++ b/src/lib/containers/table/table-top/DownloadLoginModal.tsx
@@ -36,7 +36,8 @@ export const DownloadLoginModal: React.FunctionComponent<DownloadLoginModalProps
               target="_blank"
             >
               Governance Overview
-            </a>.
+            </a>
+            .
           </p>
         </>
       )

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -1069,7 +1069,7 @@ export const detectSSOCode = () => {
   }
 }
 
-export const signOut = async (sessionCallback?: Function) => {
+export const signOut = (sessionCallback?: Function) => {
   setSessionTokenCookie(undefined, sessionCallback).catch(err => {
     console.error('err when clearing the session cookie ', err)
   })

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -53,6 +53,8 @@ import {
   UserProfile,
   WikiPage,
 } from './synapseTypes/'
+import { ReactCookieProps } from 'react-cookie'
+type Cookies = ReactCookieProps['cookies']
 
 // TODO: Create JSON response types for all return types
 export const IS_OUTSIDE_SYNAPSE_ORG = window.location.hostname
@@ -525,7 +527,7 @@ export const login = (
  * @param {*} redirectUrl
  * @param {*} endpoint
  */
-export let oAuthUrlRequest = (
+export const oAuthUrlRequest = (
   provider: string,
   redirectUrl: string,
   endpoint = BackendDestinationEnum.REPO_ENDPOINT,
@@ -546,7 +548,7 @@ export let oAuthUrlRequest = (
  * @param {*} redirectUrl
  * @param {*} endpoint
  */
-export let oAuthSessionRequest = (
+export const oAuthSessionRequest = (
   provider: string,
   authenticationCode: string | number,
   redirectUrl: string,
@@ -955,35 +957,48 @@ export const getWikiAttachmentsFromEvaluation = (
  *
  * @param {*} token Session token.  If undefined, then call should instruct the browser to delete the cookie.
  */
-export const setSessionTokenCookie = (token: string | undefined) => {
-  if (!IS_OUTSIDE_SYNAPSE_ORG) {
-    return doPost(
-      'Portal/sessioncookie',
-      { sessionToken: token },
-      undefined,
-      'include',
-      BackendDestinationEnum.PORTAL_ENDPOINT,
-    )
+export const setSessionTokenCookie = async (
+  token: string | undefined,
+  cookies?: Cookies,
+  sessionCallback?: Function,
+) => {
+  if (IS_OUTSIDE_SYNAPSE_ORG) {
+    // set's cookie in session storage
+    cookies?.set(SESSION_TOKEN_COOKIE_KEY, token, {
+      // expires in a day
+      maxAge: 60 * 60 * 24,
+    })
+    return Promise.resolve()
   }
-  // else not on a synapse.org subdomain, no Synapse SSO
-  setCookie(SESSION_TOKEN_COOKIE_KEY, token, 1)
-  return Promise.resolve()
+  // will set cookie in the http header
+  return doPost(
+    'Portal/sessioncookie',
+    { sessionToken: token },
+    undefined,
+    'include',
+    BackendDestinationEnum.PORTAL_ENDPOINT,
+  )
+    .then(_ => {
+      sessionCallback?.()
+    })
+    .catch(err => {
+      console.error('Error on setting session token ', err)
+    })
 }
 /**
  * Get the current session token from a cookie.  Note that this will only succeed if your app is running on
  * a .synapse.org subdomain.
  */
-export const getSessionTokenFromCookie = () => {
-  if (!IS_OUTSIDE_SYNAPSE_ORG) {
-    return doGet<string>(
-      'Portal/sessioncookie',
-      undefined,
-      'include',
-      BackendDestinationEnum.PORTAL_ENDPOINT,
-    )
+export const getSessionTokenFromCookie = async (cookies?: Cookies) => {
+  if (IS_OUTSIDE_SYNAPSE_ORG) {
+    return cookies?.get(SESSION_TOKEN_COOKIE_KEY)
   }
-  // else (is not on a synapse.org subdomain)
-  return Promise.resolve(getCookie(SESSION_TOKEN_COOKIE_KEY))
+  return doGet<string>(
+    'Portal/sessioncookie',
+    undefined,
+    'include',
+    BackendDestinationEnum.PORTAL_ENDPOINT,
+  )
 }
 
 export const getPrincipalAliasRequest = (
@@ -1049,19 +1064,16 @@ export const detectSSOCode = () => {
   }
 }
 
-export const signOut = () => {
-  if (!IS_OUTSIDE_SYNAPSE_ORG) {
-    setSessionTokenCookie(undefined)
-      .then(() => {
-        window.location.reload()
-      })
-      .catch(err => {
-        console.error('err when clearing the session cookie ', err)
-      })
+export const signOut = async (
+  cookies?: Cookies,
+  sessionCallback?: Function,
+) => {
+  if (IS_OUTSIDE_SYNAPSE_ORG) {
+    cookies?.remove(SESSION_TOKEN_COOKIE_KEY)
   } else {
-    // is not on a synapse.org subdomain
-    removeCookie(SESSION_TOKEN_COOKIE_KEY)
-    window.location.reload()
+    setSessionTokenCookie(undefined, cookies, sessionCallback).catch(err => {
+      console.error('err when clearing the session cookie ', err)
+    })
   }
 }
 
@@ -1104,13 +1116,13 @@ export const uploadFile = (
 const calculateMd5 = (fileBlob: File | Blob): Promise<string> => {
   // code taken from md5 example from library
   return new Promise((resolve, reject) => {
-    let blobSlice = File.prototype.slice,
+    const blobSlice = File.prototype.slice,
       file = fileBlob,
       chunkSize = 2097152, // Read in chunks of 2MB
       chunks = Math.ceil(file.size / chunkSize),
-      currentChunk = 0,
       spark = new SparkMD5.ArrayBuffer(),
       fileReader = new FileReader()
+    let currentChunk = 0
 
     fileReader.onload = function(e) {
       console.log('read chunk nr', currentChunk + 1, 'of', chunks)
@@ -1121,7 +1133,7 @@ const calculateMd5 = (fileBlob: File | Blob): Promise<string> => {
         loadNext()
       } else {
         console.log('finished loading')
-        let md5: string = spark.end()
+        const md5: string = spark.end()
         console.info('computed hash', md5) // Compute hash
         resolve(md5)
       }
@@ -1132,8 +1144,8 @@ const calculateMd5 = (fileBlob: File | Blob): Promise<string> => {
       reject(fileReader.error)
     }
 
-    let loadNext = () => {
-      let start = currentChunk * chunkSize,
+    const loadNext = () => {
+      const start = currentChunk * chunkSize,
         end = start + chunkSize >= file.size ? file.size : start + chunkSize
 
       fileReader.readAsArrayBuffer(blobSlice.call(file, start, end))
@@ -1778,32 +1790,6 @@ export const getProjectStatistics = (
     undefined,
     BackendDestinationEnum.REPO_ENDPOINT,
   )
-}
-
-const setCookie = (name: string, value: string | undefined, days: number) => {
-  if (!value) {
-    return
-  }
-  let expires = ''
-  if (days) {
-    const date = new Date()
-    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000)
-    expires = `; expires=${date.toUTCString()}`
-  }
-  document.cookie = `${name}=${value || ''}${expires}; path=/`
-}
-const getCookie = (name: string) => {
-  const nameEQ = `${name}=`
-  const ca = document.cookie.split(';')
-  for (let i = 0; i < ca.length; i++) {
-    let c = ca[i]
-    while (c.charAt(0) == ' ') c = c.substring(1, c.length)
-    if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length)
-  }
-  return null
-}
-const removeCookie = (name: string) => {
-  document.cookie = `${name}= ; expires= Thu, 21 Aug 2014 20:00:00 UTC; path=/`
 }
 
 // see https://docs.synapse.org/rest/POST/restrictionInformation.html

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,7 +1197,6 @@
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
-  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0", "@sinonjs/commons@^1.7.0":
   version "1.7.0"
@@ -1316,7 +1315,6 @@
 "@testing-library/dom@^6.11.0":
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.11.0.tgz#962a38f1a721fdb7c9e35e7579e33ff13a00eda4"
-  integrity sha512-Pkx9LMIGshyNbfmecjt18rrAp/ayMqGH674jYER0SXj0iG9xZc+zWRjk2Pg9JgPBDvwI//xGrI/oOQkAi4YEew==
   dependencies:
     "@babel/runtime" "^7.6.2"
     "@sheerun/mutationobserver-shim" "^0.3.2"
@@ -1328,7 +1326,6 @@
 "@testing-library/react@^9.4.0":
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.4.0.tgz#b021ac8cb987c8dc54c6841875f745bf9b2e88e5"
-  integrity sha512-XdhDWkI4GktUPsz0AYyeQ8M9qS/JFie06kcSnUVcpgOwFjAu9vhwR83qBl+lw9yZWkbECjL8Hd+n5hH6C0oWqg==
   dependencies:
     "@babel/runtime" "^7.7.6"
     "@testing-library/dom" "^6.11.0"
@@ -1368,6 +1365,10 @@
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.15.tgz#69040ffa92c309beeeeb7e92db66ac3f80700c0b"
   dependencies:
     "@types/node" "*"
+
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
 
 "@types/d3@^3":
   version "3.5.43"
@@ -1409,6 +1410,13 @@
 "@types/history@*":
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.4.tgz#06cbceb0ace6a342a9aafcb655a688cf38f6150d"
+
+"@types/hoist-non-react-statics@^3.0.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
@@ -1461,6 +1469,10 @@
   version "10.17.13"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
 
+"@types/object-assign@^4.0.30":
+  version "4.0.30"
+  resolved "https://registry.yarnpkg.com/@types/object-assign/-/object-assign-4.0.30.tgz#8949371d5a99f4381ee0f1df0a9b7a187e07e652"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -1495,7 +1507,6 @@
 "@types/react-dom@*", "@types/react-dom@^16.0.9":
   version "16.9.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.4.tgz#0b58df09a60961dcb77f62d4f1832427513420df"
-  integrity sha512-fya9xteU/n90tda0s+FtN5Ym4tbgxpq/hb/Af24dvs6uYnYn+fspaxw5USlw0R8apDNwxsqumdRoCoKitckQqw==
   dependencies:
     "@types/react" "*"
 
@@ -1584,14 +1595,12 @@
 "@types/testing-library__dom@*", "@types/testing-library__dom@^6.0.0":
   version "6.11.1"
   resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.11.1.tgz#6058a6ac391db679f7c60dbb27b81f0620de2dd9"
-  integrity sha512-ImChHtQqmjwraRLqBC2sgSQFtczeFvBmBcfhTYZn/3KwXbyD07LQykEQ0xJo7QHc1GbVvf7pRyGaIe6PkCdxEw==
   dependencies:
     pretty-format "^24.3.0"
 
 "@types/testing-library__react@^9.1.2":
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.2.tgz#e33af9124c60a010fc03a34eff8f8a34a75c4351"
-  integrity sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==
   dependencies:
     "@types/react-dom" "*"
     "@types/testing-library__dom" "*"
@@ -3328,7 +3337,7 @@ cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
 
-cookie@0.4.0:
+cookie@0.4.0, cookie@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
 
@@ -5366,7 +5375,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#101685d3aff3b23ea213163f6e8e12f4f111e19f"
   dependencies:
@@ -9594,6 +9603,14 @@ react-compound-slider@^2.5.0:
     prop-types "^15.7.2"
     warning "^3.0.0"
 
+react-cookie@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-4.0.3.tgz#ba8e5ea0047c916516e1181a3ad394c9b7580b56"
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.0.1"
+    hoist-non-react-statics "^3.0.0"
+    universal-cookie "^4.0.0"
+
 react-dev-utils@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-10.0.0.tgz#bd2d16426c7e4cbfed1b46fb9e2ac98ec06fcdfa"
@@ -11605,6 +11622,15 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
+universal-cookie@^4.0.0, universal-cookie@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.3.tgz#c2fa59127260e6ad21ef3e0cdd66ad453cbc41f6"
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    "@types/object-assign" "^4.0.30"
+    cookie "^0.4.0"
+    object-assign "^4.1.1"
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -11800,7 +11826,6 @@ w3c-xmlserializer@^1.1.2:
 wait-for-expect@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.1.tgz#ec204a76b0038f17711e575720aaf28505ac7185"
-  integrity sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,13 +1411,6 @@
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.4.tgz#06cbceb0ace6a342a9aafcb655a688cf38f6150d"
 
-"@types/hoist-non-react-statics@^3.0.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -5375,7 +5368,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.1.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#101685d3aff3b23ea213163f6e8e12f4f111e19f"
   dependencies:
@@ -9603,14 +9596,6 @@ react-compound-slider@^2.5.0:
     prop-types "^15.7.2"
     warning "^3.0.0"
 
-react-cookie@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-4.0.3.tgz#ba8e5ea0047c916516e1181a3ad394c9b7580b56"
-  dependencies:
-    "@types/hoist-non-react-statics" "^3.0.1"
-    hoist-non-react-statics "^3.0.0"
-    universal-cookie "^4.0.0"
-
 react-dev-utils@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-10.0.0.tgz#bd2d16426c7e4cbfed1b46fb9e2ac98ec06fcdfa"
@@ -11622,7 +11607,7 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
-universal-cookie@^4.0.0, universal-cookie@^4.0.3:
+universal-cookie@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.3.tgz#c2fa59127260e6ad21ef3e0cdd66ad453cbc41f6"
   dependencies:


### PR DESCRIPTION
Added callback functions to synapse client login/sign out functions
Used Universal-Cookie library to replace cookie functions in synapse client
Made it so the portal-side login modal shows up from synapsetable when clicking download files, this is the only way I could have the session callback for the portals get passed in without using a global variable.
