### PR TITLE
fix(PORTALS-1095): persist query parameters to URL in portals

### DIFF
--- a/src/__tests__/lib/containers/QueryWrapper.test.tsx
+++ b/src/__tests__/lib/containers/QueryWrapper.test.tsx
@@ -12,9 +12,14 @@ import { cloneDeep } from 'lodash-es'
 const createShallowComponent = async (
   mockRequest: QueryBundleRequest,
   disableLifecycleMethods: boolean = false,
+  shouldDeepLink: boolean = false,
 ) => {
   const wrapper = await shallow(
-    <QueryWrapper initQueryRequest={mockRequest} facet={'projectStatus'} />,
+    <QueryWrapper
+      initQueryRequest={mockRequest}
+      facet={'projectStatus'}
+      shouldDeepLink={shouldDeepLink}
+    />,
     { disableLifecycleMethods },
   )
   const instance = wrapper.instance() as QueryWrapper
@@ -105,6 +110,18 @@ describe('basic functionality', () => {
     const { instance, wrapper } = await createShallowComponent(lastQueryRequest)
     const state = wrapper.state() as QueryWrapperState
     await instance.executeQueryRequest(lastQueryRequest)
+    expect(SynapseClient.getQueryTableResults).toHaveBeenCalled()
+    expect(state.hasMoreData).toEqual(true)
+  })
+
+  it('executeQueryRequest updates url if param is set', async () => {
+    const { instance } = await createShallowComponent(
+      lastQueryRequest,
+      false,
+      true,
+    )
+
+    await instance.executeQueryRequest(lastQueryRequest)
     const location = window.location
     expect(location.search).toContain('QueryWrapper0')
     const query = JSON.parse(
@@ -112,7 +129,6 @@ describe('basic functionality', () => {
     )
     expect(query.sql).toEqual(lastQueryRequest.query.sql)
     expect(SynapseClient.getQueryTableResults).toHaveBeenCalled()
-    expect(state.hasMoreData).toEqual(true)
   })
 })
 

--- a/src/__tests__/lib/containers/QueryWrapperMenu.test.tsx
+++ b/src/__tests__/lib/containers/QueryWrapperMenu.test.tsx
@@ -285,8 +285,21 @@ describe('it renders an accordion config', () => {
       expect(instance.props.menuConfig![1].facet).toBe('e')
     })
 
-    it('updates url search string on facet selection', async () => {
+    it("doesn't update url search string on facet selection if deepLinking flag is not set", async () => {
       const { instance, wrapper } = await createMountedComponent(wrapperProps)
+      await wrapper
+        .find('.SRC-hand-cursor')
+        .at(0)
+        .simulate('click')
+      expect(instance.props.menuConfig![0].facet).toBe('d')
+      expect(window.location.search).not.toBe('?menuIndex=0&facet=d')
+    })
+
+    it('updates url search string on facet selection if deepLinking flag is set', async () => {
+      const { instance, wrapper } = await createMountedComponent({
+        ...wrapperProps,
+        shouldDeepLink: true,
+      })
       await wrapper
         .find('.SRC-hand-cursor')
         .at(0)

--- a/src/demo/containers/Demo.tsx
+++ b/src/demo/containers/Demo.tsx
@@ -34,6 +34,7 @@ type DemoProps = {
  */
 class Demo extends React.Component<DemoProps, DemoState> {
   entityFormRef: any
+  searchParamsProps: any 
   /**
    * Maintain internal state of user session
    */
@@ -122,6 +123,11 @@ class Demo extends React.Component<DemoProps, DemoState> {
     }
     this.getVersion = this.getVersion.bind(this)
     this.onRunDownloadSpeedTest = this.onRunDownloadSpeedTest.bind(this)
+    this.searchParamsProps = {}
+    const searchParams = new URLSearchParams(window.location.search)
+    searchParams.forEach((value, key) => {
+      this.searchParamsProps[key] = value
+    })
   }
 
   public onSubmitEntityForm() {
@@ -332,6 +338,7 @@ class Demo extends React.Component<DemoProps, DemoState> {
             stackedBarChartConfiguration={{
               loadingScreen: <div />,
             }}
+            searchParams = {{facet: this.searchParamsProps['facet'], facetValue: this.searchParamsProps['facetValue']}}
           />
         </div>
       </div>

--- a/src/lib/containers/QueryWrapperMenu.tsx
+++ b/src/lib/containers/QueryWrapperMenu.tsx
@@ -79,7 +79,8 @@ export type QueryWrapperMenuProps = {
   searchParams?: MenuSearchParams
   name?: string
   globalQueryCountSql?: string
-  componentIndex?: number
+  componentIndex?: number //used for deep linking
+  shouldDeepLink?: boolean
 } & CommonMenuProps
 
 type Info = {
@@ -182,14 +183,21 @@ export default class QueryWrapperMenu extends React.Component<
         activeMenuIndices,
         accordionGroupIndex: accordionIndexIn,
       })
-      const facetName = this.props.menuConfig?.[menuIndexIn].facet
-      DeepLinkingUtils.updateUrlWithNewSearchParam(
-        'menuIndex',
-        undefined,
-        accordionIndexIn.toString(),
-      )
-      if (facetName) {
-        DeepLinkingUtils.updateUrlWithNewSearchParam('facet', undefined, facetName)
+
+      if (this.props.shouldDeepLink) {
+        const facetName = this.props.menuConfig?.[menuIndexIn].facet
+        DeepLinkingUtils.updateUrlWithNewSearchParam(
+          'menuIndex',
+          undefined,
+          accordionIndexIn.toString(),
+        )
+        if (facetName) {
+          DeepLinkingUtils.updateUrlWithNewSearchParam(
+            'facet',
+            undefined,
+            facetName,
+          )
+        }
       }
     }
   }

--- a/src/lib/containers/QueryWrapperMenu.tsx
+++ b/src/lib/containers/QueryWrapperMenu.tsx
@@ -292,6 +292,7 @@ export default class QueryWrapperMenu extends React.Component<
       accordionConfig = [],
       facetAliases = {},
       entityId,
+      shouldDeepLink
     } = this.props
     const {
       cardConfiguration,
@@ -386,6 +387,7 @@ export default class QueryWrapperMenu extends React.Component<
             token={token}
             rgbIndex={rgbIndex}
             facetAliases={facetAliases}
+            shouldDeepLink={shouldDeepLink}
           >
             {showBarChart ? (
               <StackedBarChart {...stackedBarChartConfiguration!} />

--- a/src/lib/utils/functions/deepLinkingUtils.ts
+++ b/src/lib/utils/functions/deepLinkingUtils.ts
@@ -1,0 +1,119 @@
+import { QueryBundleRequest } from '../synapseTypes/Table/QueryBundleRequest'
+import { Query } from '../synapseTypes'
+import { SynapseConstants } from '..'
+import { parseEntityIdFromSqlStatement } from './sqlFunctions'
+
+
+//id consists of a component class/function name and it's index
+function getComponentSearchHashId(
+  componentName: string,
+  componentIndex: number,
+): string {
+  return `${componentName}${componentIndex}`
+}
+
+//returns updated search string with the component's info 
+function patchSearchString(
+  componentSearchHashId: string,
+  stringifiedQuery: string,
+): string | undefined {
+  const searchString = window.location.search
+  
+  const searchFragment = `${componentSearchHashId}=${stringifiedQuery}`
+  if (!searchString) {
+    return searchFragment
+  }
+
+  if (!searchString.includes(`${componentSearchHashId}=`)) {
+    //substr(1) because we don't want '?' character
+    return `${searchString.substr(1)}&${searchFragment}`
+  }
+  const searchHashes = window.location.search
+    .slice(searchString.indexOf('?') + 1)
+    .split('&')
+
+  const searchHashesUpdated = searchHashes
+    .map(item => {
+      const split = item.split('=')
+      if (split[0] === componentSearchHashId) {
+        return `${searchFragment}`
+      } else return item
+    })
+    .join('&')
+  return searchHashesUpdated
+}
+
+//gets a value for the search param for the component from the url
+export function getSearchParamValueFromUrl(
+  componentName: string,
+  componentIndex: number,
+): string | undefined {
+  if (!window.location.search) {
+    return undefined
+  }
+  const componentSearchHashId = getComponentSearchHashId(
+    componentName,
+    componentIndex,
+  )
+  const hashes = window.location.search
+    .slice(window.location.search.indexOf('?') + 1)
+    .split('&')
+  const getSearchParamValue = hashes
+    .filter(item => {
+      const hash = item.split('=')
+      return hash[0] === componentSearchHashId
+    })
+    .map(item => item.split('=')[1])[0]
+  return getSearchParamValue
+    ? decodeURIComponent(getSearchParamValue)
+    : undefined
+}
+
+//updates the url with the components new search params
+export function updateUrlWithNewSearchParam(
+  componentName: string,
+  componentIndex: number|undefined,
+  stringifiedQuery: string,
+) {
+  const componentSearchHashId = componentIndex !== undefined? getComponentSearchHashId(
+    componentName,
+    componentIndex,
+  ) : componentName
+  const searchString = patchSearchString(
+    componentSearchHashId,
+    stringifiedQuery,
+  )
+  const location = window.location
+  const newURL = `${location.protocol}//${location.hostname}${
+    location.port ? ':' + location.port : ''
+  }${location.pathname}?${searchString}`
+
+  window.history.pushState('object or string', 'Title', newURL)
+}
+
+export function getQueryRequestFromLink(
+    componentName: string,
+    componentIndex: number,
+  ): QueryBundleRequest | undefined {
+    const searchParamValue = getSearchParamValueFromUrl(
+      componentName,
+      componentIndex,
+    )
+  
+    let initQueryRequest: QueryBundleRequest | undefined = undefined
+    if (searchParamValue) {
+      const query = JSON.parse(searchParamValue) as Query
+      if (query.sql) {
+        initQueryRequest = {
+          concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+          partMask:
+            SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
+            SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
+            SynapseConstants.BUNDLE_MASK_QUERY_RESULTS,
+          entityId: parseEntityIdFromSqlStatement(query.sql),
+          query: query,
+        }
+      }
+    }
+    return initQueryRequest
+  }


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/PORTALS-1095

I think a good way to test it would be to select a facet on the left and do some filtering. Wait of data to load. Copy the url, paste it into a different tab and see what happens
