### PR TITLE
SWC-5052 continued

### DIFF
--- a/src/__tests__/lib/containers/HasAccess.test.tsx
+++ b/src/__tests__/lib/containers/HasAccess.test.tsx
@@ -24,6 +24,9 @@ import {
   mockUnmetControlledDataRestrictionInformationACT,
   mockUnmetControlledDataRestrictionInformationRestricted,
 } from '../../../mocks/mock_has_access_data'
+import {
+  mockFileHandle
+} from '../../../mocks/mock_file_handle'
 
 const SynapseClient = require('../../../lib/utils/SynapseClient')
 const token: string = '123444'
@@ -47,6 +50,9 @@ const props: HasAccessProps = {
 
 describe('basic tests', () => {
   it('works with open data no restrictions', async () => {
+    SynapseClient.getFileEntityFileHandle = jest.fn(() => 
+      Promise.resolve(mockFileHandle),
+    )
     SynapseClient.getRestrictionInformation = jest.fn(() =>
       Promise.resolve(mockOpenRestrictionInformation),
     )

--- a/src/demo/containers/Demo.tsx
+++ b/src/demo/containers/Demo.tsx
@@ -95,9 +95,9 @@ class Demo extends React.Component<{}, DemoState> {
             sql: 'SELECT * FROM syn21156352',
           },
           {
-            facet: 'dataType',
+            facet: 'study',
             sql:
-              'SELECT id, fundingAgency, assay, diagnosis, dataType FROM syn16858331',
+            'SELECT study, dataType, assay, id AS file_id, specimenID, individualID, diagnosis, sex, consortium as "Program", grant, species, organ, tissue, cellType, fileFormat FROM syn11346063',
           },
           {
             facet: 'diagnosis',

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -133,10 +133,8 @@ export default class HasAccess extends React.Component<
   }
   getFileEntityFileHandle = () => {
     const { entityId, entityVersionNumber, token, isInDownloadList } = this.props
-    if (
-      this.state.downloadType ||
-      !entityId
-    ) {
+    if (this.state.downloadType) {
+      // already know the downloadType
       return
     }
     // fileHandle was not passed to us, ask for it.

--- a/src/lib/containers/download_list/DownloadListTable.tsx
+++ b/src/lib/containers/download_list/DownloadListTable.tsx
@@ -253,6 +253,7 @@ export default function DownloadListTable(props: DownloadListTableProps) {
                     fileHandle={fileHandle}
                     token={token}
                     entityId={synId}
+                    isInDownloadList={true}
                   />
                 </td>
                 <td>

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -905,12 +905,12 @@ export default class SynapseTable extends React.Component<
           return <td className="SRC-hidden" key={`(${rowIndex},${colIndex})`} />
         },
       )
-      // also push the access column value if we are showing user access for individual items (must be logged in)
-      if (isShowingAccessColumn && token) {
+      // also push the access column value if we are showing user access for individual items (still shown if not logged in)
+      if (isShowingAccessColumn) {
         const rowSynapseId = `syn${row.rowId}`
         rowContent.push(
           <td key={`(${rowIndex},accessColumn)`} className="SRC_noBorderTop">
-            <HasAccess entityId={rowSynapseId} token={token}></HasAccess>
+            <HasAccess entityId={rowSynapseId} entityVersionNumber={row.versionNumber?.toString()} token={token}></HasAccess>
           </td>,
         )
       }
@@ -1069,7 +1069,6 @@ export default class SynapseTable extends React.Component<
     facets: FacetColumnResult[],
     isShowingAccessColumn: boolean | undefined,
   ) {
-    const { token } = this.props
     const {
       isColumnSelected,
       sortedColumnSelection,
@@ -1156,7 +1155,7 @@ export default class SynapseTable extends React.Component<
       },
     )
     // also push the access column if we are showing user access for individual items (must be logged in)
-    if (isShowingAccessColumn && token) {
+    if (isShowingAccessColumn) {
       tableColumnHeaderElements.push(
         <th key="accessColumn">
           <div className="SRC-centerContent">

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -1438,8 +1438,12 @@ export const getFileEntityFileHandle = (
       }
       getFiles(request, sessionToken)
         .then((data: BatchFileResult) => {
-          const fileHandle: FileHandle = data.requestedFiles[0].fileHandle!
-          resolve(fileHandle)
+          if (data.requestedFiles.length > 0 && data.requestedFiles[0].fileHandle) {
+            resolve(data.requestedFiles[0].fileHandle)  
+          } else {
+            // not found, or not allowed to access
+            reject(undefined)
+          }
         })
         .catch(err => {
           reject(err)

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -1409,6 +1409,45 @@ export const getFileEntityContent = (
   })
 }
 
+/**
+ * Return the FileHandle of the file (latest version) associated to the given FileEntity.
+ * @param sessionToken
+ * @param fileEntityId: ID of the FileEntity
+ * @param endpoint
+ */
+export const getFileEntityFileHandle = (
+  fileEntityId: string,
+  fileEntityVersionNumber?: string,
+  sessionToken?: string,
+): Promise<FileHandle> => {
+  return new Promise((resolve, reject) => {
+    getEntity(sessionToken, fileEntityId, fileEntityVersionNumber).then((entity:Entity) => {
+      const fileEntity:FileEntity = entity as FileEntity
+      const fileHandleAssociationList = [
+        {
+          associateObjectId: fileEntity.id,
+          associateObjectType: 'FileEntity',
+          fileHandleId: fileEntity.dataFileHandleId,
+        },
+      ]
+      const request: any = {
+        includeFileHandles: true,
+        includePreSignedURLs: false,
+        includePreviewPreSignedURLs: false,
+        requestedFiles: fileHandleAssociationList,
+      }
+      getFiles(request, sessionToken)
+        .then((data: BatchFileResult) => {
+          const fileHandle: FileHandle = data.requestedFiles[0].fileHandle!
+          resolve(fileHandle)
+        })
+        .catch(err => {
+          reject(err)
+        })
+    })
+  })
+}
+
 export const getFileHandleContentFromID = (
   fileHandleId: string,
   sessionToken: string,

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -55,6 +55,8 @@ import {
   AccessRequirement,
   AccessApproval,
   EntityId,
+  FileResult,
+  FileHandleAssociateType,
 } from './synapseTypes/'
 import UniversalCookies from 'universal-cookie'
 
@@ -1421,16 +1423,15 @@ export const getFileEntityFileHandle = (
   sessionToken?: string,
 ): Promise<FileHandle> => {
   return new Promise((resolve, reject) => {
-    getEntity(sessionToken, fileEntityId, fileEntityVersionNumber).then((entity:Entity) => {
-      const fileEntity:FileEntity = entity as FileEntity
-      const fileHandleAssociationList = [
+    getEntity<FileEntity>(sessionToken, fileEntityId, fileEntityVersionNumber).then((fileEntity:FileEntity) => {
+      const fileHandleAssociationList:FileHandleAssociation[] = [
         {
-          associateObjectId: fileEntity.id,
-          associateObjectType: 'FileEntity',
+          associateObjectId: fileEntity.id!,
+          associateObjectType: FileHandleAssociateType.FileEntity,
           fileHandleId: fileEntity.dataFileHandleId,
         },
       ]
-      const request: any = {
+      const request:BatchFileRequest = {
         includeFileHandles: true,
         includePreSignedURLs: false,
         includePreviewPreSignedURLs: false,

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -55,7 +55,6 @@ import {
   AccessRequirement,
   AccessApproval,
   EntityId,
-  FileResult,
   FileHandleAssociateType,
 } from './synapseTypes/'
 import UniversalCookies from 'universal-cookie'

--- a/src/mocks/mock_file_handle.ts
+++ b/src/mocks/mock_file_handle.ts
@@ -1,0 +1,3 @@
+import { FileHandle } from '../lib/utils/synapseTypes/'
+
+export const mockFileHandle:FileHandle = { id: "8781190", etag: "abc-deg-4028-8eb8-aaaaa", createdBy: "33203344343", createdOn: "2016-05-09T22:08:22.000Z", concreteType: "org.sagebionetworks.repo.model.file.S3FileHandle", contentType: "application/octet-stream", contentMd5: "123456789", fileName: "ACT_Proteomics_PFC_RAW_ad_act27.raw", storageLocationId: 1, contentSize: 20}


### PR DESCRIPTION
- Show Access column if not logged in (may be open data).  If unable to get the FileHandle and not logged in, then indicate user needs to first sign in.
- Distinguish HasAccess being used in a DownloadList vs other contexts.  Only show warnings about being part of a DownloadOrder package if item is in the DownloadList.  Add tests for HasAccess outside of DownloadList.