### PR TITLE
Republish to try and fix broken yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
@@ -73,12 +73,14 @@
     "react-test-renderer": "^16.4.2",
     "react-tooltip": "^3.9.2",
     "react-transition-group": "2.6.0",
+    "regenerator-runtime": "^0.13.2",
     "rollup-plugin-babel-minify": "^9.1.1",
     "rss-parser": "^3.7.2",
     "sanitize-html": "^1.18.4",
     "spark-md5": "^3.0.0",
     "sql-parser": "^0.5.0",
-    "universal-cookie": "^4.0.3"
+    "universal-cookie": "^4.0.3",
+    "use-deep-compare-effect": "^1.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.3",
@@ -107,7 +109,6 @@
     "eslint-plugin-react-hooks": "^2.5.0",
     "npm": "^6.9.0",
     "npm-run-all": "^4.1.3",
-    "regenerator-runtime": "^0.13.2",
     "rollup": "^1.16.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^9.2.0",
@@ -119,7 +120,6 @@
     "rollup-plugin-svg": "2.0.0",
     "sinon": "^7.2.2",
     "typescript": "3.7.4",
-    "use-deep-compare-effect": "^1.3.1",
     "yarn": "1.17.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Yarn isn't recognizing the last published version 1.14.1, republishing to see if that helps.