### PR TITLE
fix(PORTALS-1101): fix the infinite loop. Need to understand it better

### DIFF
--- a/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
@@ -10,7 +10,7 @@ import { useState } from 'react'
 import { EntityHeader } from '../../../utils/synapseTypes/EntityHeader'
 import useGetProfiles from '../../../utils/hooks/useGetProfiles'
 import useGetEntityHeaders from '../../../utils/hooks/useGetEntityHeaders'
-import { ReferenceList, UserProfile } from '../../../utils/synapseTypes'
+import { UserProfile } from '../../../utils/synapseTypes'
 
 export type EnumFacetFilterProps = {
   facetValues: FacetColumnResultValueCount[]
@@ -83,11 +83,9 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
       : []
   const userProfiles = useGetProfiles({ ids: userIds, token })
 
-  const entityIds: ReferenceList =
+  const entityIds =
     columnModel.columnType === 'ENTITYID'
-      ? facetValues.map(facet => {
-          return { targetId: facet.value }
-        })
+      ? facetValues.map(facet =>  facet.value )
       : []
   const entityHeaders = useGetEntityHeaders({
     references: entityIds,

--- a/src/lib/utils/hooks/useGetEntityHeaders.ts
+++ b/src/lib/utils/hooks/useGetEntityHeaders.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react'
-import { EntityHeader, ReferenceList } from '../synapseTypes'
+import { EntityHeader} from '../synapseTypes'
 import { getAllEntityHeader } from '../SynapseClient'
 import { SynapseConstants } from '..'
-import { without } from 'lodash-es'
+import { without, chunk } from 'lodash-es'
 
 export type UseGetProfilesProps = {
-  references: ReferenceList
+  references: string[]
   token?: string
 }
 
@@ -17,24 +17,27 @@ export default function useGetEntityHeaders(props: UseGetProfilesProps) {
     const getData = async () => {
       // look at current list of data, see if incoming ids has new data,
       // if so grab those ids
+      console.log ('called')
       const curList = data.map(el => el.id)
       const incomingList = references
-        .filter(el => el.targetId !== SynapseConstants.VALUE_NOT_SET)
-        .map(el => el.targetId)
+        .filter(el => el!== SynapseConstants.VALUE_NOT_SET)
       const newValues = without(incomingList, ...curList)
       if (newValues.length > 0) {
         try {
           const newReferences = Array.from<string>(newValues).map(el => {
             return { targetId: el }
           })
-          const newData = await getAllEntityHeader(newReferences, token)
-          setData(oldData => oldData.concat(...newData))
+          const newReferencesChunks = chunk(newReferences, 45)
+          for (const newReferences of newReferencesChunks) {
+            const newData = await getAllEntityHeader(newReferences, token)
+            setData(oldData => oldData.concat(...newData))
+          }
         } catch (error) {
           console.error('Error on data retrieval', error)
         }
       }
     }
     getData()
-  }, [token, references, data])
+  }, [token])
   return data
 }


### PR DESCRIPTION
useGetEntityHeaders enters an infinite loop in the /Playground/QueryWrapperPlotNavDemo
Taking `references, data` out of useEffect dependency array fixes the loop. I do *not* understand why `references` affect this. Will investigate farther  but wanted to put in a fix for now
