### PR TITLE
Add DownloadList to Portals

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "rollup-plugin-svg": "2.0.0",
     "sinon": "^7.2.2",
     "typescript": "3.7.4",
+    "use-deep-compare-effect": "^1.3.1",
     "yarn": "1.17.3"
   },
   "scripts": {

--- a/src/__tests__/lib/containers/DownloadConfirmation.test.tsx
+++ b/src/__tests__/lib/containers/DownloadConfirmation.test.tsx
@@ -163,10 +163,7 @@ describe('it performs the expected functionality', () => {
     wrapper.find('button.btn-primary').simulate('click')
     await resolveAllPending(wrapper)
     expect(wrapper.find('button.btn-primary')).toHaveLength(0)
-    const link = wrapper.find('a')
+    const link = wrapper.find('button.test-view-downloadlist')
     expect(link.text()).toBe('View Download List')
-    expect(link.props().href).toBe(
-      `https://www.synapse.org/#!Profile:${addFilesToDownloadListResponse.downloadList.ownerId}/downloads`,
-    )
   })
 })

--- a/src/__tests__/lib/containers/DownloadConfirmation.test.tsx
+++ b/src/__tests__/lib/containers/DownloadConfirmation.test.tsx
@@ -13,10 +13,9 @@ import {
 } from '../../../lib/containers/download_list/DownloadConfirmation'
 
 let getQueryTableResultsFn: Function
-
 let addFilesToDownloadRequestFn: Function
 const SynapseClient = require('../../../lib/utils/SynapseClient')
