### PR TITLE
PORTALS-1022 - cont.

### DIFF
--- a/src/__tests__/lib/containers/TotalQueryResults.test.tsx
+++ b/src/__tests__/lib/containers/TotalQueryResults.test.tsx
@@ -43,7 +43,7 @@ describe('it works', () => {
   const unitDescription = 'units'
   const props: TotalQueryResultsProps = {
     unitDescription,
-    isLoading: false,
+    isLoading: true,
     token: '',
     getLastQueryRequest,
     frontText: 'Displaying',

--- a/src/__tests__/lib/containers/TotalQueryResults.test.tsx
+++ b/src/__tests__/lib/containers/TotalQueryResults.test.tsx
@@ -33,7 +33,7 @@ describe('it works', () => {
       queryResults: {} as RowSet,
     },
   }
-  const getLastQueryRequest = jest.fn().mockReturnValue(mockQueryRequest)
+  const lastQueryRequest = mockQueryRequest
   const SynapseClient = require('../../../lib/utils/SynapseClient')
   const mockGetQueryTableResultsFn = jest
     .fn()
@@ -43,9 +43,9 @@ describe('it works', () => {
   const unitDescription = 'units'
   const props: TotalQueryResultsProps = {
     unitDescription,
-    isLoading: true,
+    isLoading: false,
     token: '',
-    getLastQueryRequest,
+    lastQueryRequest,
     frontText: 'Displaying',
   }
   it('renders without crashing', () => {

--- a/src/__tests__/lib/containers/TotalQueryResults.test.tsx
+++ b/src/__tests__/lib/containers/TotalQueryResults.test.tsx
@@ -19,7 +19,8 @@ describe('it works', () => {
   const mockQueryRequest: QueryBundleRequest = {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
     entityId: '',
-    partMask: SynapseConstants.BUNDLE_MASK_QUERY_RESULTS,
+    partMask: SynapseConstants.BUNDLE_MASK_QUERY_RESULTS |
+    SynapseConstants.BUNDLE_MASK_QUERY_FACETS,
     query: {
       sql: '',
     },
@@ -60,7 +61,8 @@ describe('it works', () => {
     )
     expect(mockGetQueryTableResultsFn).toHaveBeenCalledWith(
       expect.objectContaining({
-        partMask: SynapseConstants.BUNDLE_MASK_QUERY_COUNT,
+        partMask: SynapseConstants.BUNDLE_MASK_QUERY_COUNT |
+        SynapseConstants.BUNDLE_MASK_QUERY_FACETS,
       }),
       '',
     )

--- a/src/__tests__/lib/containers/widgets/facet-nav/FacetNavPanel.test.tsx
+++ b/src/__tests__/lib/containers/widgets/facet-nav/FacetNavPanel.test.tsx
@@ -58,9 +58,10 @@ describe('initialization', () => {
     expect(panel).toHaveLength(1)
 
     const buttons =  container.querySelectorAll<HTMLElement>('button > svg')
-    expect(buttons.length).toBe(2)
-    expect((buttons[0].getAttribute('data-icon'))).toBe('expand-alt')
-    expect((buttons[1].getAttribute('data-icon'))).toBe('times')
+    expect(buttons.length).toBe(3)
+    expect((buttons[0].getAttribute('data-icon'))).toBe('filter')
+    expect((buttons[1].getAttribute('data-icon'))).toBe('expand-alt')
+    expect((buttons[2].getAttribute('data-icon'))).toBe('times')
 
     const panelBody = container.querySelectorAll('div.FacetNavPanel__body')
     expect(panelBody.length).toBe(1)
@@ -83,10 +84,10 @@ describe('initialization', () => {
     expect(panel).toHaveLength(1)
 
     const buttons =  container.querySelectorAll<HTMLElement>('button > svg')
-    expect(buttons.length).toBe(2)
-
-    expect((buttons[0].getAttribute('data-icon'))).toBe('compress-alt')
-    expect((buttons[1].getAttribute('data-icon'))).toBe('times')
+    expect(buttons.length).toBe(3)
+    expect((buttons[0].getAttribute('data-icon'))).toBe('filter')
+    expect((buttons[1].getAttribute('data-icon'))).toBe('compress-alt')
+    expect((buttons[2].getAttribute('data-icon'))).toBe('times')
 
     const panelBody = container.querySelectorAll('div.FacetNavPanel__body')
     expect(panelBody.length).toBe(0)

--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -170,7 +170,7 @@ export class CardContainer extends React.Component<
             token={token}
             isLoading={isLoading!}
             unitDescription={unitDescription}
-            getLastQueryRequest={getLastQueryRequest}
+            lastQueryRequest={getLastQueryRequest!()}
             frontText={'Displaying'}
           />
         )}

--- a/src/lib/containers/Facets.tsx
+++ b/src/lib/containers/Facets.tsx
@@ -299,7 +299,7 @@ class Facets extends React.Component<QueryWrapperChildProps, FacetsState> {
       <div className="SRC-syn-border-spacing">
         {!showBarChart && (
           <TotalQueryResults
-            getLastQueryRequest={this.props.getLastQueryRequest}
+            lastQueryRequest = {this.props.getLastQueryRequest!()}
             token={this.props.token}
             unitDescription={unitDescription!}
             frontText={'Displaying'}

--- a/src/lib/containers/Search.tsx
+++ b/src/lib/containers/Search.tsx
@@ -331,7 +331,7 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
           isLoading={isLoading!}
           frontText={'Displaying'}
           token={this.props.token}
-          getLastQueryRequest={getLastQueryRequest}
+          lastQueryRequest={getLastQueryRequest!()}
           unitDescription={usedUnitDescription}
         />
       </div>

--- a/src/lib/containers/TotalQueryResults.tsx
+++ b/src/lib/containers/TotalQueryResults.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react'
 import { QueryBundleRequest } from '../utils/synapseTypes'
 import { SynapseClient, SynapseConstants } from '../'
+import useDeepCompareEffect from 'use-deep-compare-effect'
 
 export type TotalQueryResultsProps = {
   isLoading: boolean
   style?: React.CSSProperties
-  getLastQueryRequest: (() => QueryBundleRequest) | undefined
+  //getLastQueryRequest: (() => QueryBundleRequest) | undefined
+  lastQueryRequest: QueryBundleRequest 
   token: string | undefined
   unitDescription: string
   frontText: string
@@ -18,23 +20,24 @@ const TotalQueryResults: React.FunctionComponent<TotalQueryResultsProps> = ({
   style,
   unitDescription,
   frontText,
-  getLastQueryRequest,
+  //getLastQueryRequest,
+  lastQueryRequest,
   token,
   isLoading: parentLoading,
 }) => {
   const [total, setTotal] = React.useState(0)
   const [isLoading, setIsLoading] = React.useState(false)
 
-  React.useEffect(() => {
+  useDeepCompareEffect(() => {
     const calculateTotal = async () => {
-      const queryRequest = getLastQueryRequest!()
-      queryRequest.partMask =
+     // const lastQueryRequest = getLastQueryRequest!()
+      lastQueryRequest.partMask =
         SynapseConstants.BUNDLE_MASK_QUERY_COUNT |
         SynapseConstants.BUNDLE_MASK_QUERY_FACETS
 
-      if (parentLoading) {
+      if (!parentLoading) {
         setIsLoading(true)
-        SynapseClient.getQueryTableResults(queryRequest, token)
+        SynapseClient.getQueryTableResults(lastQueryRequest, token)
           .then(data => {
             setTotal(data.queryCount!)
           })
@@ -47,7 +50,7 @@ const TotalQueryResults: React.FunctionComponent<TotalQueryResultsProps> = ({
       }
     }
     calculateTotal()
-  }, [parentLoading, token, getLastQueryRequest])
+  }, [parentLoading, token, lastQueryRequest])
 
   return (
     <div

--- a/src/lib/containers/TotalQueryResults.tsx
+++ b/src/lib/containers/TotalQueryResults.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-import {
-  QueryBundleRequest,
-} from '../utils/synapseTypes'
+import { QueryBundleRequest } from '../utils/synapseTypes'
 import { SynapseClient, SynapseConstants } from '../'
 
 export type TotalQueryResultsProps = {
@@ -33,17 +31,20 @@ const TotalQueryResults: React.FunctionComponent<TotalQueryResultsProps> = ({
       queryRequest.partMask =
         SynapseConstants.BUNDLE_MASK_QUERY_COUNT |
         SynapseConstants.BUNDLE_MASK_QUERY_FACETS
-      setIsLoading(true)
-      SynapseClient.getQueryTableResults(queryRequest, token)
-        .then(data => {
-          setTotal(data.queryCount!)
-        })
-        .catch(err => {
-          console.error('err ', err)
-        })
-        .finally(() => {
-          setIsLoading(false)
-        })
+
+      if (parentLoading) {
+        setIsLoading(true)
+        SynapseClient.getQueryTableResults(queryRequest, token)
+          .then(data => {
+            setTotal(data.queryCount!)
+          })
+          .catch(err => {
+            console.error('err ', err)
+          })
+          .finally(() => {
+            setIsLoading(false)
+          })
+      }
     }
     calculateTotal()
   }, [parentLoading, token, getLastQueryRequest])

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -330,7 +330,7 @@ export default class SynapseTable extends React.Component<
                 isLoading={isLoading}
                 style={{ fontSize: 15 }}
                 unitDescription={unitDescription}
-                getLastQueryRequest={this.props.getLastQueryRequest}
+                lastQueryRequest={this.props.getLastQueryRequest!()}
                 token={token}
                 frontText={'Showing'}
               />

--- a/src/lib/containers/table/table-top/FacetFilter.tsx
+++ b/src/lib/containers/table/table-top/FacetFilter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Dropdown } from 'react-bootstrap'
+import { Dropdown} from 'react-bootstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   FacetColumnResultValues,
@@ -15,6 +15,9 @@ type FacetFilterProps = {
   applyChanges: Function
   lastFacetSelection: FacetSelection
   isLoading: boolean
+  className?: string
+  variant?: 'light'|'dark'|'primary'
+  colorOnExpanded?: string
 }
 
 type FacetFilterState = {
@@ -68,17 +71,20 @@ export default class FacetFilter extends React.Component<
       applyChanges,
       isLoading,
       lastFacetSelection,
+      className = 'SRC-primary-text-color SRC-primary-background-color-hover condenced',
+      colorOnExpanded= 'white',
+      variant = 'light'
     } = this.props
     const { columnName } = facetColumnResult
     const { show } = this.state
-    const color = show ? 'white' : ''
+    const color = show ? colorOnExpanded : ''
     const allRef: React.Ref<HTMLInputElement> = React.createRef()
     return (
       <Dropdown show={show} onToggle={this.onToggle}>
         <Dropdown.Toggle
-          className="SRC-primary-text-color SRC-primary-background-color-hover condenced"
+          className={className}
           id={facetColumnResult.columnName}
-          variant={'light'}
+          variant={variant}
         >
           <FontAwesomeIcon
             style={{ margin: 'auto' }}
@@ -148,11 +154,11 @@ export default class FacetFilter extends React.Component<
                       <label className="dropdownList SRC-overflowWrap SRC-base-font SRC-fullWidth">
                         <input
                           ref={inputRef}
-                          onChange={applyChanges({
+                          onChange={(event) => applyChanges({
                             ref: this.ref,
                             columnName,
                             facetValue,
-                          })}
+                          })(event)}
                           checked={isValueSelected}
                           className="SRC-facet-checkboxes"
                           type="checkbox"

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -219,7 +219,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
             </div>
           ))}
         </div>
-        <div className="FacetNav__row">
+        <div className="FacetNav__row clearfix">
           {getFacets(data).map((item, index) => (
             <div
               className="col-sm-12 col-md-6"

--- a/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
@@ -291,7 +291,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
                 facetValue: '',
                 selector: '',
               }}
-              isLoading={false}
+              isLoading={!!isLoading}
               className=""
               colorOnExpanded="#000"
               applyChanges={(_: any) => (evt: React.ChangeEvent<HTMLInputElement>) =>

--- a/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
@@ -8,12 +8,12 @@ import * as PlotlyTyped from 'plotly.js'
 import createPlotlyComponent from 'react-plotly.js/factory'
 import { SizeMe } from 'react-sizeme'
 import {
-  faFilter,
   faExpandAlt,
   faCompressAlt,
   faTimes,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import FacetFilter from '../../table/table-top/FacetFilter'
 
 import { QueryWrapperChildProps } from 'lib/containers/QueryWrapper'
 import {
@@ -156,7 +156,7 @@ function extractPlotDataArray(
     const displayValue =
       facetValue.value === 'org.sagebionetworks.UNDEFINED_NULL_NOTSET'
         ? 'Unannotated'
-        : facetValue.value 
+        : facetValue.value
     singlePieChartData.labels?.push(displayValue)
     // @ts-ignore
     singlePieChartData.facetEnumerationValues.push(facetValue.value)
@@ -177,8 +177,11 @@ function extractPlotDataArray(
   return result
 }
 
-
-const applyFacetFilter = (event: PlotlyTyped.PlotMouseEvent, allFacetValues: FacetColumnResultValues, callbackApplyFn: Function) => {
+const applyFacetFilter = (
+  event: PlotlyTyped.PlotMouseEvent,
+  allFacetValues: FacetColumnResultValues,
+  callbackApplyFn: Function,
+) => {
   if (event.points && event.points[0]) {
     const plotPointData: any = event.points[0]
     const facetValueClickedValue =
@@ -186,12 +189,56 @@ const applyFacetFilter = (event: PlotlyTyped.PlotMouseEvent, allFacetValues: Fac
     const facetValueClicked = allFacetValues.facetValues.find(
       facet => facet.value === facetValueClickedValue,
     )
-    callbackApplyFn(allFacetValues, facetValueClicked)
+    callbackApplyFn(
+      allFacetValues,
+      facetValueClicked,
+      !facetValueClicked!.isSelected,
+    )
+  }
+}
+
+const applyDropdownFilter = (
+  evt: React.ChangeEvent<HTMLInputElement>,
+  allFacetValues: FacetColumnResultValues,
+  callbackApplyFn: Function,
+) => {
+  if (evt.target.value) {
+    const facetValueClicked = allFacetValues.facetValues.find(
+      facet => facet.value === evt.target.value,
+    )
+    callbackApplyFn(allFacetValues, facetValueClicked, evt.target.checked)
   }
 }
 
 const getGraphSize = (width: number | null): string => {
   return width ? `${width * 0.6}px` : `200px`
+}
+const renderLegend = (
+  labels: string[] = [],
+  colors: string[] = [],
+  isExpanded: boolean,
+): JSX.Element => {
+  const numLegendItems = isExpanded
+    ? Math.min(labels.length, 9)
+    : Math.min(labels.length, 3)
+  if (numLegendItems === 0) {
+    return <></>
+  }
+  return (
+    <div
+      className={`FacetNavPanel__body__legend${isExpanded ? '--expanded' : ''}`}
+    >
+      {labels.slice(0, numLegendItems).map((label, index) => (
+        <div
+          className="FacetNavPanel__body__legend__row"
+          key={`legendLabel_${index}`}
+        >
+          <div style={{ backgroundColor: colors[index] }}></div>
+          <label>{label}</label>
+        </div>
+      ))}
+    </div>
+  )
 }
 
 const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
@@ -205,8 +252,10 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
   asyncJobStatus,
   facetToPlot,
   data,
+  isLoading
 }: FacetNavPanelProps): JSX.Element => {
   const [plotData, setPlotData] = useState<GraphData>()
+  const [isExpanded, setIsExpanded] = useState(false)
 
   useEffect(() => {
     if (!facetToPlot) {
@@ -217,12 +266,16 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
     }
   }, [facetToPlot, data])
 
+  useEffect(() => {
+    setIsExpanded(onCollapse !== undefined)
+  }, [onCollapse])
+
+ 
 
   if (isLoadingNewData || !facetToPlot) {
     return (
       <div className="SRC-loadingContainer SRC-centerContentColumn">
-        {!!loadingScreen && loadingScreen}
-        <div>{asyncJobStatus && asyncJobStatus.progressMessage}</div>
+        {loadingScreen}
       </div>
     )
   } else {
@@ -230,31 +283,53 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
       <div className="FacetNavPanel">
         <div className="FacetNavPanel__title">
           <span>{unCamelCase(facetToPlot.columnName)}</span>
+          {isLoading && <span style={{ marginLeft: '2px' }} className={'spinner'} />}
           <div className="FacetNavPanel__title__tools">
-          <FontAwesomeIcon icon={faFilter} title="filter" />
-           
-            {onExpand && (
-              <button onClick={() => onExpand(index)}>
+            <FacetFilter
+              lastFacetSelection={{
+                columnName: '',
+                facetValue: '',
+                selector: '',
+              }}
+              isLoading={false}
+              className=""
+              colorOnExpanded="#000"
+              applyChanges={(_: any) => (evt: React.ChangeEvent<HTMLInputElement>) =>
+                applyDropdownFilter(
+                  evt,
+                  facetToPlot,
+                  applyChanges,
+                )}
+              isAllFilterSelectedForFacet={
+                facetToPlot.facetValues.filter(item => item.isSelected)
+                  .length === 0
+              }
+              facetColumnResult={facetToPlot}
+            />
+
+            {!isExpanded && (
+              <button onClick={() => onExpand!(index)}>
                 <FontAwesomeIcon icon={faExpandAlt} title="expand" />
               </button>
             )}
-            {onCollapse && (
-              <button onClick={() => onCollapse(index)}>
+            {isExpanded && (
+              <button onClick={() => onCollapse!(index)}>
                 <FontAwesomeIcon icon={faCompressAlt} title="contract" />
               </button>
             )}
             <button onClick={() => onHide(index)}>
               <FontAwesomeIcon icon={faTimes} title="collapse" />
             </button>
-            
           </div>
         </div>
-        <div className={`FacetNavPanel__body${onCollapse ? '--expanded' : ''}`}>
+     
+        
+        <div className={`FacetNavPanel__body${isExpanded ? '--expanded' : ''}`}>
           <SizeMe monitorHeight>
             {({ size }) => (
               <div
                 className={`FacetNavPanel__body__plot${
-                  onCollapse ? '--expanded' : ''
+                  isExpanded ? '--expanded' : ''
                 }`}
               >
                 <Plot
@@ -266,23 +341,14 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
                   }}
                   config={{ displayModeBar: false, responsive: true }}
                   useResizeHandler={true}
-                  onClick={evt => applyFacetFilter(evt, facetToPlot, applyChanges)}
+                  onClick={evt =>
+                    applyFacetFilter(evt, facetToPlot, applyChanges)
+                  }
                 ></Plot>
               </div>
             )}
           </SizeMe>
-          <div
-            className={`FacetNavPanel__body__legend${
-              onCollapse ? '--expanded' : ''
-            }`}
-          >
-            {plotData?.labels.slice(0, 3).map((label, index) => (
-              <div className="FacetNavPanel__body__legend__row" key={`legendLabel_${index}`}>
-                <div style={{ backgroundColor: plotData?.colors[index] }}></div>
-                <label>{label}</label>
-              </div>
-            ))}{' '}
-          </div>
+          {renderLegend(plotData?.labels, plotData?.colors, isExpanded)}
         </div>
       </div>
     )

--- a/src/lib/style/components/facet_nav/_facet-nav-panel.scss
+++ b/src/lib/style/components/facet_nav/_facet-nav-panel.scss
@@ -8,6 +8,13 @@
       margin-left: auto;
       order: 2;
       text-align: right;
+      display: flex;
+
+      .show button.dropdown-toggle, button.dropdown-toggle:hover {
+        background: transparent;
+  
+        color:inherit;
+    }
     }
   }
   &__body {

--- a/src/lib/style/components/facet_nav/_facet-nav.scss
+++ b/src/lib/style/components/facet_nav/_facet-nav.scss
@@ -3,9 +3,13 @@
 
     &__row {
         background-color: #fff;
-        overflow: hidden;
+
         div[class*=" col-"] {
             min-height: 200px
         }
     }
+
+   &__showMore {
+       float:right
+   }
 }


### PR DESCRIPTION
- refactor  TotalQueryResults to use hooks
- add filters to the Facet visualizations
lates demo is on [gh-pages](https://conundrumgirl.github.io/Synapse-React-Client/Playground/QueryWrapperPlotNavDemo)
