### PR TITLE
PORTALS-1256: added early exit if search params are QueryWrapper definitions

### DIFF
--- a/src/__tests__/lib/utils/functions/sqlFunctions.test.ts
+++ b/src/__tests__/lib/utils/functions/sqlFunctions.test.ts
@@ -1,5 +1,5 @@
 import {
-   parseEntityIdFromSqlStatement
+   parseEntityIdFromSqlStatement, insertConditionsFromSearchParams, SQLOperator
   } from '../../../../lib/utils/functions/sqlFunctions'
   
 
@@ -12,4 +12,18 @@ import {
       })
   })
 
+  describe('insertConditionsFromSearchParams', () => {
+    it('should parse correctly', () => {
+      let sql = "SELECT id AS \"File ID\", assay, dataType, diagnosis, tumorType,  species, individualID, fileFormat, dataSubtype, nf1Genotype as \"NF1 Genotype\", nf2Genotype as \"NF2 Genotype\", studyName, fundingAgency, consortium, name AS \"File Name\", accessType, accessTeam FROM syn16858331 WHERE resourceType = 'experimentalData'"
+      let searchParams =
+      {
+        QueryWrapper0: "{\"sql\":\"SELECT id AS \"File ID\", assay, dataType, diagnosis, tumorType,  species, individualID,  fileFormat, dataSubtype, nf1Genotype as \\\"NF1 Genotype\\\", nf2Genotype as \\\"NF2 Genotype\\\", studyName, fundingAgency, consortium, name AS \\\"File Name\\\", accessType, accessTeam  FROM syn16858331 WHERE resourceType = 'experimentalData'\",\"limit\":25,\"offset\":0,\"selectedFacets\":[{\"concreteType\":\"org.sagebionetworks.repo.model.table.FacetColumnValuesRequest\",\"columnName\":\"assay\",\"facetValues\":[\"exomeSeq\"]}]}"
+      }
+      let operator:SQLOperator = "LIKE"
+      // if no search params are there, then it should return the input sql
+      expect(insertConditionsFromSearchParams({}, sql, operator)).toBe(sql)
+      // if the only search params set are from the QueryWrapper, then it should return the input sql
+      expect(insertConditionsFromSearchParams(searchParams, sql, operator)).toBe(sql)
+    })
+  })
  


### PR DESCRIPTION
or there are no search params.  Also, parser returns DBLSTRINGs from tokenizer, and then fails when attempting to reconstruct the same sql using it's own parser!  Replace all DBLSTRINGs with LITERAL, but I don't think we'll ever get into this situation today because we don't mix the study page conditional with the encoded Query search param.