### PR TITLE
SWC-5125: must be logged in before presenting the OAuth request description, 

### DIFF
--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -1560,7 +1560,7 @@ export const getEvaluationSubmissions = (
  */
 export const getOAuth2RequestDescription = (
   oidcAuthRequest: OIDCAuthorizationRequest,
-  sessionToken: string | undefined,
+  sessionToken: string,
 ): Promise<OIDCAuthorizationRequestDescription> => {
   return doPost(
     '/auth/v1/oauth2/description',
@@ -1577,7 +1577,7 @@ export const getOAuth2RequestDescription = (
  */
 export const hasUserAuthorizedOAuthClient = (
   oidcAuthRequest: OIDCAuthorizationRequest,
-  sessionToken: string | undefined,
+  sessionToken: string,
 ): Promise<OAuthConsentGrantedResponse> => {
   return doPost(
     '/auth/v1/oauth2/consentcheck',


### PR DESCRIPTION
or checking to see if user has already given consent to this request