### PR TITLE
PORTALS-1033

### DIFF
--- a/src/__tests__/lib/containers/HasAccess.test.tsx
+++ b/src/__tests__/lib/containers/HasAccess.test.tsx
@@ -28,6 +28,9 @@ import {
   mockFileHandle
 } from '../../../mocks/mock_file_handle'
 import {
+  mockFolderEntity
+} from '../../../mocks/mock_folder_entity'
+import {
   mockFileEntity
 } from '../../../mocks/mock_file_entity'
 
@@ -91,7 +94,6 @@ describe('basic tests', () => {
       Promise.resolve(mockOpenRestrictionInformation),
     )
     const { wrapper, instance } = await createShallowComponent(props)
-    instance.getRestrictionInformation()
     const request: RestrictionInformationRequest = {
       restrictableObjectType: RestrictableObjectType.ENTITY,
       objectId: entityId,
@@ -103,6 +105,25 @@ describe('basic tests', () => {
     expect(instance.state.restrictionInformation).toEqual(
       mockOpenRestrictionInformation,
     )
+    const icons = wrapper.find(FontAwesomeIcon)
+    expect(icons).toHaveLength(2)
+    expect(icons.get(1).props.icon).toEqual(faUnlockAlt)
+    // no access restrictions
+    expect(wrapper.find('a')).toHaveLength(0)
+  })
+
+  it('works with a public folder', async () => {
+    SynapseClient.getEntity = jest.fn(() => 
+      Promise.resolve(mockFolderEntity),
+    )
+    SynapseClient.getFileEntityFileHandle = jest.fn(() => 
+      Promise.reject('it is a folder'),
+    )
+
+    SynapseClient.getRestrictionInformation = jest.fn(() =>
+      Promise.resolve(mockOpenRestrictionInformation),
+    )
+    const { wrapper } = await createShallowComponent(props)
     const icons = wrapper.find(FontAwesomeIcon)
     expect(icons).toHaveLength(2)
     expect(icons.get(1).props.icon).toEqual(faUnlockAlt)
@@ -234,15 +255,14 @@ describe('basic tests', () => {
       Promise.resolve(mockFileEntity),
     )
     SynapseClient.getFileEntityFileHandle = jest.fn(() => 
-      Promise.resolve(undefined),
+      Promise.reject('unmet restriction'),
     )
 
     SynapseClient.getRestrictionInformation = jest.fn(() =>
       Promise.resolve(mockUnmetControlledDataRestrictionInformationACT),
     )
 
-    const { wrapper, instance } = await createShallowComponent(props)
-    instance.getRestrictionInformation()
+    const { wrapper } = await createShallowComponent(props)
     const request: RestrictionInformationRequest = {
       restrictableObjectType: RestrictableObjectType.ENTITY,
       objectId: entityId,
@@ -251,22 +271,22 @@ describe('basic tests', () => {
       request,
       token,
     )
-    expect(instance.state.restrictionInformation).toEqual(
+    expect(wrapper.instance().state.restrictionInformation).toEqual(
       mockUnmetControlledDataRestrictionInformationACT,
     )
-    const link = wrapper.find('a')
-    expect(link).toHaveLength(1)
-    const icons = wrapper.find(FontAwesomeIcon)
-    expect(icons).toHaveLength(2)
-    expect(icons.get(1).props.icon).toEqual(faLock)
-    const tooltipSpan = wrapper.find(
-      `[data-tip="${
-        HasAccess.tooltipText[FileHandleDownloadTypeEnum.AccessBlocked]
-      }"]`,
-    )
-    expect(tooltipSpan).toHaveLength(1)
-    // no access restrictions
-    expect(wrapper.find('a').text()).toEqual('Request Access')
+    // const link = wrapper.find('a')
+    // expect(link).toHaveLength(1)
+    // const icons = wrapper.find(FontAwesomeIcon)
+    // expect(icons).toHaveLength(2)
+    // expect(icons.get(1).props.icon).toEqual(faLock)
+    // const tooltipSpan = wrapper.find(
+    //   `[data-tip="${
+    //     HasAccess.tooltipText[FileHandleDownloadTypeEnum.AccessBlocked]
+    //   }"]`,
+    // )
+    // expect(tooltipSpan).toHaveLength(1)
+    // // no access restrictions
+    // expect(wrapper.find('a').text()).toEqual('Request Access')
   })
 
   it('works with unmet controlled access data - terms of use', async () => {
@@ -274,15 +294,12 @@ describe('basic tests', () => {
       Promise.resolve(mockFileEntity),
     )
     SynapseClient.getFileEntityFileHandle = jest.fn(() => 
-      Promise.resolve(undefined),
+      Promise.reject('unmet terms of use'),
     )
-
     SynapseClient.getRestrictionInformation = jest.fn(() =>
       Promise.resolve(mockUnmetControlledDataRestrictionInformationRestricted),
     )
-
-    const { wrapper, instance } = await createShallowComponent(props)
-    instance.getRestrictionInformation()
+    const { wrapper } = await createShallowComponent(props)
     const request: RestrictionInformationRequest = {
       restrictableObjectType: RestrictableObjectType.ENTITY,
       objectId: entityId,
@@ -291,21 +308,21 @@ describe('basic tests', () => {
       request,
       token,
     )
-    expect(instance.state.restrictionInformation).toEqual(
+    expect(wrapper.instance().state.restrictionInformation).toEqual(
       mockUnmetControlledDataRestrictionInformationRestricted,
     )
-    const link = wrapper.find('a')
-    expect(link).toHaveLength(1)
-    const icons = wrapper.find(FontAwesomeIcon)
-    expect(icons).toHaveLength(2)
-    expect(icons.get(1).props.icon).toEqual(faLock)
-    const tooltipSpan = wrapper.find(
-      `[data-tip="${
-        HasAccess.tooltipText[FileHandleDownloadTypeEnum.AccessBlocked]
-      }"]`,
-    )
-    expect(tooltipSpan).toHaveLength(1)
-    // no access restrictions
-    expect(wrapper.find('a').text()).toEqual('Request Access')
+    // const link = wrapper.find('a')
+    // expect(link).toHaveLength(1)
+    // const icons = wrapper.find(FontAwesomeIcon)
+    // expect(icons).toHaveLength(2)
+    // expect(icons.get(1).props.icon).toEqual(faLock)
+    // const tooltipSpan = wrapper.find(
+    //   `[data-tip="${
+    //     HasAccess.tooltipText[FileHandleDownloadTypeEnum.AccessBlocked]
+    //   }"]`,
+    // )
+    // expect(tooltipSpan).toHaveLength(1)
+    // // no access restrictions
+    // expect(wrapper.find('a').text()).toEqual('Request Access')
   })
 })

--- a/src/__tests__/lib/containers/HasAccess.test.tsx
+++ b/src/__tests__/lib/containers/HasAccess.test.tsx
@@ -13,7 +13,7 @@ import {
 } from 'lib/utils/synapseTypes/'
 import * as React from 'react'
 import HasAccess, {
-  DownloadTypeEnum,
+  FileHandleDownloadTypeEnum,
   ExternalFileHandleConcreteTypeEnum,
   GIGABYTE_SIZE,
   GoogleCloudFileHandleEnum,
@@ -27,6 +27,10 @@ import {
 import {
   mockFileHandle
 } from '../../../mocks/mock_file_handle'
+import {
+  mockFileEntity
+} from '../../../mocks/mock_file_entity'
+
 
 const SynapseClient = require('../../../lib/utils/SynapseClient')
 const token: string = '123444'
@@ -76,9 +80,13 @@ const props: HasAccessProps = {
 
 describe('basic tests', () => {
   it('works with open data no restrictions', async () => {
+    SynapseClient.getEntity = jest.fn(() => 
+      Promise.resolve(mockFileEntity),
+    )
     SynapseClient.getFileEntityFileHandle = jest.fn(() => 
       Promise.resolve(mockFileHandle),
     )
+
     SynapseClient.getRestrictionInformation = jest.fn(() =>
       Promise.resolve(mockOpenRestrictionInformation),
     )
@@ -125,7 +133,7 @@ describe('basic tests', () => {
     expect(icons.get(1).props.icon).toEqual(faLink)
     const tooltipSpan = wrapper.find(
       `[data-tip="${
-        HasAccess.tooltipText[DownloadTypeEnum.ExternalFileHandle]
+        HasAccess.tooltipText[FileHandleDownloadTypeEnum.ExternalFileLink]
       }"]`,
     )
     expect(tooltipSpan).toHaveLength(1)
@@ -146,6 +154,9 @@ describe('basic tests', () => {
       storageLocationId: 0,
       contentSize: 0,
     }
+    SynapseClient.getEntity = jest.fn(() => 
+      Promise.resolve(mockFileEntity),
+    )
     SynapseClient.getFileEntityFileHandle = jest.fn(() => 
       Promise.resolve(cloudFileHandle),
     )
@@ -158,7 +169,7 @@ describe('basic tests', () => {
     expect(icons).toHaveLength(2)
     expect(icons.get(1).props.icon).toEqual(faLink)
     const tooltipSpan = wrapper.find(
-      `[data-tip="${HasAccess.tooltipText[DownloadTypeEnum.CloudFileHandle]}"]`,
+      `[data-tip="${HasAccess.tooltipText[FileHandleDownloadTypeEnum.ExternalCloudFile]}"]`,
     )
     expect(tooltipSpan).toHaveLength(1)
     // no access restrictions
@@ -174,7 +185,7 @@ describe('basic tests', () => {
     expect(icons).toHaveLength(2)
     expect(icons.get(1).props.icon).toEqual(faDatabase)
     const tooltipSpan = wrapper.find(
-      `[data-tip="${HasAccess.tooltipText[DownloadTypeEnum.TooLargeFile]}"]`,
+      `[data-tip="${HasAccess.tooltipText[FileHandleDownloadTypeEnum.TooLarge]}"]`,
     )
     expect(tooltipSpan).toHaveLength(1)
     // no access restrictions
@@ -219,6 +230,9 @@ describe('basic tests', () => {
   })
 
   it('works with unmet controlled access data - controlled by act', async () => {
+    SynapseClient.getEntity = jest.fn(() => 
+      Promise.resolve(mockFileEntity),
+    )
     SynapseClient.getFileEntityFileHandle = jest.fn(() => 
       Promise.resolve(undefined),
     )
@@ -247,7 +261,7 @@ describe('basic tests', () => {
     expect(icons.get(1).props.icon).toEqual(faLock)
     const tooltipSpan = wrapper.find(
       `[data-tip="${
-        HasAccess.tooltipText[DownloadTypeEnum.HasUnmetAccessRestrictions]
+        HasAccess.tooltipText[FileHandleDownloadTypeEnum.AccessBlocked]
       }"]`,
     )
     expect(tooltipSpan).toHaveLength(1)
@@ -256,6 +270,9 @@ describe('basic tests', () => {
   })
 
   it('works with unmet controlled access data - terms of use', async () => {
+    SynapseClient.getEntity = jest.fn(() => 
+      Promise.resolve(mockFileEntity),
+    )
     SynapseClient.getFileEntityFileHandle = jest.fn(() => 
       Promise.resolve(undefined),
     )
@@ -284,7 +301,7 @@ describe('basic tests', () => {
     expect(icons.get(1).props.icon).toEqual(faLock)
     const tooltipSpan = wrapper.find(
       `[data-tip="${
-        HasAccess.tooltipText[DownloadTypeEnum.HasUnmetAccessRestrictions]
+        HasAccess.tooltipText[FileHandleDownloadTypeEnum.AccessBlocked]
       }"]`,
     )
     expect(tooltipSpan).toHaveLength(1)

--- a/src/demo/containers/Demo.tsx
+++ b/src/demo/containers/Demo.tsx
@@ -8,6 +8,7 @@ import Uploader from '../../lib/containers/Uploader'
 import FileContentDownloadUploadDemo from '../../lib/containers/FileContentDownloadUploadDemo'
 import StatisticsPlot from 'lib/containers/StatisticsPlot'
 import { testDownloadSpeed } from '../../lib/utils/functions/testDownloadSpeed'
+import HasAccess from 'lib/containers/HasAccess'
 
 type DemoState = {
   token: string | null
@@ -212,6 +213,29 @@ class Demo extends React.Component<{}, DemoState> {
             <hr />
           </div>
         )}
+        { 
+        <div className="container">
+            <h5>Public Folder - HasAccess widget</h5>
+            <HasAccess
+              token={token ? token : undefined}
+              entityId={'syn7122428'}
+              isInDownloadList={false}
+            />
+            <h5>A Controlled Access Folder - HasAccess widget</h5>
+            <HasAccess
+              token={token ? token : undefined}
+              entityId={'syn7383419'}
+              isInDownloadList={false}
+            />
+            <h5>Open Data</h5>
+            <HasAccess
+              token={token ? token : undefined}
+              entityId={'syn5481758'}
+              isInDownloadList={false}
+            />
+            <hr />
+          </div>
+        }
         {token && (
           <div className="container">
             <h5>Project Statistics Demo</h5>

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -20,6 +20,7 @@ import {
   RestrictionInformationRequest,
   RestrictionInformationResponse,
   RestrictionLevel,
+  FileEntity
 } from '../utils/synapseTypes/'
 import { TOOLTIP_DELAY_SHOW } from './table/SynapseTableConstants'
 library.add(faUnlockAlt)
@@ -36,7 +37,7 @@ export type HasAccessProps = {
 
 type HasAccessState = {
   restrictionInformation?: RestrictionInformationResponse
-  downloadType?: DownloadTypeEnum
+  fileHandleDownloadType?: FileHandleDownloadTypeEnum
 }
 
 export enum ExternalFileHandleConcreteTypeEnum {
@@ -51,37 +52,38 @@ export enum GoogleCloudFileHandleEnum {
 
 export const GIGABYTE_SIZE = 2 ** 30
 
-export enum DownloadTypeEnum {
-  CloudFileHandle,
-  ExternalFileHandle,
-  TooLargeFile,
-  IsOpenNoUnmetAccessRestrictions,
-  HasUnmetAccessRestrictions,
-  ClosedForAnonymousDownload
+export enum FileHandleDownloadTypeEnum {
+  ExternalCloudFile,
+  ExternalFileLink,
+  TooLarge,
+  Accessible,
+  AccessBlocked,
+  AccessBlockedToAnonymous,
+  NoFileHandle
 }
 
 export const getDownloadTypeForFileHandle = (fileHandle: FileHandle, isInDownloadList?: boolean) => {
   if (fileHandle && !isInDownloadList) {
-    return DownloadTypeEnum.IsOpenNoUnmetAccessRestrictions
+    return FileHandleDownloadTypeEnum.Accessible
   }
   const { concreteType, contentSize } = fileHandle
   // check if it's too large
   if (contentSize >= GIGABYTE_SIZE) {
-    return DownloadTypeEnum.TooLargeFile
+    return FileHandleDownloadTypeEnum.TooLarge
   }
   // check if it's a google cloud file handle
   if (concreteType === GoogleCloudFileHandleEnum.GoogleCloudFileHandle) {
-    return DownloadTypeEnum.CloudFileHandle
+    return FileHandleDownloadTypeEnum.ExternalCloudFile
   }
   // check if it's an external file handle
   const isExternalFileHandle = Object.values<string>(
     ExternalFileHandleConcreteTypeEnum,
   ).includes(concreteType)
   if (isExternalFileHandle) {
-    return DownloadTypeEnum.ExternalFileHandle
+    return FileHandleDownloadTypeEnum.ExternalFileLink
   }
-  // otherwise its open
-  return DownloadTypeEnum.IsOpenNoUnmetAccessRestrictions
+  // otherwise its available
+  return FileHandleDownloadTypeEnum.Accessible
 }
 
 /**
@@ -99,15 +101,15 @@ export default class HasAccess extends React.Component<
   HasAccessState
 > {
   public static tooltipText = {
-    [DownloadTypeEnum.ClosedForAnonymousDownload]:
+    [FileHandleDownloadTypeEnum.AccessBlockedToAnonymous]:
       'You must sign in to access this file.',
-    [DownloadTypeEnum.HasUnmetAccessRestrictions]:
+    [FileHandleDownloadTypeEnum.AccessBlocked]:
       'You must request access to this restricted file.',
-    [DownloadTypeEnum.TooLargeFile]:
+    [FileHandleDownloadTypeEnum.TooLarge]:
       'This file is too large to download as a package and must be downloaded manually.',
-    [DownloadTypeEnum.ExternalFileHandle]:
+    [FileHandleDownloadTypeEnum.ExternalFileLink]:
       'This is an external link, which must be downloaded manually.',
-    [DownloadTypeEnum.CloudFileHandle]:
+    [FileHandleDownloadTypeEnum.ExternalCloudFile]:
       'This file must be downloaded manually (e.g. a file in Google Cloud).',
   }
 
@@ -115,10 +117,11 @@ export default class HasAccess extends React.Component<
     super(props)
     this.getRestrictionInformation = this.getRestrictionInformation.bind(this)
     this.getFileEntityFileHandle = this.getFileEntityFileHandle.bind(this)
+    this.updateStateFileHandleAccessBlocked = this.updateStateFileHandleAccessBlocked.bind(this)
     
-    const downloadType = props.fileHandle ? getDownloadTypeForFileHandle(props.fileHandle, props.isInDownloadList) : undefined
+    const fileHandleDownloadType = props.fileHandle ? getDownloadTypeForFileHandle(props.fileHandle, props.isInDownloadList) : undefined
     this.state = {
-      downloadType
+      fileHandleDownloadType
     }
   }
 
@@ -133,26 +136,49 @@ export default class HasAccess extends React.Component<
   }
   getFileEntityFileHandle = () => {
     const { entityId, entityVersionNumber, token, isInDownloadList } = this.props
-    if (this.state.downloadType) {
+    if (this.state.fileHandleDownloadType) {
       // already know the downloadType
       return
     }
     // fileHandle was not passed to us, ask for it.
-    SynapseClient.getFileEntityFileHandle(entityId, entityVersionNumber, token)
-      .then(fileHandle => {
-        const downloadType = getDownloadTypeForFileHandle(fileHandle, isInDownloadList)
-        this.setState({
-          downloadType
-        })
+    // is this a FileEntity?
+    SynapseClient.getEntity(token, entityId, entityVersionNumber)
+      .then((entity) => {
+        if (entity.hasOwnProperty('dataFileHandleId')) {
+          // looks like a FileEntity, get the FileHandle
+          SynapseClient.getFileEntityFileHandle(entity as FileEntity, token)
+            .then((fileHandle:FileHandle) => {
+              if (fileHandle) {
+                const fileHandleDownloadType = getDownloadTypeForFileHandle(fileHandle, isInDownloadList)
+                this.setState({
+                  fileHandleDownloadType
+                })
+              } else {
+                // no file handle is undefined
+                this.updateStateFileHandleAccessBlocked()
+              }
+            })
+        } else {
+          // entity looks like something else.
+          this.setState({
+            fileHandleDownloadType: FileHandleDownloadTypeEnum.NoFileHandle
+          })
+        }
       })
       .catch(err => {
-        // could not get file handle
-        const downloadType = token ? DownloadTypeEnum.HasUnmetAccessRestrictions : DownloadTypeEnum.ClosedForAnonymousDownload
-        this.setState({
-          downloadType
-        })
+        // could not get entity
+        this.updateStateFileHandleAccessBlocked()
       })
   }
+
+  updateStateFileHandleAccessBlocked = () => {
+    const { token } = this.props
+    const fileHandleDownloadType = token ? FileHandleDownloadTypeEnum.AccessBlocked : FileHandleDownloadTypeEnum.AccessBlockedToAnonymous
+        this.setState({
+          fileHandleDownloadType
+        })
+  }
+
   getRestrictionInformation = () => {
     const { entityId, token } = this.props
     if (
@@ -191,19 +217,26 @@ export default class HasAccess extends React.Component<
     )
   }
 
-  renderIcon = (downloadType: DownloadTypeEnum | string) => {
+  renderIcon = (downloadType: FileHandleDownloadTypeEnum | string, restrictionInformation?:RestrictionInformationResponse) => {
+    // if there are any access restrictions
+    if (restrictionInformation?.hasUnmetAccessRequirement) {
+      return this.renderIconHelper(faLock, 'SRC-warning-color')
+    }
     switch (downloadType) {
       // fileHandle available
-      case DownloadTypeEnum.ExternalFileHandle:
-      case DownloadTypeEnum.CloudFileHandle:
+      case FileHandleDownloadTypeEnum.ExternalFileLink:
+      case FileHandleDownloadTypeEnum.ExternalCloudFile:
         return this.renderIconHelper(faLink, 'SRC-warning-color')
-      case DownloadTypeEnum.TooLargeFile:
+      case FileHandleDownloadTypeEnum.TooLarge:
         return this.renderIconHelper(faDatabase, 'SRC-danger-color')
-      // no fileHandle available
-      case DownloadTypeEnum.HasUnmetAccessRestrictions:
-      case DownloadTypeEnum.ClosedForAnonymousDownload:
+      // was FileEntity, but no fileHandle was available
+      case FileHandleDownloadTypeEnum.AccessBlocked:
+      case FileHandleDownloadTypeEnum.AccessBlockedToAnonymous:
         return this.renderIconHelper(faLock, 'SRC-warning-color')
-      case DownloadTypeEnum.IsOpenNoUnmetAccessRestrictions:
+      // was a FileEntity, and fileHandle was available
+      case FileHandleDownloadTypeEnum.Accessible:
+      // or was not a FileEntity, but no unmet access restrictions
+      case FileHandleDownloadTypeEnum.NoFileHandle:
         return this.renderIconHelper(faUnlockAlt, 'SRC-success-color')
       default:
         // nothing is rendered until access requirement is loaded
@@ -248,15 +281,15 @@ export default class HasAccess extends React.Component<
   }
 
   render() {
-    const downloadType = this.state.downloadType
-    if (typeof downloadType === 'undefined') {
+    const fileHandleDownloadType = this.state.fileHandleDownloadType
+    if (typeof fileHandleDownloadType === 'undefined') {
       // note, this can't be "if (!downloadType)" since DownloadTypeEnum has a 0 value (which is falsy)
       // loading
       return <></>
     }
-    const tooltipText = HasAccess.tooltipText[downloadType]
+    const tooltipText = HasAccess.tooltipText[fileHandleDownloadType]
     const entityId = this.props.entityId
-    const icon = this.renderIcon(downloadType)
+    const icon = this.renderIcon(fileHandleDownloadType, this.state.restrictionInformation)
     const viewARsLink: React.ReactElement = this.renderARsLink()
     return (
       <span style={{ whiteSpace: 'nowrap' }}>

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -148,15 +148,13 @@ export default class HasAccess extends React.Component<
           // looks like a FileEntity, get the FileHandle
           SynapseClient.getFileEntityFileHandle(entity as FileEntity, token)
             .then((fileHandle:FileHandle) => {
-              if (fileHandle) {
-                const fileHandleDownloadType = getDownloadTypeForFileHandle(fileHandle, isInDownloadList)
-                this.setState({
-                  fileHandleDownloadType
-                })
-              } else {
-                // no file handle is undefined
-                this.updateStateFileHandleAccessBlocked()
-              }
+              const fileHandleDownloadType = getDownloadTypeForFileHandle(fileHandle, isInDownloadList)
+              this.setState({
+                fileHandleDownloadType
+              })
+            }).catch(err => {
+              // could not get the file handle
+              this.updateStateFileHandleAccessBlocked()
             })
         } else {
           // entity looks like something else.

--- a/src/lib/containers/download_list/DownloadListTable.tsx
+++ b/src/lib/containers/download_list/DownloadListTable.tsx
@@ -25,7 +25,7 @@ import {
 } from '../../utils/synapseTypes'
 import HasAccess, {
   getDownloadTypeForFileHandle,
-  DownloadTypeEnum,
+  FileHandleDownloadTypeEnum,
 } from '../HasAccess'
 import UserCard from '../UserCard'
 import { CreatePackage } from './CreatePackage'
@@ -222,7 +222,7 @@ export default function DownloadListTable(props: DownloadListTableProps) {
               createdOn = moment(createdOn).format('L LT')
               if (
                 getDownloadTypeForFileHandle(fileHandle) ===
-                DownloadTypeEnum.IsOpenNoUnmetAccessRestrictions
+                FileHandleDownloadTypeEnum.Accessible
               ) {
                 numBytes += contentSize
                 numFiles += 1

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -1411,44 +1411,41 @@ export const getFileEntityContent = (
 }
 
 /**
- * Return the FileHandle of the file (latest version) associated to the given FileEntity.
+ * Return the FileHandle of the file associated to the given FileEntity.
+ * * @param fileEntity: FileEntity
  * @param sessionToken
- * @param fileEntityId: ID of the FileEntity
  * @param endpoint
  */
 export const getFileEntityFileHandle = (
-  fileEntityId: string,
-  fileEntityVersionNumber?: string,
+  fileEntity: FileEntity,
   sessionToken?: string,
 ): Promise<FileHandle> => {
   return new Promise((resolve, reject) => {
-    getEntity<FileEntity>(sessionToken, fileEntityId, fileEntityVersionNumber).then((fileEntity:FileEntity) => {
-      const fileHandleAssociationList:FileHandleAssociation[] = [
-        {
-          associateObjectId: fileEntity.id!,
-          associateObjectType: FileHandleAssociateType.FileEntity,
-          fileHandleId: fileEntity.dataFileHandleId,
-        },
-      ]
-      const request:BatchFileRequest = {
-        includeFileHandles: true,
-        includePreSignedURLs: false,
-        includePreviewPreSignedURLs: false,
-        requestedFiles: fileHandleAssociationList,
-      }
-      getFiles(request, sessionToken)
-        .then((data: BatchFileResult) => {
-          if (data.requestedFiles.length > 0 && data.requestedFiles[0].fileHandle) {
-            resolve(data.requestedFiles[0].fileHandle)  
-          } else {
-            // not found, or not allowed to access
-            reject(undefined)
-          }
-        })
-        .catch(err => {
-          reject(err)
-        })
-    })
+    const fileHandleAssociationList:FileHandleAssociation[] = [
+      {
+        associateObjectId: fileEntity.id!,
+        associateObjectType: FileHandleAssociateType.FileEntity,
+        fileHandleId: fileEntity.dataFileHandleId,
+      },
+    ]
+    const request:BatchFileRequest = {
+      includeFileHandles: true,
+      includePreSignedURLs: false,
+      includePreviewPreSignedURLs: false,
+      requestedFiles: fileHandleAssociationList,
+    }
+    getFiles(request, sessionToken)
+      .then((data: BatchFileResult) => {
+        if (data.requestedFiles.length > 0 && data.requestedFiles[0].fileHandle) {
+          resolve(data.requestedFiles[0].fileHandle)  
+        } else {
+          // not found, or not allowed to access
+          reject(undefined)
+        }
+      })
+      .catch(err => {
+        reject(err)
+      })
   })
 }
 

--- a/src/mocks/mock_folder_entity.ts
+++ b/src/mocks/mock_folder_entity.ts
@@ -1,0 +1,8 @@
+import { Entity } from '../lib/utils/synapseTypes/'
+
+export const mockFolderEntity: Entity = {
+  id: 'syn123333',
+  parentId: 'syn12034444',
+  name: 'my folder name',
+  concreteType: 'org.sagebionetworks.repo.model.FolderEntity',
+}


### PR DESCRIPTION
Add support to show access for other entity types.   Renamed quite a few variables so that they made more sense to me.  Test a file that was marked as "Open Data" (while anonymous).