-let TestDownloadSpeed = require('../../../lib/utils/functions/testDownloadSpeed')
+const TestDownloadSpeed = require('../../../lib/utils/functions/testDownloadSpeed')
 const mockClose = jest.fn()
 
 const query = {
@@ -104,6 +103,9 @@ describe('it performs the expected functionality', () => {
     .mockResolvedValue(addFilesToDownloadListResponse)
 
   TestDownloadSpeed.testDownloadSpeed = jest.fn().mockResolvedValue(55)
+  getQueryTableResultsFn = SynapseClient.getQueryTableResults = jest
+    .fn()
+    .mockResolvedValue(queryBundleResponse)
 
   const props: DownloadConfirmationProps = {
     fnClose: mockClose,
@@ -112,9 +114,7 @@ describe('it performs the expected functionality', () => {
   }
 
   beforeEach(() => {
-    getQueryTableResultsFn = SynapseClient.getQueryTableResults = jest
-      .fn()
-      .mockResolvedValue(queryBundleResponse)
+    jest.clearAllMocks()
   })
 
   it('should render without crashing with just a cancel button', () => {
@@ -124,6 +124,7 @@ describe('it performs the expected functionality', () => {
     expect(mainDiv.hasClass('alert-info')).toBe(true)
     expect(wrapper.find('button')).toHaveLength(1)
     expect(wrapper.find('button').text()).toBe('Cancel')
+    expect(getQueryTableResultsFn).toHaveBeenCalledTimes(1)
   })
 
   it("should call the 'close' function on cancel", () => {
@@ -135,10 +136,11 @@ describe('it performs the expected functionality', () => {
   it("should call getQueryTableResults with correct params and show 'add' and 'cancel' buttons once info is loaded", async () => {
     const { wrapper } = createMountedComponent(props)
     await resolveAllPending(wrapper)
-
     expect(getQueryTableResultsFn).toHaveBeenCalledWith(
       mockGetQueryTableRequest,
+      props.token,
     )
+    expect(getQueryTableResultsFn).toHaveBeenCalledTimes(1)
     expect(wrapper.find('button')).toHaveLength(2)
     expect(wrapper.find('button.btn-link').text()).toBe('Cancel')
     expect(wrapper.find('button.btn-primary').text()).toBe('Add')

--- a/src/__tests__/lib/containers/HasAccess.test.tsx
+++ b/src/__tests__/lib/containers/HasAccess.test.tsx
@@ -2,7 +2,6 @@ import {
   faDatabase,
   faLink,
   faUnlockAlt,
-  faLock,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { shallow } from 'enzyme'
@@ -24,21 +23,14 @@ import {
   mockUnmetControlledDataRestrictionInformationACT,
   mockUnmetControlledDataRestrictionInformationRestricted,
 } from '../../../mocks/mock_has_access_data'
-import {
-  mockFileHandle
-} from '../../../mocks/mock_file_handle'
-import {
-  mockFolderEntity
-} from '../../../mocks/mock_folder_entity'
-import {
-  mockFileEntity
-} from '../../../mocks/mock_file_entity'
-
+import { mockFileHandle } from '../../../mocks/mock_file_handle'
+import { mockFolderEntity } from '../../../mocks/mock_folder_entity'
+import { mockFileEntity } from '../../../mocks/mock_file_entity'
 
 const SynapseClient = require('../../../lib/utils/SynapseClient')
 const token: string = '123444'
 const entityId = 'syn9988882982'
-const isInDownloadList:boolean = true
+const isInDownloadList: boolean = true
 const externalFileHandle: FileHandle = {
   id: '',
   etag: '',
@@ -78,15 +70,13 @@ const createShallowComponent = async (
 const props: HasAccessProps = {
   token,
   entityId,
-  isInDownloadList
+  isInDownloadList,
 }
 
 describe('basic tests', () => {
   it('works with open data no restrictions', async () => {
-    SynapseClient.getEntity = jest.fn(() => 
-      Promise.resolve(mockFileEntity),
-    )
-    SynapseClient.getFileEntityFileHandle = jest.fn(() => 
+    SynapseClient.getEntity = jest.fn(() => Promise.resolve(mockFileEntity))
+    SynapseClient.getFileEntityFileHandle = jest.fn(() =>
       Promise.resolve(mockFileHandle),
     )
 
@@ -98,6 +88,8 @@ describe('basic tests', () => {
       restrictableObjectType: RestrictableObjectType.ENTITY,
       objectId: entityId,
     }
+    // verify api calls and counts
+    expect(SynapseClient.getRestrictionInformation).toHaveBeenCalledTimes(1)
     expect(SynapseClient.getRestrictionInformation).toHaveBeenCalledWith(
       request,
       token,
@@ -105,6 +97,9 @@ describe('basic tests', () => {
     expect(instance.state.restrictionInformation).toEqual(
       mockOpenRestrictionInformation,
     )
+    expect(SynapseClient.getEntity).toHaveBeenCalledTimes(1)
+    expect(SynapseClient.getFileEntityFileHandle).toHaveBeenCalledTimes(1)
+    // verify UI
     const icons = wrapper.find(FontAwesomeIcon)
     expect(icons).toHaveLength(2)
     expect(icons.get(1).props.icon).toEqual(faUnlockAlt)
@@ -113,10 +108,8 @@ describe('basic tests', () => {
   })
 
   it('works with a public folder', async () => {
-    SynapseClient.getEntity = jest.fn(() => 
-      Promise.resolve(mockFolderEntity),
-    )
-    SynapseClient.getFileEntityFileHandle = jest.fn(() => 
+    SynapseClient.getEntity = jest.fn(() => Promise.resolve(mockFolderEntity))
+    SynapseClient.getFileEntityFileHandle = jest.fn(() =>
       Promise.reject('it is a folder'),
     )
 
@@ -175,10 +168,8 @@ describe('basic tests', () => {
       storageLocationId: 0,
       contentSize: 0,
     }
-    SynapseClient.getEntity = jest.fn(() => 
-      Promise.resolve(mockFileEntity),
-    )
-    SynapseClient.getFileEntityFileHandle = jest.fn(() => 
+    SynapseClient.getEntity = jest.fn(() => Promise.resolve(mockFileEntity))
+    SynapseClient.getFileEntityFileHandle = jest.fn(() =>
       Promise.resolve(cloudFileHandle),
     )
 
@@ -190,7 +181,9 @@ describe('basic tests', () => {
     expect(icons).toHaveLength(2)
     expect(icons.get(1).props.icon).toEqual(faLink)
     const tooltipSpan = wrapper.find(
-      `[data-tip="${HasAccess.tooltipText[FileHandleDownloadTypeEnum.ExternalCloudFile]}"]`,
+      `[data-tip="${
+        HasAccess.tooltipText[FileHandleDownloadTypeEnum.ExternalCloudFile]
+      }"]`,
     )
     expect(tooltipSpan).toHaveLength(1)
     // no access restrictions
@@ -206,7 +199,9 @@ describe('basic tests', () => {
     expect(icons).toHaveLength(2)
     expect(icons.get(1).props.icon).toEqual(faDatabase)
     const tooltipSpan = wrapper.find(
-      `[data-tip="${HasAccess.tooltipText[FileHandleDownloadTypeEnum.TooLarge]}"]`,
+      `[data-tip="${
+        HasAccess.tooltipText[FileHandleDownloadTypeEnum.TooLarge]
+      }"]`,
     )
     expect(tooltipSpan).toHaveLength(1)
     // no access restrictions
@@ -251,10 +246,8 @@ describe('basic tests', () => {
   })
 
   it('works with unmet controlled access data - controlled by act', async () => {
-    SynapseClient.getEntity = jest.fn(() => 
-      Promise.resolve(mockFileEntity),
-    )
-    SynapseClient.getFileEntityFileHandle = jest.fn(() => 
+    SynapseClient.getEntity = jest.fn(() => Promise.resolve(mockFileEntity))
+    SynapseClient.getFileEntityFileHandle = jest.fn(() =>
       Promise.reject('unmet restriction'),
     )
 
@@ -290,10 +283,8 @@ describe('basic tests', () => {
   })
 
   it('works with unmet controlled access data - terms of use', async () => {
-    SynapseClient.getEntity = jest.fn(() => 
-      Promise.resolve(mockFileEntity),
-    )
-    SynapseClient.getFileEntityFileHandle = jest.fn(() => 
+    SynapseClient.getEntity = jest.fn(() => Promise.resolve(mockFileEntity))
+    SynapseClient.getFileEntityFileHandle = jest.fn(() =>
       Promise.reject('unmet terms of use'),
     )
     SynapseClient.getRestrictionInformation = jest.fn(() =>

--- a/src/__tests__/lib/containers/download_list/DownloadListTable.test.tsx
+++ b/src/__tests__/lib/containers/download_list/DownloadListTable.test.tsx
@@ -19,6 +19,7 @@ describe('it performs all functionality ', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    jest.clearAllMocks()
   })
 
   afterEach(() => {
@@ -51,7 +52,8 @@ describe('it performs all functionality ', () => {
       },
     ],
   }
-  SynapseClient.getDownloadList = jest.fn().mockResolvedValue(downloadListMock)
+  const mockGetDownloadListFn = jest.fn().mockResolvedValue(downloadListMock)
+  SynapseClient.getDownloadList = mockGetDownloadListFn
   const entityHeaderMock: PaginatedResults<EntityHeader> = {
     totalNumberOfResults: 3,
     results: [
@@ -81,7 +83,8 @@ describe('it performs all functionality ', () => {
       },
     ],
   }
-  SynapseClient.getEntityHeader = jest.fn().mockResolvedValue(entityHeaderMock)
+  const mockGetEntityHeaderFn = jest.fn().mockResolvedValue(entityHeaderMock)
+  SynapseClient.getEntityHeader = mockGetEntityHeaderFn
   const batchFileResultMock: BatchFileResult = {
     requestedFiles: [
       {
@@ -93,11 +96,12 @@ describe('it performs all functionality ', () => {
       },
     ],
   }
-  SynapseClient.getFiles = jest.fn().mockResolvedValue(batchFileResultMock)
-  const deleteDownloadListFnMock = jest.fn().mockResolvedValue('')
-  SynapseClient.deleteDownloadListFiles = deleteDownloadListFnMock
-  const clearDownloadListMock = jest.fn().mockResolvedValue('')
-  SynapseClient.deleteDownloadList = clearDownloadListMock
+  const mockGetFilesFn = jest.fn().mockResolvedValue(batchFileResultMock)
+  SynapseClient.getFiles = mockGetFilesFn
+  const mockDeleteDownloadListFn = jest.fn().mockResolvedValue('')
+  SynapseClient.deleteDownloadListFiles = mockDeleteDownloadListFn
+  const mockClearDownloadListFn = jest.fn().mockResolvedValue('')
+  SynapseClient.deleteDownloadList = mockClearDownloadListFn
 
   const tokenMock = 'token'
   const props: DownloadListTableProps = {
@@ -122,11 +126,17 @@ describe('it performs all functionality ', () => {
     expect(
       rows.item(1).querySelector<HTMLAnchorElement>('td a')!.innerHTML,
     ).toEqual(fileTwoName)
+    expect(mockGetDownloadListFn).toHaveBeenCalledTimes(1)
+    expect(mockGetEntityHeaderFn).toHaveBeenCalledTimes(1)
+    expect(mockGetFilesFn).toHaveBeenCalledTimes(1)
   })
   it('deletes a specific row', async () => {
     await act(async () => {
       ReactDOM.render(<DownloadListTable {...props} />, container)
     })
+    mockGetDownloadListFn.mockClear()
+    mockGetEntityHeaderFn.mockClear()
+    mockGetFilesFn.mockClear()
     const trashBtn = container
       .querySelectorAll<HTMLTableRowElement>('tbody tr')
       .item(0)
@@ -134,7 +144,7 @@ describe('it performs all functionality ', () => {
     await act(async () => {
       trashBtn.click()
     })
-    expect(deleteDownloadListFnMock).toHaveBeenCalledWith(
+    expect(mockDeleteDownloadListFn).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
           fileHandleId: fileOneId,
@@ -142,16 +152,24 @@ describe('it performs all functionality ', () => {
       ]),
       tokenMock,
     )
+    expect(mockGetDownloadListFn).not.toHaveBeenCalled()
+    expect(mockGetEntityHeaderFn).not.toHaveBeenCalled()
+    expect(mockGetFilesFn).not.toHaveBeenCalled()
   })
   it('Clears all rows', async () => {
     await act(async () => {
       ReactDOM.render(<DownloadListTable {...props} />, container)
     })
+    mockGetDownloadListFn.mockClear()
+    mockGetEntityHeaderFn.mockClear()
+    mockGetFilesFn.mockClear()
     await act(async () => {
       container
         .querySelector<HTMLButtonElement>(`#${TESTING_CLEAR_BTN_CLASS}`)!
         .click()
     })
-    expect(clearDownloadListMock).toHaveBeenCalled()
+    expect(mockGetDownloadListFn).not.toHaveBeenCalled()
+    expect(mockGetEntityHeaderFn).not.toHaveBeenCalled()
+    expect(mockGetFilesFn).not.toHaveBeenCalled()
   })
 })

--- a/src/demo/containers/playground/Playground.tsx
+++ b/src/demo/containers/playground/Playground.tsx
@@ -97,7 +97,7 @@ const App = ({
       <Route
         exact={true}
         path={`${match.url}/QueryWrapperMenuDemo`}
-        render={() => <QueryWrapperMenuDemo rgbIndex={0} />}
+        render={() => <QueryWrapperMenuDemo token={token} rgbIndex={0} />}
       />
 
       <Route

--- a/src/demo/containers/playground/Playground.tsx
+++ b/src/demo/containers/playground/Playground.tsx
@@ -6,6 +6,7 @@ import SearchDemo from './SearchDemo'
 import ModalDownloadDemo from './ModalDownloadDemo'
 import UserCardDemo from './UserCardDemo'
 import MarkdownSynapseDemo from './MarkdownSynapseDemo'
+import ShowDownloadDemo from './ShowDownloadDemo'
 import { NewsFeedDemo } from './NewsFeedDemo'
 import FormServicesIntegrationDemo from './FormServicesIntegrationDemo'
 import QueryWrapperPlotNavDemo from './QueryWrapperPlotNavDemo'
@@ -87,6 +88,9 @@ const App = ({
           <Link to={`${match.url}/TemplateComponentDemo`}>
             TemplateComponentDemo
           </Link>
+        </li>
+        <li>
+          <Link to={`${match.url}/ShowDownloadDemo`}>ShowDownloadDemo</Link>
         </li>
       </ul>
 
@@ -175,6 +179,12 @@ const App = ({
         exact={true}
         path={`${match.url}/TemplateComponentDemo`}
         component={() => <TemplateComponentDemo />}
+      />
+
+      <Route
+        exact={true}
+        path={`${match.url}/ShowDownloadDemo`}
+        component={() => <ShowDownloadDemo token={token} />}
       />
 
       <Route exact={true} path={match.path} component={() => <div />} />

--- a/src/demo/containers/playground/QueryWrapperMenuDemo.tsx
+++ b/src/demo/containers/playground/QueryWrapperMenuDemo.tsx
@@ -22,7 +22,7 @@ type DemoState = {
  * module
  */
 class QueryWrapperMenuDemo extends React.Component<
-  { rgbIndex: number },
+  { rgbIndex: number; token: string | undefined },
   DemoState
 > {
   /**
@@ -46,7 +46,7 @@ class QueryWrapperMenuDemo extends React.Component<
       isLoading: true,
       ownerId: '',
       showMarkdown: true,
-      activeTab: 3,
+      activeTab: 2,
       tabFour: {
         stackedBarChartConfiguration: {
           loadingScreen: <div> Im loading as fast I can! </div>,
@@ -73,6 +73,7 @@ class QueryWrapperMenuDemo extends React.Component<
         unitDescription: 'datum',
         tableConfiguration: {
           title: 'title',
+          enableDownloadConfirmation: true,
         },
         searchConfiguration: {
           searchable: [
@@ -274,7 +275,11 @@ class QueryWrapperMenuDemo extends React.Component<
           Table with markdown
         </button>
         <h2>Demo of table</h2>
-        <QueryWrapperMenu isConsistent={true} {...props} />
+        <QueryWrapperMenu
+          token={this.props.token}
+          isConsistent={true}
+          {...props}
+        />
       </div>
     )
   }

--- a/src/demo/containers/playground/ShowDownloadDemo.tsx
+++ b/src/demo/containers/playground/ShowDownloadDemo.tsx
@@ -1,37 +1,13 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import ShowDownload from '../../../lib/containers/download_list/ShowDownload'
-import DownloadListTable from 'lib/containers/download_list/DownloadListTable'
-import { DOWNLOAD_LIST_CHANGE_EVENT } from 'lib/utils/functions/dispatchDownloadListChangeEvent'
-import { Modal } from 'react-bootstrap'
 
 const ShowDownloadDemo = ({ token }: { token: string | undefined }) => {
-  const [showDownloadList, setShowDownloadList] = useState(false)
-  useEffect(() => {
-    const listener = document.addEventListener(
-      DOWNLOAD_LIST_CHANGE_EVENT,
-      () => {
-        setShowDownloadList(true)
-      },
-    )
-    return listener
-  })
   if (!token) {
     return <p> You need to sign in to for ShowDownload to render </p>
   }
   return (
     <div>
       <ShowDownload token={token} />
-      <Modal
-        centered={true}
-        animation={false}
-        size={'lg'}
-        onHide={() => {
-          setShowDownloadList(false)
-        }}
-        show={showDownloadList}
-      >
-        <DownloadListTable token={token} />
-      </Modal>
     </div>
   )
 }

--- a/src/demo/containers/playground/ShowDownloadDemo.tsx
+++ b/src/demo/containers/playground/ShowDownloadDemo.tsx
@@ -1,0 +1,38 @@
+import React, { useState, useEffect } from 'react'
+import ShowDownload from '../../../lib/containers/download_list/ShowDownload'
+import DownloadListTable from 'lib/containers/download_list/DownloadListTable'
+import { DOWNLOAD_LIST_CHANGE_EVENT } from 'lib/utils/functions/dispatchDownloadListChangeEvent'
+import { Modal } from 'react-bootstrap'
+
+const ShowDownloadDemo = ({ token }: { token: string | undefined }) => {
+  const [showDownloadList, setShowDownloadList] = useState(false)
+  useEffect(() => {
+    const listener = document.addEventListener(
+      DOWNLOAD_LIST_CHANGE_EVENT,
+      () => {
+        setShowDownloadList(true)
+      },
+    )
+    return listener
+  })
+  if (!token) {
+    return <p> You need to sign in to for ShowDownload to render </p>
+  }
+  return (
+    <div>
+      <ShowDownload token={token} />
+      <Modal
+        centered={true}
+        animation={false}
+        size={'lg'}
+        onHide={() => {
+          setShowDownloadList(false)
+        }}
+        show={showDownloadList}
+      >
+        <DownloadListTable token={token} />
+      </Modal>
+    </div>
+  )
+}
+export default ShowDownloadDemo

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -344,6 +344,10 @@ export default class HasAccess extends React.Component<
     )
   }
 
+  componentWillUnmount() {
+    console.log('unmounting')
+  }
+
   // Show Access Requirements
   renderARsLink = () => {
     const { entityId, token } = this.props

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -168,10 +168,6 @@ export default class HasAccess extends React.Component<
     this.getFileEntityFileHandle(forceRefresh)
   }
 
-  componentWillUnmount() {
-    console.log('has access is unmounting')
-  }
-
   getFileEntityFileHandle = (forceRefresh?: boolean) => {
     const {
       entityId,

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -44,6 +44,8 @@ type HasAccessState = {
   fileHandleDownloadType?: FileHandleDownloadTypeEnum
   displayAccessRequirement: boolean
   accessRequirements?: Array<AccessRequirement>
+  isGettingRestrictionInformation: boolean
+  isGettingEntityInformation: boolean
 }
 
 export enum ExternalFileHandleConcreteTypeEnum {
@@ -59,13 +61,13 @@ export enum GoogleCloudFileHandleEnum {
 export const GIGABYTE_SIZE = 2 ** 30
 
 export enum FileHandleDownloadTypeEnum {
-  ExternalCloudFile,
-  ExternalFileLink,
-  TooLarge,
-  Accessible,
-  AccessBlocked,
-  AccessBlockedToAnonymous,
-  NoFileHandle,
+  ExternalCloudFile = 'ExternalCloudFile',
+  ExternalFileLink = 'ExternalFileLink',
+  TooLarge = 'TooLarge',
+  Accessible = 'Accessible',
+  AccessBlocked = 'AccessBlocked',
+  AccessBlockedToAnonymous = 'AccessBlockedToAnonymous',
+  NoFileHandle = 'NoFileHandle',
 }
 
 export const getDownloadTypeForFileHandle = (
@@ -137,24 +139,39 @@ export default class HasAccess extends React.Component<
       fileHandleDownloadType,
       displayAccessRequirement: false,
       accessRequirements: [],
+      isGettingEntityInformation: false,
+      isGettingRestrictionInformation: false,
     }
   }
 
   componentDidMount() {
-    this.getRestrictionInformation()
-    this.getFileEntityFileHandle()
+    this.refresh()
   }
 
   componentDidUpdate(prevProps: HasAccessProps) {
     if (!prevProps.token && this.props.token) {
-      // they just signed in, force refresh the data
-      this.getRestrictionInformation(true)
-      this.getFileEntityFileHandle(true)
+      this.refresh(true)
     } else {
-      this.getRestrictionInformation()
-      this.getFileEntityFileHandle()
+      this.refresh()
     }
   }
+
+  refresh = (forceRefresh?: boolean) => {
+    if (
+      !this.props.token ||
+      this.state.isGettingEntityInformation ||
+      this.state.isGettingRestrictionInformation
+    ) {
+      return
+    }
+    this.getRestrictionInformation(forceRefresh)
+    this.getFileEntityFileHandle(forceRefresh)
+  }
+
+  componentWillUnmount() {
+    console.log('has access is unmounting')
+  }
+
   getFileEntityFileHandle = (forceRefresh?: boolean) => {
     const {
       entityId,
@@ -162,13 +179,16 @@ export default class HasAccess extends React.Component<
       token,
       isInDownloadList,
     } = this.props
-    if (!forceRefresh && this.state.fileHandleDownloadType) {
+    if (this.state.fileHandleDownloadType && !forceRefresh) {
       // already know the downloadType
       return
     }
+    this.setState({
+      isGettingEntityInformation: true,
+    })
     // fileHandle was not passed to us, ask for it.
     // is this a FileEntity?
-    SynapseClient.getEntity(token, entityId, entityVersionNumber)
+    return SynapseClient.getEntity(token, entityId, entityVersionNumber)
       .then(entity => {
         if (entity.hasOwnProperty('dataFileHandleId')) {
           // looks like a FileEntity, get the FileHandle
@@ -183,19 +203,30 @@ export default class HasAccess extends React.Component<
               })
             })
             .catch(err => {
+              console.error('Error on getFileHandle = ', err)
               // could not get the file handle
               this.updateStateFileHandleAccessBlocked()
+            })
+            .finally(() => {
+              this.setState({
+                isGettingEntityInformation: false,
+              })
             })
         } else {
           // entity looks like something else.
           this.setState({
             fileHandleDownloadType: FileHandleDownloadTypeEnum.NoFileHandle,
+            isGettingEntityInformation: false,
           })
         }
       })
       .catch(err => {
+        console.error('Error on get Entity = ', err)
         // could not get entity
         this.updateStateFileHandleAccessBlocked()
+        this.setState({
+          isGettingEntityInformation: false,
+        })
       })
   }
 
@@ -211,24 +242,29 @@ export default class HasAccess extends React.Component<
 
   getRestrictionInformation = (forceRefresh?: boolean) => {
     const { entityId, token } = this.props
-    if (
-      !forceRefresh &&
-      (this.state.restrictionInformation || !entityId || !token)
-    ) {
+    if (this.state.restrictionInformation && !forceRefresh) {
       return
     }
+    this.setState({
+      isGettingRestrictionInformation: true,
+    })
     const request: RestrictionInformationRequest = {
       restrictableObjectType: RestrictableObjectType.ENTITY,
       objectId: entityId,
     }
-    SynapseClient.getRestrictionInformation(request, token)
+    return SynapseClient.getRestrictionInformation(request, token)
       .then(restrictionInformation => {
         this.setState({
           restrictionInformation,
         })
       })
       .catch(err => {
-        console.log('Error on getRestrictionInformation: ', err)
+        console.error('Error on getRestrictionInformation: ', err)
+      })
+      .finally(() => {
+        this.setState({
+          isGettingRestrictionInformation: false,
+        })
       })
   }
 
@@ -280,11 +316,6 @@ export default class HasAccess extends React.Component<
         // nothing is rendered until access requirement is loaded
         return <></>
     }
-  }
-
-  refresh = () => {
-    this.getRestrictionInformation()
-    this.getFileEntityFileHandle()
   }
 
   handleGetAccess = () => {

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -149,11 +149,10 @@ export default class HasAccess extends React.Component<
   }
 
   componentDidUpdate(prevProps: HasAccessProps) {
-    if (!prevProps.token && this.props.token) {
-      this.refresh(true)
-    } else {
-      this.refresh()
-    }
+    const forceRefresh =
+      prevProps.token === undefined && this.props.token !== undefined
+    // if there token has updated then force refresh the component state
+    this.refresh(forceRefresh)
   }
 
   refresh = (forceRefresh?: boolean) => {
@@ -342,10 +341,6 @@ export default class HasAccess extends React.Component<
       )}#!AccessRequirements:ID=${entityId}&TYPE=ENTITY`,
       forceSamePage ? '_self' : '_blank',
     )
-  }
-
-  componentWillUnmount() {
-    console.log('unmounting')
   }
 
   // Show Access Requirements

--- a/src/lib/containers/UserCardSmall.tsx
+++ b/src/lib/containers/UserCardSmall.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 // ignore because this is rollup requiring imports be named a certain way
 // tslint:disable-next-line
-import ReactTooltip from "react-tooltip"
+import ReactTooltip from 'react-tooltip'
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faCircle,  } from '@fortawesome/free-solid-svg-icons'
+import { faCircle } from '@fortawesome/free-solid-svg-icons'
 import { UserProfile } from '../utils/synapseTypes/'
 import { getColor } from '../utils/functions/getUserData'
 
@@ -17,10 +17,16 @@ export type UserCardSmallProps = {
   link?: string
 }
 
-export const UserCardSmall: React.FunctionComponent<UserCardSmallProps> = (
-  { userProfile, hideText = false, hideTooltip = false, preSignedURL, link }
-) => {
-  const linkLocation = link ? link : `https://www.synapse.org/#!Profile:${userProfile.ownerId}`
+export const UserCardSmall: React.FunctionComponent<UserCardSmallProps> = ({
+  userProfile,
+  hideText = false,
+  hideTooltip = false,
+  preSignedURL,
+  link,
+}) => {
+  const linkLocation = link
+    ? link
+    : `https://www.synapse.org/#!Profile:${userProfile.ownerId}`
   let img
   let marginLeft
   let label = ''
@@ -28,7 +34,7 @@ export const UserCardSmall: React.FunctionComponent<UserCardSmallProps> = (
     if (userProfile.displayName) {
       label += userProfile.displayName
     } else if (userProfile.firstName && userProfile.lastName) {
-      label += (`${userProfile.firstName} ${userProfile.lastName}`)
+      label += `${userProfile.firstName} ${userProfile.lastName}`
     }
     if (userProfile.userName) {
       label += ` (${userProfile.userName})`
@@ -55,19 +61,28 @@ export const UserCardSmall: React.FunctionComponent<UserCardSmallProps> = (
     const color = getColor(userProfile.userName)
     marginLeft = '3px'
     img = (
-      <div style={{ background: color }} className="SRC-userImgSmall SRC-centerContentInline">
-        {(userProfile.firstName && userProfile.firstName[0]) || userProfile.userName[0]}
+      <div
+        style={{ background: color }}
+        className="SRC-userImgSmall SRC-centerContentInline"
+      >
+        {(userProfile.firstName && userProfile.firstName[0]) ||
+          userProfile.userName[0]}
       </div>
     )
   }
   return (
     <a
       href={linkLocation}
-      className="SRC-userCard SRC-primary-text-color SRC-no-underline-on-hover"
+      className="SRC-userCard UserCardSmall SRC-primary-text-color SRC-no-underline-on-hover"
     >
       {img}
-        <ReactTooltip delayShow={1000} id={label} multiline={true}/>
-        {!hideText && <span className="SRC-primary-text-color SRC-underline-on-hover" style={{ marginLeft, whiteSpace: 'nowrap' }}>{`@${userProfile.userName}`}</span>}
+      <ReactTooltip delayShow={1000} id={label} multiline={true} />
+      {!hideText && (
+        <span
+          className="SRC-primary-text-color SRC-underline-on-hover"
+          style={{ marginLeft, whiteSpace: 'nowrap' }}
+        >{`@${userProfile.userName}`}</span>
+      )}
     </a>
   )
 }

--- a/src/lib/containers/download_list/DownloadConfirmation.tsx
+++ b/src/lib/containers/download_list/DownloadConfirmation.tsx
@@ -8,7 +8,7 @@ import {
   QueryBundleRequest,
 } from '../../utils/synapseTypes/'
 import DownloadDetails from './DownloadDetails'
-import { dispatchDownloadListChangeEvent } from '../../utils/functions/dispatchDownloadListChangeEvent'
+import DownloadListTable from './DownloadListTable'
 
 enum StatusEnum {
   LOADING_INFO,
@@ -133,6 +133,7 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
     fileSize: 0,
     status: StatusEnum.LOADING_INFO,
   })
+  const [showDownloadList, setShowDownloadList] = useState(false)
 
   useEffect(() => {
     ;(async function getDataOnLoad(query: QueryBundleRequest, token: string) {
@@ -195,10 +196,7 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
       case StatusEnum.SUCCESS:
         return (
           <span>
-            <button
-              // @ts-ignore
-              onClick={dispatchDownloadListChangeEvent}
-            >
+            <button onClick={() => setShowDownloadList(true)}>
               View Download List
             </button>
           </span>
@@ -210,36 +208,45 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
   }
 
   return (
-    <div
-      className={`alert download-confirmation ${
-        StatusConstruct[state.status].className
-      }`}
-    >
-      <div className="download-confirmation__section">
-        {getContent(state, token)}
-      </div>
+    <>
       <div
-        className="download-confirmation__section text-right"
-        style={{
-          width: '150px',
-        }}
+        className={`alert download-confirmation ${
+          StatusConstruct[state.status].className
+        }`}
       >
-        {state.status !== StatusEnum.PROCESSING && (
-          <button className="btn btn-link" onClick={hideComponent}>
-            {StatusConstruct[state.status].closeText}
-          </button>
-        )}
+        <div className="download-confirmation__section">
+          {getContent(state, token)}
+        </div>
+        <div
+          className="download-confirmation__section text-right"
+          style={{
+            width: '150px',
+          }}
+        >
+          {state.status !== StatusEnum.PROCESSING && (
+            <button className="btn btn-link" onClick={hideComponent}>
+              {StatusConstruct[state.status].closeText}
+            </button>
+          )}
 
-        {state.status === StatusEnum.INFO && (
-          <button
-            type="button"
-            className="btn btn-primary"
-            onClick={triggerAddToDownload}
-          >
-            Add
-          </button>
-        )}
+          {state.status === StatusEnum.INFO && (
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={triggerAddToDownload}
+            >
+              Add
+            </button>
+          )}
+        </div>
       </div>
-    </div>
+      {showDownloadList && (
+        <DownloadListTable
+          token={token}
+          renderAsModal={true}
+          onHide={() => setShowDownloadList(false)}
+        />
+      )}
+    </>
   )
 }

--- a/src/lib/containers/download_list/DownloadConfirmation.tsx
+++ b/src/lib/containers/download_list/DownloadConfirmation.tsx
@@ -124,6 +124,7 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
       sumFileSizes,
     } = await SynapseClient.getQueryTableResults(
       queryBundleRequestSizeInformation,
+      token,
     )
     const estimatedDownloadBytesPerSecond = await testDownloadSpeed(token)
     const size = sumFileSizes ? sumFileSizes['sumFileSizesBytes'] : 0

--- a/src/lib/containers/download_list/DownloadConfirmation.tsx
+++ b/src/lib/containers/download_list/DownloadConfirmation.tsx
@@ -8,6 +8,7 @@ import {
   QueryBundleRequest,
 } from '../../utils/synapseTypes/'
 import DownloadDetails from './DownloadDetails'
+import { dispatchDownloadListChangeEvent } from '../../utils/functions/dispatchDownloadListChangeEvent'
 
 enum StatusEnum {
   LOADING_INFO,
@@ -194,13 +195,12 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
       case StatusEnum.SUCCESS:
         return (
           <span>
-            <a
-              href={`https://www.synapse.org/#!Profile:${ownerId}/downloads`}
-              target="_blank"
-              rel="noopener noreferrer"
+            <button
+              // @ts-ignore
+              onClick={dispatchDownloadListChangeEvent}
             >
               View Download List
-            </a>
+            </button>
           </span>
         )
 

--- a/src/lib/containers/download_list/DownloadDetails.tsx
+++ b/src/lib/containers/download_list/DownloadDetails.tsx
@@ -51,7 +51,7 @@ export default function DownloadDetails(props: DownloadDetailsProps) {
   const numBytesTooltipId = 'num_bytes_id'
   const friendlyTimeTooltipId = 'friendly_time_id'
   const isInactive = numFiles === 0 || timeEstimateInSeconds === 0
-  const iconClassName = isInactive? 'SRC-inactive' : 'SRC-primary-text-color'
+  const iconClassName = isInactive ? 'SRC-inactive' : 'SRC-primary-text-color'
   return (
     <span className="download-details-container">
       <span>
@@ -84,7 +84,7 @@ export default function DownloadDetails(props: DownloadDetailsProps) {
           id={friendlyTimeTooltipId}
         />
         <FontAwesomeIcon className={iconClassName} icon="clock" />
-        {isLoading && <span className="loader" />}
+        {isLoading && numFiles > 0 && <span className="spinner" />}
         {!isLoading && friendlyTime}
       </span>
     </span>

--- a/src/lib/containers/download_list/DownloadDetails.tsx
+++ b/src/lib/containers/download_list/DownloadDetails.tsx
@@ -32,7 +32,7 @@ export default function DownloadDetails(props: DownloadDetailsProps) {
   const { token, numFiles, numBytes } = props
 
   useEffect(() => {
-    if (isLoading && token) {
+    if (token) {
       testDownloadSpeed(token).then(speed => {
         setState({
           isLoading: false,
@@ -40,7 +40,7 @@ export default function DownloadDetails(props: DownloadDetailsProps) {
         })
       })
     }
-  })
+  }, [token])
 
   const timeEstimateInSeconds =
     isLoading || downloadSpeed === 0 ? 0 : numBytes / downloadSpeed

--- a/src/lib/containers/download_list/DownloadListTable.tsx
+++ b/src/lib/containers/download_list/DownloadListTable.tsx
@@ -45,6 +45,8 @@ export type DownloadListTableProps = {
   token?: string
   listUpdatedCallback?: VoidFunction
   forceSamePage?: boolean
+  renderAsModal?: boolean
+  onHide?: Function
 }
 
 export const TESTING_TRASH_BTN_CLASS = 'TESTING_TRASH_BTN_CLASS'
@@ -60,8 +62,9 @@ export default function DownloadListTable(props: DownloadListTableProps) {
   // https://reactjs.org/docs/hooks-faq.html#should-i-use-one-or-many-state-variables
   const [isLoading, setIsLoading] = useState<LoadingState>(true)
   const [fileBeingDeleted, setFileBeingDeleted] = useState<string>('')
+  const [showAsModalState, setShowAsModalState] = useState(true)
   const { token } = props
-  const { forceSamePage = false } = props
+  const { forceSamePage = false, renderAsModal = false, onHide } = props
   const { references, batchFileResult, downloadList } = data
   const requestedFiles =
     (batchFileResult && batchFileResult.requestedFiles) || []
@@ -188,132 +191,162 @@ export default function DownloadListTable(props: DownloadListTableProps) {
     }
   }
 
+  const Container = (props: any) => {
+    return renderAsModal ? (
+      <ReactBootstrap.Modal
+        centered={true}
+        animation={false}
+        size={'lg'}
+        dialogClassName={'download-list-modal-container'}
+        show={showAsModalState}
+        onHide={() => {
+          setShowAsModalState(false)
+          onHide?.()
+        }}
+      >
+        {props.children}
+      </ReactBootstrap.Modal>
+    ) : (
+      <>{props.children}</>
+    )
+  }
+
   const filesToDownload = (downloadList && downloadList.filesToDownload) || []
   const results = (references && references.results) || []
   let numBytes = 0
   let numFiles = 0
   return (
-    <div className="DownloadListTable">
-      <div className="SRC-split download-list-table-top SRC-primary-background-color SRC-border-bottom-only">
-        <span className="create-package-text">
-          Download List &nbsp;&nbsp; {isLoading && <span className="spinner" />}
-        </span>
-        <button
-          className="SRC-underline-on-hover uppercase-text"
-          onClick={clearDownloadList}
-          id={TESTING_CLEAR_BTN_CLASS}
-        >
-          Clear list
-        </button>
-      </div>
-      <ReactBootstrap.Table striped={true} responsive={true}>
-        <thead>
-          <tr>
-            <th>File Name</th>
-            <th>Access</th>
-            <th>Created By</th>
-            <th>Created On</th>
-            <th>Size</th>
-            {/* th below is made for trash can icon but holds no content */}
-            <th />
-          </tr>
-        </thead>
-        <tbody className="download-list-table">
-          {filesToDownload.map(item => {
-            let createdBy = ''
-            let createdOn = ''
-            let fileName = ''
-            let contentSize = undefined
-            const synId = item.associateObjectId
-            const fileHandleId = item.fileHandleId
-            const isCurrentlyBeingDeletedClass =
-              fileBeingDeleted === fileHandleId ? 'SRC-inactive-bg' : ''
-            // See if batch file results has this fileHandleId
-            const fileResult = requestedFiles.find(
-              fileRes => fileRes.fileHandleId === fileHandleId,
-            )
-            const fileHandle = fileResult ? fileResult.fileHandle : undefined
-            const canDownload = fileHandle !== undefined
-            if (fileHandle) {
-              // fileHandle is defined, this file is downloadable, show its metadata
-              ;({ createdBy, createdOn, fileName, contentSize } = fileHandle)
-              createdOn = moment(createdOn).format('L LT')
-              if (
-                getDownloadTypeForFileHandle(fileHandle) ===
-                FileHandleDownloadTypeEnum.Accessible
-              ) {
-                numBytes += contentSize
-                numFiles += 1
+    <Container>
+      <div className="DownloadListTable">
+        <div className="SRC-split download-list-table-top SRC-primary-background-color SRC-border-bottom-only">
+          <span className="create-package-text">
+            Download List &nbsp;&nbsp;{' '}
+            {isLoading && <span className="spinner" />}
+          </span>
+          <button
+            className="SRC-underline-on-hover uppercase-text"
+            onClick={clearDownloadList}
+            id={TESTING_CLEAR_BTN_CLASS}
+          >
+            Clear list
+          </button>
+        </div>
+        <ReactBootstrap.Table striped={true} responsive={true}>
+          <thead>
+            <tr>
+              <th>File Name</th>
+              <th>Access</th>
+              <th>Created By</th>
+              <th>Created On</th>
+              <th>Size</th>
+              {/* th below is made for trash can icon but holds no content */}
+              <th />
+            </tr>
+          </thead>
+          <tbody className="download-list-table">
+            {filesToDownload.map(item => {
+              let createdBy = ''
+              let createdOn = ''
+              let fileName = ''
+              let contentSize = undefined
+              const synId = item.associateObjectId
+              const fileHandleId = item.fileHandleId
+              const isCurrentlyBeingDeletedClass =
+                fileBeingDeleted === fileHandleId ? 'SRC-inactive-bg' : ''
+              // See if batch file results has this fileHandleId
+              const fileResult = requestedFiles.find(
+                fileRes => fileRes.fileHandleId === fileHandleId,
+              )
+              const fileHandle = fileResult ? fileResult.fileHandle : undefined
+              const canDownload = fileHandle !== undefined
+              if (fileHandle) {
+                // fileHandle is defined, this file is downloadable, show its metadata
+                ;({ createdBy, createdOn, fileName, contentSize } = fileHandle)
+                createdOn = moment(createdOn).format('L LT')
+                if (
+                  getDownloadTypeForFileHandle(fileHandle) ===
+                  FileHandleDownloadTypeEnum.Accessible
+                ) {
+                  numBytes += contentSize
+                  numFiles += 1
+                }
+              } else {
+                // file is not downloadable, only show its name from entity header info
+                const requestedFile = results.find(
+                  req => req.id === item.associateObjectId,
+                )!
+                fileName = requestedFile.name
               }
-            } else {
-              // file is not downloadable, only show its name from entity header info
-              const requestedFile = results.find(
-                req => req.id === item.associateObjectId,
-              )!
-              fileName = requestedFile.name
-            }
-            const userProfile = userProfiles.find(
-              el => el.ownerId === createdBy,
-            )
-            return (
-              <tr className={isCurrentlyBeingDeletedClass} key={fileHandleId}>
-                <td>
-                  <a
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={`https://www.synapse.org/#!Synapse:${synId}`}
-                  >
-                    {fileName}
-                  </a>
-                </td>
-                <td>
-                  <HasAccess
-                    fileHandle={fileHandle}
-                    token={token}
-                    entityId={synId}
-                    isInDownloadList={true}
-                    forceSamePage={forceSamePage}
-                  />
-                </td>
-                <td>
-                  {userProfile && (
-                    <UserCard
-                      size={'SMALL USER CARD'}
-                      userProfile={userProfile}
-                      preSignedURL={userProfile.clientPreSignedURL}
+              const userProfile = userProfiles.find(
+                el => el.ownerId === createdBy,
+              )
+              return (
+                <tr className={isCurrentlyBeingDeletedClass} key={fileHandleId}>
+                  <td>
+                    <a
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      href={`https://www.synapse.org/#!Synapse:${synId}`}
+                    >
+                      {fileName}
+                    </a>
+                  </td>
+                  <td>
+                    <HasAccess
+                      fileHandle={fileHandle}
+                      token={token}
+                      entityId={synId}
+                      isInDownloadList={true}
+                      forceSamePage={forceSamePage}
                     />
-                  )}
-                  {canDownload && !userProfile && <span className="spinner" />}
-                </td>
-                <td>{createdOn}</td>
-                <td>{contentSize && calculateFriendlyFileSize(contentSize)}</td>
-                <td>
-                  <button
-                    className={TESTING_TRASH_BTN_CLASS}
-                    onClick={
-                      fileBeingDeleted === ''
-                        ? () => deleteFileFromList(fileHandleId, synId)
-                        : undefined
-                    }
-                  >
-                    <FontAwesomeIcon
-                      className="SRC-primary-text-color"
-                      icon="trash"
-                    />
-                  </button>
-                </td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </ReactBootstrap.Table>
-      <CreatePackage updateDownloadList={() => fetchData(token)} token={token}>
-        <DownloadDetails
-          numBytes={numBytes}
-          numFiles={numFiles}
+                  </td>
+                  <td>
+                    {userProfile && (
+                      <UserCard
+                        size={'SMALL USER CARD'}
+                        userProfile={userProfile}
+                        preSignedURL={userProfile.clientPreSignedURL}
+                      />
+                    )}
+                    {canDownload && !userProfile && (
+                      <span className="spinner" />
+                    )}
+                  </td>
+                  <td>{createdOn}</td>
+                  <td>
+                    {contentSize && calculateFriendlyFileSize(contentSize)}
+                  </td>
+                  <td>
+                    <button
+                      className={TESTING_TRASH_BTN_CLASS}
+                      onClick={
+                        fileBeingDeleted === ''
+                          ? () => deleteFileFromList(fileHandleId, synId)
+                          : undefined
+                      }
+                    >
+                      <FontAwesomeIcon
+                        className="SRC-primary-text-color"
+                        icon="trash"
+                      />
+                    </button>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </ReactBootstrap.Table>
+        <CreatePackage
+          updateDownloadList={() => fetchData(token)}
           token={token}
-        />
-      </CreatePackage>
-    </div>
+        >
+          <DownloadDetails
+            numBytes={numBytes}
+            numFiles={numFiles}
+            token={token}
+          />
+        </CreatePackage>
+      </div>
+    </Container>
   )
 }

--- a/src/lib/containers/download_list/DownloadListTable.tsx
+++ b/src/lib/containers/download_list/DownloadListTable.tsx
@@ -187,161 +187,150 @@ export default function DownloadListTable(props: DownloadListTableProps) {
     }
   }
 
-  const Container = useCallback(
-    (props: any) => {
-      return renderAsModal ? (
-        <ReactBootstrap.Modal
-          centered={true}
-          animation={false}
-          size={'lg'}
-          dialogClassName={'download-list-modal-container'}
-          show={true}
-          onHide={() => {
-            onHide?.()
-          }}
-        >
-          {props.children}
-        </ReactBootstrap.Modal>
-      ) : (
-        <>{props.children}</>
-      )
-    },
-    [onHide, renderAsModal],
-  )
-
   const filesToDownload = downloadList?.filesToDownload ?? []
   const results = references?.results ?? []
   let numBytes = 0
   let numFiles = 0
-  return (
-    <Container>
-      <div className="DownloadListTable">
-        <div className="SRC-split download-list-table-top SRC-primary-background-color SRC-border-bottom-only">
-          <span className="create-package-text">
-            Download List &nbsp;&nbsp;{' '}
-            {isLoading && <span className="spinner" />}
-          </span>
-          <button
-            className="SRC-underline-on-hover uppercase-text"
-            onClick={clearDownloadList}
-            id={TESTING_CLEAR_BTN_CLASS}
-          >
-            Clear list
-          </button>
-        </div>
-        <ReactBootstrap.Table striped={true} responsive={true}>
-          <thead>
-            <tr>
-              <th>File Name</th>
-              <th>Access</th>
-              <th>Created By</th>
-              <th>Created On</th>
-              <th>Size</th>
-              {/* th below is made for trash can icon but holds no content */}
-              <th />
-            </tr>
-          </thead>
-          <tbody className="download-list-table">
-            {filesToDownload.map(item => {
-              let createdBy = ''
-              let createdOn = ''
-              let fileName = ''
-              let contentSize = undefined
-              const synId = item.associateObjectId
-              const fileHandleId = item.fileHandleId
-              const isCurrentlyBeingDeletedClass =
-                fileBeingDeleted === fileHandleId ? 'SRC-inactive-bg' : ''
-              // See if batch file results has this fileHandleId
-              const fileResult = requestedFiles.find(
-                fileRes => fileRes.fileHandleId === fileHandleId,
-              )
-              const fileHandle = fileResult ? fileResult.fileHandle : undefined
-              const canDownload = fileHandle !== undefined
-              if (fileHandle) {
-                // fileHandle is defined, this file is downloadable, show its metadata
-                ;({ createdBy, createdOn, fileName, contentSize } = fileHandle)
-                createdOn = moment(createdOn).format('L LT')
-                if (
-                  getDownloadTypeForFileHandle(fileHandle) ===
-                  FileHandleDownloadTypeEnum.Accessible
-                ) {
-                  numBytes += contentSize
-                  numFiles += 1
-                }
-              } else {
-                // file is not downloadable, only show its name from entity header info
-                const requestedFile = results.find(
-                  req => req.id === item.associateObjectId,
-                )!
-                fileName = requestedFile.name
-              }
-              const userProfile = userProfiles.find(
-                el => el.ownerId === createdBy,
-              )
-              return (
-                <tr className={isCurrentlyBeingDeletedClass} key={fileHandleId}>
-                  <td>
-                    <a
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={`https://www.synapse.org/#!Synapse:${synId}`}
-                    >
-                      {fileName}
-                    </a>
-                  </td>
-                  <td>
-                    <HasAccess
-                      fileHandle={fileHandle}
-                      token={token}
-                      entityId={synId}
-                      isInDownloadList={true}
-                      forceSamePage={forceSamePage}
-                    />
-                  </td>
-                  <td>
-                    {userProfile && (
-                      <UserCard
-                        size={'SMALL USER CARD'}
-                        userProfile={userProfile}
-                        preSignedURL={userProfile.clientPreSignedURL}
-                      />
-                    )}
-                    {canDownload && !userProfile && (
-                      <span className="spinner" />
-                    )}
-                  </td>
-                  <td>{createdOn}</td>
-                  <td>
-                    {contentSize && calculateFriendlyFileSize(contentSize)}
-                  </td>
-                  <td>
-                    <button
-                      className={TESTING_TRASH_BTN_CLASS}
-                      onClick={
-                        fileBeingDeleted === ''
-                          ? () => deleteFileFromList(fileHandleId, synId)
-                          : undefined
-                      }
-                    >
-                      <FontAwesomeIcon
-                        className="SRC-primary-text-color"
-                        icon="trash"
-                      />
-                    </button>
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </ReactBootstrap.Table>
-        <CreatePackage updateDownloadList={fetchData} token={token}>
-          <DownloadDetails
-            numBytes={numBytes}
-            numFiles={numFiles}
-            token={token}
-          />
-        </CreatePackage>
+  const content = (
+    <div className="DownloadListTable">
+      <div className="SRC-split download-list-table-top SRC-primary-background-color SRC-border-bottom-only">
+        <span className="create-package-text">
+          Download List &nbsp;&nbsp; {isLoading && <span className="spinner" />}
+        </span>
+        <button
+          className="SRC-underline-on-hover uppercase-text"
+          onClick={clearDownloadList}
+          id={TESTING_CLEAR_BTN_CLASS}
+        >
+          Clear list
+        </button>
       </div>
-    </Container>
+      <ReactBootstrap.Table striped={true} responsive={true}>
+        <thead>
+          <tr>
+            <th>File Name</th>
+            <th>Access</th>
+            <th>Created By</th>
+            <th>Created On</th>
+            <th>Size</th>
+            {/* th below is made for trash can icon but holds no content */}
+            <th />
+          </tr>
+        </thead>
+        <tbody className="download-list-table">
+          {filesToDownload.map(item => {
+            let createdBy = ''
+            let createdOn = ''
+            let fileName = ''
+            let contentSize = undefined
+            const synId = item.associateObjectId
+            const fileHandleId = item.fileHandleId
+            const isCurrentlyBeingDeletedClass =
+              fileBeingDeleted === fileHandleId ? 'SRC-inactive-bg' : ''
+            // See if batch file results has this fileHandleId
+            const fileResult = requestedFiles.find(
+              fileRes => fileRes.fileHandleId === fileHandleId,
+            )
+            const fileHandle = fileResult ? fileResult.fileHandle : undefined
+            const canDownload = fileHandle !== undefined
+            if (fileHandle) {
+              // fileHandle is defined, this file is downloadable, show its metadata
+              ;({ createdBy, createdOn, fileName, contentSize } = fileHandle)
+              createdOn = moment(createdOn).format('L LT')
+              if (
+                getDownloadTypeForFileHandle(fileHandle) ===
+                FileHandleDownloadTypeEnum.Accessible
+              ) {
+                numBytes += contentSize
+                numFiles += 1
+              }
+            } else {
+              // file is not downloadable, only show its name from entity header info
+              const requestedFile = results.find(
+                req => req.id === item.associateObjectId,
+              )!
+              fileName = requestedFile.name
+            }
+            const userProfile = userProfiles.find(
+              el => el.ownerId === createdBy,
+            )
+            return (
+              <tr className={isCurrentlyBeingDeletedClass} key={fileHandleId}>
+                <td>
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={`https://www.synapse.org/#!Synapse:${synId}`}
+                  >
+                    {fileName}
+                  </a>
+                </td>
+                <td>
+                  <HasAccess
+                    fileHandle={fileHandle}
+                    token={token}
+                    entityId={synId}
+                    isInDownloadList={true}
+                    forceSamePage={forceSamePage}
+                  />
+                </td>
+                <td>
+                  {userProfile && (
+                    <UserCard
+                      size={'SMALL USER CARD'}
+                      userProfile={userProfile}
+                      preSignedURL={userProfile.clientPreSignedURL}
+                    />
+                  )}
+                  {canDownload && !userProfile && <span className="spinner" />}
+                </td>
+                <td>{createdOn}</td>
+                <td>{contentSize && calculateFriendlyFileSize(contentSize)}</td>
+                <td>
+                  <button
+                    className={TESTING_TRASH_BTN_CLASS}
+                    onClick={
+                      fileBeingDeleted === ''
+                        ? () => deleteFileFromList(fileHandleId, synId)
+                        : undefined
+                    }
+                  >
+                    <FontAwesomeIcon
+                      className="SRC-primary-text-color"
+                      icon="trash"
+                    />
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </ReactBootstrap.Table>
+      <CreatePackage updateDownloadList={fetchData} token={token}>
+        <DownloadDetails
+          numBytes={numBytes}
+          numFiles={numFiles}
+          token={token}
+        />
+      </CreatePackage>
+    </div>
   )
+  if (renderAsModal) {
+    return (
+      <ReactBootstrap.Modal
+        centered={true}
+        animation={false}
+        size={'lg'}
+        dialogClassName={'download-list-modal-container'}
+        show={true}
+        onHide={() => {
+          onHide?.()
+        }}
+      >
+        {content}
+      </ReactBootstrap.Modal>
+    )
+  } else {
+    return content
+  }
 }

--- a/src/lib/containers/download_list/DownloadListTable.tsx
+++ b/src/lib/containers/download_list/DownloadListTable.tsx
@@ -193,20 +193,20 @@ export default function DownloadListTable(props: DownloadListTableProps) {
   let numBytes = 0
   let numFiles = 0
   return (
-    <div>
-      <div className="SRC-split download-list-table-top">
-        <span className="create-package-text SRC-centerContentInline">
+    <div className="DownloadListTable">
+      <div className="SRC-split download-list-table-top SRC-primary-background-color SRC-border-bottom-only">
+        <span className="create-package-text">
           Download List &nbsp;&nbsp; {isLoading && <span className="spinner" />}
         </span>
         <button
-          className="SRC-primary-text-color SRC-underline-on-hover"
+          className="SRC-underline-on-hover uppercase-text"
           onClick={clearDownloadList}
           id={TESTING_CLEAR_BTN_CLASS}
         >
-          Clear All
+          Clear list
         </button>
       </div>
-      <ReactBootstrap.Table responsive={true}>
+      <ReactBootstrap.Table striped={true} responsive={true}>
         <thead>
           <tr>
             <th>File Name</th>

--- a/src/lib/containers/download_list/ShowDownload.tsx
+++ b/src/lib/containers/download_list/ShowDownload.tsx
@@ -5,10 +5,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Link, withRouter, RouteComponentProps } from 'react-router-dom'
 import { SynapseClient } from '../../utils'
 import { DownloadList } from '../../utils/synapseTypes'
-import {
-  DOWNLOAD_LIST_CHANGE_EVENT,
-  dispatchDownloadListChangeEvent,
-} from '../../utils/functions/dispatchDownloadListChangeEvent'
+import { DOWNLOAD_LIST_CHANGE_EVENT } from '../../utils/functions/dispatchDownloadListChangeEvent'
+import DownloadListTable from './DownloadListTable'
 
 library.add(faDownload)
 
@@ -21,6 +19,7 @@ function ShowDownload({ token, to }: ShowDownloadProps & RouteComponentProps) {
   const [downloadList, setDownloadList] = useState<DownloadList | undefined>(
     undefined,
   )
+  const [showDownloadModal, setShowDownloadModal] = useState(false)
   useEffect(() => {
     if (!token) {
       return
@@ -28,9 +27,10 @@ function ShowDownload({ token, to }: ShowDownloadProps & RouteComponentProps) {
     const updateDownloadList = async (
       event?: CustomEventInit<DownloadList>,
     ) => {
-      if (event) {
+      if (event?.detail) {
         setDownloadList(event.detail)
       } else {
+        // for initialization
         SynapseClient.getDownloadList(token).then(downloadList => {
           setDownloadList(downloadList)
         })
@@ -50,6 +50,9 @@ function ShowDownload({ token, to }: ShowDownloadProps & RouteComponentProps) {
     return <></>
   }
   const size = downloadList?.filesToDownload.length ?? 0
+  if (size === 0) {
+    return <></>
+  }
   const positionClass = to ? 'position-by-anchor' : 'position-by-button'
   const content = (
     <>
@@ -59,17 +62,27 @@ function ShowDownload({ token, to }: ShowDownloadProps & RouteComponentProps) {
       <span className={`download-size ${positionClass}`}>{size}</span>
     </>
   )
+
   return to ? (
     <Link className="Download-Link SRC-userImgSmall" to={to}>
       {content}
     </Link>
   ) : (
-    <button
-      onClick={() => dispatchDownloadListChangeEvent(downloadList)}
-      className="Download-Link"
-    >
-      {content}
-    </button>
+    <>
+      <button
+        onClick={() => setShowDownloadModal(true)}
+        className="Download-Link"
+      >
+        {content}
+      </button>
+      {showDownloadModal && (
+        <DownloadListTable
+          token={token}
+          renderAsModal={true}
+          onHide={() => setShowDownloadModal(false)}
+        />
+      )}
+    </>
   )
 }
 

--- a/src/lib/containers/download_list/ShowDownload.tsx
+++ b/src/lib/containers/download_list/ShowDownload.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faDownload } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { Link, withRouter, RouteComponentProps } from 'react-router-dom'
+import { SynapseClient } from '../../utils'
+import { DownloadList } from '../../utils/synapseTypes'
+import {
+  DOWNLOAD_LIST_CHANGE_EVENT,
+  dispatchDownloadListChangeEvent,
+} from '../../utils/functions/dispatchDownloadListChangeEvent'
+
+library.add(faDownload)
+
+export type ShowDownloadProps = {
+  token?: string
+  to?: string
+}
+
+function ShowDownload({ token, to }: ShowDownloadProps & RouteComponentProps) {
+  const [downloadList, setDownloadList] = useState<DownloadList | undefined>(
+    undefined,
+  )
+  useEffect(() => {
+    if (!token) {
+      return
+    }
+    const updateDownloadList = async (
+      event?: CustomEventInit<DownloadList>,
+    ) => {
+      if (event) {
+        setDownloadList(event.detail)
+      } else {
+        SynapseClient.getDownloadList(token).then(downloadList => {
+          setDownloadList(downloadList)
+        })
+      }
+    }
+    updateDownloadList()
+    document.addEventListener(DOWNLOAD_LIST_CHANGE_EVENT, updateDownloadList)
+    return () => {
+      document.removeEventListener(
+        DOWNLOAD_LIST_CHANGE_EVENT,
+        updateDownloadList,
+      )
+    }
+  }, [token])
+
+  if (!token) {
+    return <></>
+  }
+  const size = downloadList?.filesToDownload.length ?? 0
+  const positionClass = to ? 'position-by-anchor' : 'position-by-button'
+  const content = (
+    <>
+      <span className="icon-container">
+        <FontAwesomeIcon icon="download" />
+      </span>
+      <span className={`download-size ${positionClass}`}>{size}</span>
+    </>
+  )
+  return to ? (
+    <Link className="Download-Link SRC-userImgSmall" to={to}>
+      {content}
+    </Link>
+  ) : (
+    <button
+      onClick={() => dispatchDownloadListChangeEvent(downloadList)}
+      className="Download-Link"
+    >
+      {content}
+    </button>
+  )
+}
+
+export default withRouter(ShowDownload)

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -7,7 +7,6 @@ import QueryWrapperMenu from './containers/QueryWrapperMenu'
 import QueryWrapper from './containers/QueryWrapper'
 import StackedBarChart from './containers/StackedBarChart'
 import HasAccess from './containers/HasAccess'
-import DownloadListTable from './containers/download_list/DownloadListTable'
 import SynapseTable from './containers/table/SynapseTable'
 import UserCard from './containers/UserCard'
 import Login from './containers/Login'
@@ -18,6 +17,8 @@ import SynapseFormWrapper from './containers/synapse_form_wrapper/SynapseFormWra
 import SynapseFormSubmissionsGrid from './containers/synapse_form_wrapper/SynapseFormSubmissionsGrid'
 import CardContainerLogic from './containers/CardContainerLogic'
 import ModalDownload from './containers/ModalDownload'
+import ShowDownload from './containers/download_list/ShowDownload'
+import DownloadListTable from './containers/download_list/DownloadListTable'
 import NewsFeedMenu from './containers/NewsFeedMenu'
 import ThemesPlot from './containers/widgets/themes-plot/ThemesPlot'
 import './style/main.scss'
@@ -43,6 +44,7 @@ const SynapseComponents = {
   HasAccess,
   DownloadListTable,
   ThemesPlot,
+  ShowDownload,
 }
 
 export { SynapseClient, SynapseConstants, SynapseComponents }

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -543,11 +543,17 @@ div.SRC-logo-cursor * {
   font-size: 26px;
 }
 
+.UserCardSmall {
+  height: fit-content;
+  width: fit-content;
+}
+
 .SRC-userImgSmall {
+  font-size: 18px;
   border-radius: 50%;
-  height: 23px;
-  width: 23px;
-  min-width: 23px;
+  width: 30px;
+  height: 30px;
+  padding: 20px;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;

--- a/src/lib/style/base/_helpers.scss
+++ b/src/lib/style/base/_helpers.scss
@@ -52,3 +52,9 @@
   position: absolute;
   width: 1px;
 }
+
+.center-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/lib/style/components/_all.scss
+++ b/src/lib/style/components/_all.scss
@@ -1,4 +1,5 @@
 @import './cards', './download-confirmation', './download-list', './spinner',
   './synapse_form_wrapper/steps-side-nav',
   './synapse_form_wrapper/synapse-form-wrapper', './query-filter',
-  './range-slider', './markdown', './access-requirement-list', './themes-plot';
+  './range-slider', './markdown', './access-requirement-list', './themes-plot',
+  './download-link';

--- a/src/lib/style/components/_download-link.scss
+++ b/src/lib/style/components/_download-link.scss
@@ -1,0 +1,36 @@
+.Download-Link {
+  position: relative;
+  display: inline-block;
+  .icon-container {
+    background-color: $primary-action-color;
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    padding: 20px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+    * {
+      color: white;
+    }
+  }
+  .download-size {
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    background-color: green;
+    text-align: center;
+    position: absolute;
+    width: 30px;
+    height: 18px;
+    color: white;
+    border-radius: 8px;
+    &.position-by-button {
+      top: 7px;
+      right: -8px;
+    }
+    &.position-by-anchor {
+      top: -20px;
+      right: -10px;
+    }
+  }
+}

--- a/src/lib/style/components/_download-link.scss
+++ b/src/lib/style/components/_download-link.scss
@@ -34,3 +34,24 @@
     }
   }
 }
+
+.download-list-modal-container {
+  width: fit-content;
+  position: relative;
+  .DownloadListTable {
+    padding: 20px;
+    max-height: 700px;
+    overflow: auto;
+    table {
+      position: relative;
+      th {
+        top: 0px;
+        position: sticky;
+        z-index: 12;
+      }
+    }
+  }
+  .create-package-container {
+    border-top: 1px solid #dcdcdc;
+  }
+}

--- a/src/lib/style/components/_download-list.scss
+++ b/src/lib/style/components/_download-list.scss
@@ -15,7 +15,31 @@
     margin-right: 4px;
   }
 }
+.DownloadListTable {
+  .create-package-text {
+    font-size: 17px;
+    margin: 0px;
+  }
 
+  .download-list-table-top {
+    align-items: center;
+    height: 40px;
+    padding-left: 5px;
+    * {
+      color: white;
+    }
+  }
+
+  .action-button {
+    margin-left: 15px;
+  }
+
+  .download-list-table {
+    td {
+      vertical-align: middle !important;
+    }
+  }
+}
 .create-package-container {
   display: flex;
   padding: 8px;
@@ -41,19 +65,9 @@
   margin-left: 5px;
 }
 
-.create-package-text {
-  font-size: 17px;
-  margin: 0px;
-}
-
-.download-list-table-top {
-  padding: 8px;
-}
-
 .action-button {
   margin-left: 15px;
 }
-
 
 .download-list-table {
   td {

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -1439,7 +1439,7 @@ export const getFileEntityFileHandle = (
           data.requestedFiles.length > 0 &&
           data.requestedFiles[0].fileHandle
         ) {
-          resolve(data.requestedFiles[0].fileHandle)
+          return resolve(data.requestedFiles[0].fileHandle)
         } else {
           // not found, or not allowed to access
           reject(undefined)

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -62,6 +62,7 @@ import {
   FileHandleAssociateType,
 } from './synapseTypes/'
 import UniversalCookies from 'universal-cookie'
+import { dispatchDownloadListChangeEvent } from './functions/dispatchDownloadListChangeEvent'
 
 const cookies = new UniversalCookies()
 
@@ -1578,7 +1579,7 @@ export const getEvaluationSubmissions = (
  * http://rest-docs.synapse.org/rest/POST/oauth2/description.html
  */
 export const getOAuth2RequestDescription = (
-  oidcAuthRequest: OIDCAuthorizationRequest
+  oidcAuthRequest: OIDCAuthorizationRequest,
 ): Promise<OIDCAuthorizationRequestDescription> => {
   return doPost(
     '/auth/v1/oauth2/description',
@@ -2062,13 +2063,16 @@ export const deleteDownloadListFiles = (
   list: FileHandleAssociation[],
   sessionToken: string | undefined,
 ): Promise<DownloadList> => {
-  return doPost(
+  return doPost<DownloadList>(
     '/file/v1/download/list/remove',
     { list },
     sessionToken,
     undefined,
     BackendDestinationEnum.REPO_ENDPOINT,
-  )
+  ).then(data => {
+    dispatchDownloadListChangeEvent(data)
+    return data
+  })
 }
 
 // https://rest-docs.synapse.org/rest/DELETE/download/list.html ?
@@ -2079,5 +2083,7 @@ export const deleteDownloadList = (sessionToken: string | undefined) => {
     sessionToken,
     undefined,
     BackendDestinationEnum.REPO_ENDPOINT,
-  )
+  ).then(_ => {
+    dispatchDownloadListChangeEvent(undefined)
+  })
 }

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -313,7 +313,10 @@ export const addFilesToDownloadList = (
         requestUrl,
         sessionToken,
         updateParentState,
-      )
+      ).then(data => {
+        dispatchDownloadListChangeEvent(data.downloadList)
+        return data
+      })
     })
     .catch((error: any) => {
       throw error

--- a/src/lib/utils/functions/dispatchDownloadListChangeEvent.ts
+++ b/src/lib/utils/functions/dispatchDownloadListChangeEvent.ts
@@ -1,0 +1,13 @@
+import { DownloadList } from '../synapseTypes'
+
+export const DOWNLOAD_LIST_CHANGE_EVENT = 'DOWNLOAD_LIST_UPDATED_EVENT'
+
+export const dispatchDownloadListChangeEvent = (
+  downloadList: DownloadList | undefined,
+) => {
+  const downloadEvent = new CustomEvent(DOWNLOAD_LIST_CHANGE_EVENT, {
+    detail: downloadList,
+  })
+  console.log('dispatched event')
+  document.dispatchEvent(downloadEvent)
+}

--- a/src/lib/utils/functions/dispatchDownloadListChangeEvent.ts
+++ b/src/lib/utils/functions/dispatchDownloadListChangeEvent.ts
@@ -8,6 +8,5 @@ export const dispatchDownloadListChangeEvent = (
   const downloadEvent = new CustomEvent(DOWNLOAD_LIST_CHANGE_EVENT, {
     detail: downloadList,
   })
-  console.log('dispatched event')
   document.dispatchEvent(downloadEvent)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1604,6 +1604,12 @@
     "@types/react-dom" "*"
     "@types/testing-library__dom" "*"
 
+"@types/use-deep-compare-effect@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/use-deep-compare-effect/-/use-deep-compare-effect-1.2.0.tgz#d55d9bda6fea5ff7c93038c53052db1b3145f5d9"
+  dependencies:
+    "@types/react" "*"
+
 "@types/xml2js@^0.4.4":
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/@types/xml2js/-/xml2js-0.4.5.tgz#d21759b056f282d9c7066f15bbf5c19b908f22fa"
@@ -3832,6 +3838,10 @@ delegates@^1.0.0:
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+
+dequal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-1.0.0.tgz#41c6065e70de738541c82cdbedea5292277a017e"
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -11715,6 +11725,14 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-deep-compare-effect@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.3.1.tgz#90bdbed97e1acb8423f7bb0bf24de58590d021af"
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@types/use-deep-compare-effect" "^1.2.0"
+    dequal "^1.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
# Issues found and fixed

### Two async calls in HasAccess were causing 4x the number of calls
scenario:
- `componentDidMount()` is called with two functions inside - `asyncCall_1` and `asyncCall_2`
- `asyncCall_1` finishes before `asyncCall_2` and call's `setState`
- `componentDidUpdate` is triggered because of the `setState` call
- `asyncCall_1` and `asyncCall_2` are both called by `componentDidUpdate`
- `asyncCall_2` from the first `componentDidMount` finishes and call's `setState`
- `componentDidUpdate` is called (note - the first `componentDidUpdate` hasn't finished yet..)
-  ... until finally this all stop's because both stop conditions for `asyncCall_1` and `asyncCall_1` are met

### DownloadListTable renders as a modal
- The download list renders as a modal now to support the ShowDownload component,  removed invokeDownloadListUpdatedEvent by calling listUpdatedCallback() directly using typescript conditional properties

### DownloadConfirmation makes too many API calls on updates to props
One of the props to DownloadConfirmation is the queryBundleRequest object, this object break's the react memoization process because that only uses direct equality comparison. I fixed this by using the `use-deep-compare-effect` which handles this exact issue by doing a deep diff on the props coming in.

### Added ShowDownload component
(Need a better name for this) but this implements the download preview icon in the top right of the screen. The component listens for changes to the download list by a global event and updates itself accordingly.
