### PR TITLE
fix(QueryFilter): Make query filter do it's own update

### DIFF
--- a/src/__tests__/lib/containers/widgets/query-filter/QueryFilter.test.tsx
+++ b/src/__tests__/lib/containers/widgets/query-filter/QueryFilter.test.tsx
@@ -37,15 +37,15 @@ const lastQueryRequestResult = {
   },
 }
 
-const mockApplyChanges = jest.fn(() => null)
+const mockExecuteQueryRequest = jest.fn(_selectedFacets => null)
 const mockGetQueryRequest = jest.fn(() => _.cloneDeep(lastQueryRequestResult))
 
 function createTestProps(overrides?: QueryFilterProps): QueryFilterProps {
   return {
-    applyChanges: mockApplyChanges,
     isLoading: false,
     data: mockQueryResponseData as QueryResultBundle,
     getLastQueryRequest: mockGetQueryRequest,
+    executeQueryRequest: mockExecuteQueryRequest,
     token: '123',
 
     ...overrides,
@@ -60,6 +60,7 @@ let wrapper: ShallowWrapper<
 let props: QueryFilterProps
 
 function init(overrides?: QueryFilterProps) {
+  jest.clearAllMocks()
   props = createTestProps(overrides)
   wrapper = shallow(<QueryFilter {...props} />)
 }
@@ -99,8 +100,9 @@ describe('handling child component callbacks', () => {
 
     const enumWrapper = wrapper.find('EnumFacetFilter').at(0)
     enumWrapper.simulate('change', 'Ford', true)
-
-    expect(mockApplyChanges).toHaveBeenCalledWith(expectedResult)
+    const expected = _.cloneDeep(lastQueryRequestResult)
+    expected.query = { ...expected.query, selectedFacets: expectedResult }
+    expect(mockExecuteQueryRequest).toHaveBeenCalledWith(expected)
   })
 
   it('should propagate enum clear correctly', async () => {
@@ -115,7 +117,9 @@ describe('handling child component callbacks', () => {
     ]
     const enumWrapper = wrapper.find('EnumFacetFilter').at(0)
     enumWrapper.simulate('clear')
-    expect(mockApplyChanges).toHaveBeenCalledWith(expectedResult)
+    const expected = _.cloneDeep(lastQueryRequestResult)
+    expected.query = { ...expected.query, selectedFacets: expectedResult }
+    expect(mockExecuteQueryRequest).toHaveBeenCalledWith(expected)
   })
 
   it('should propagate range correctly', async () => {
@@ -133,9 +137,10 @@ describe('handling child component callbacks', () => {
         max: '1998',
         min: '1997',
       },
-    ]
+    ] 
     const enumWrapper = wrapper.find('RangeFacetFilter').at(0)
     enumWrapper.simulate('change', ['1997', '1998'])
-    expect(mockApplyChanges).toHaveBeenCalledWith(expectedResult)
-  })
+    const expected = _.cloneDeep(lastQueryRequestResult)
+    expected.query = { ...expected.query, selectedFacets: expectedResult }
+    expect(mockExecuteQueryRequest).toHaveBeenCalledWith(expected)})
 })

--- a/src/lib/containers/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/QueryWrapperPlotNav.tsx
@@ -49,7 +49,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
   }
   return (
     <QueryWrapper {...rest} initQueryRequest={initQueryRequest}>
-      {<FacetNav applyChanges={() => ''} facetsToPlot={['assay', 'createdBy', 'consortium', 'dataType', 'tumorType']} loadingScreen={loadingScreen}  />}
+      {<FacetNav facetsToPlot={['assay', 'createdBy', 'consortium', 'dataType', 'tumorType']} loadingScreen={loadingScreen}  />}
 
       {
         /*<FacetsPlotNav

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -352,9 +352,6 @@ export default class SynapseTable extends React.Component<
                     {...this.props}
                     data={this.props.data!}
                     token={this.props.token!}
-                    applyChanges={(newFacets: FacetColumnRequest[]) =>
-                      this.applyChangesFromQueryFilter(newFacets)
-                    }
                   />
                 }
               </div>

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -13,7 +13,6 @@ import { useState, useEffect } from 'react'
 import * as _ from 'lodash'
 
 export type FacetNavOwnProps = {
-  applyChanges: Function
   loadingScreen?: React.FunctionComponent | JSX.Element
   facetsToPlot?: string[] | undefined
 }

--- a/src/lib/containers/widgets/query-filter/QueryFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/QueryFilter.tsx
@@ -18,10 +18,11 @@ import {
 } from '../../../utils/synapseTypes'
 
 export type QueryFilterProps = {
-  applyChanges: Function
+  //applyChanges: Function
   isLoading?: boolean
   data: QueryResultBundle
   getLastQueryRequest?: Function
+  executeQueryRequest?: Function
   token: string
 }
 
@@ -119,12 +120,21 @@ export const QueryFilter: React.FunctionComponent<QueryFilterProps> = ({
   data,
   isLoading = false,
   getLastQueryRequest,
+  executeQueryRequest,
   token,
-  applyChanges,
 }: QueryFilterProps): JSX.Element => {
+  if (!data) {
+    return <></>
+  }
   const columnModels = data.columnModels
   const facets = data.facets as FacetColumnResult[]
   const lastRequest = getLastQueryRequest ? getLastQueryRequest() : undefined
+
+  const applyChanges = (facets: FacetColumnRequest[]) => {
+    const queryRequest: QueryBundleRequest = getLastQueryRequest!()
+    queryRequest.query.selectedFacets = facets
+    executeQueryRequest!(queryRequest)
+  }
 
   return (
     <div className="QueryFilter">


### PR DESCRIPTION
This should allow QueryFilter to work outside of the  SynapseTable functionally (still needs layout work for parent container)