### PR TITLE
Portals 1273

### DIFF
--- a/src/__tests__/lib/containers/QueryWrapperMenu.test.tsx
+++ b/src/__tests__/lib/containers/QueryWrapperMenu.test.tsx
@@ -287,10 +287,7 @@ describe('it renders an accordion config', () => {
 
     it("doesn't update url search string on facet selection if deepLinking flag is not set", async () => {
       const { instance, wrapper } = await createMountedComponent(wrapperProps)
-      await wrapper
-        .find('.SRC-hand-cursor')
-        .at(0)
-        .simulate('click')
+      await wrapper.find('.SRC-hand-cursor').at(0).simulate('click')
       expect(instance.props.menuConfig![0].facet).toBe('d')
       expect(window.location.search).not.toBe('?menuIndex=0&facet=d')
     })
@@ -300,10 +297,7 @@ describe('it renders an accordion config', () => {
         ...wrapperProps,
         shouldDeepLink: true,
       })
-      await wrapper
-        .find('.SRC-hand-cursor')
-        .at(0)
-        .simulate('click')
+      await wrapper.find('.SRC-hand-cursor').at(0).simulate('click')
       expect(instance.props.menuConfig![0].facet).toBe('d')
       expect(window.location.search).toBe('?menuIndex=0&facet=d')
     })

--- a/src/__tests__/lib/containers/widgets/facet-nav/FacetNav.test.tsx
+++ b/src/__tests__/lib/containers/widgets/facet-nav/FacetNav.test.tsx
@@ -1,4 +1,6 @@
-import FacetNav from '../../../../../lib/containers/widgets/facet-nav/FacetNav'
+import FacetNav, {
+  FacetNavProps,
+} from '../../../../../lib/containers/widgets/facet-nav/FacetNav'
 import * as React from 'react'
 import * as _ from 'lodash'
 import { render, fireEvent } from '@testing-library/react'
@@ -18,17 +20,19 @@ const lastQueryRequest: QueryBundleRequest = {
   },
 }
 const mockGetLastQueryRequest = jest.fn(() => lastQueryRequest)
-const mockApplyCallback = jest.fn(() => null)
 
-type ComponentProps = React.ComponentProps<typeof FacetNav>
-
-function createTestProps(overrides?: ComponentProps): ComponentProps {
+function createTestProps(overrides?: FacetNavProps): FacetNavProps {
   return {
-    applyChanges: mockApplyCallback,
     getLastQueryRequest: mockGetLastQueryRequest,
     data: testData as QueryResultBundle,
     loadingScreen: <div className="loading"></div>,
     ...overrides,
+    topLevelControlsState: {
+      showFacetVisualization: true,
+      showFacetFilter: true,
+      showColumnFilter: true,
+      showSearchBar: true,
+    },
   }
 }
 
@@ -52,9 +56,9 @@ function getButtonOnFacet(
 }
 
 let container: HTMLElement
-let props: ComponentProps
+let props: FacetNavProps
 
-function init(overrides?: ComponentProps) {
+function init(overrides?: FacetNavProps) {
   props = createTestProps(overrides)
   const { container: _container, ...others } = render(<FacetNav {...props} />)
   container = _container

--- a/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
+++ b/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
@@ -22,7 +22,7 @@ class QueryWrapperPlotNavDemo extends React.Component<{}, DemoState> {
    */
   constructor(props: any) {
     super(props)
-    const sql: string = 'SELECT * FROM syn16858331 limit 10'
+    const sql: string = 'SELECT * FROM syn16858331'
     this.state = {
       isLoading: true,
       ownerId: '',

--- a/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
+++ b/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
@@ -22,7 +22,7 @@ class QueryWrapperPlotNavDemo extends React.Component<{}, DemoState> {
    */
   constructor(props: any) {
     super(props)
-    const sql: string = 'SELECT * FROM syn16858331'
+    const sql: string = 'SELECT * FROM syn16858331 limit 10'
     this.state = {
       isLoading: true,
       ownerId: '',

--- a/src/demo/containers/playground/WidgetDemo.tsx
+++ b/src/demo/containers/playground/WidgetDemo.tsx
@@ -2,7 +2,10 @@ import * as React from 'react'
 import { Checkbox } from '../../../lib/containers/widgets/Checkbox'
 import { RadioGroup } from '../../../lib/containers/widgets/RadioGroup'
 import ThemesPlot from '../../../lib/containers/widgets/themes-plot/ThemesPlot'
-import { PlotProps, ClickCallbackParams} from '../../../lib/containers/widgets/themes-plot/types'
+import {
+  PlotProps,
+  ClickCallbackParams,
+} from '../../../lib/containers/widgets/themes-plot/types'
 import { Range, RangeValues } from '../../../lib/containers/widgets/Range'
 import { RangeSlider } from '../../../lib/containers/widgets/RangeSlider'
 import { useState } from 'react'
@@ -49,11 +52,11 @@ export const WidgetDemo: React.FunctionComponent<WigetDemoPros> = (
     groupField: 'consortium',
     whereClause: 'totalCount is not NULL',
     colors: {
-      ['CSBC']: 'rgba(64,123,160, 1)',
-      ['PS-ON']: 'rgba(91,176,181,1)'
-    }
+      CSBC: 'rgba(64,123,160, 1)',
+      'PS-ON': 'rgba(91,176,181,1)',
+    },
   }
-  
+
   const sideBarPlotProps: PlotProps = {
     entityId: 'syn21649281',
     xField: 'totalCount',
@@ -61,20 +64,20 @@ export const WidgetDemo: React.FunctionComponent<WigetDemoPros> = (
     groupField: 'consortium',
     countLabel: 'projects',
     plotStyle: {
-      backgroundColor: '#f5f9fa'
+      backgroundColor: '#f5f9fa',
     },
     colors: {
-      ['CSBC']: '#4788A5',
-      ['PS-ON']: '#5bb0b5'
-    }
+      CSBC: '#4788A5',
+      'PS-ON': '#5bb0b5',
+    },
   }
 
-  const dotPlotProps:PlotProps = {
+  const dotPlotProps: PlotProps = {
     entityId: 'syn21639584',
     xField: 'totalCount',
     yField: 'theme',
     groupField: 'groupBy',
-    infoField:  'themeDescription',
+    infoField: 'themeDescription',
     whereClause: "groupBy IN ('publications', 'tools', 'datasets')",
     markerSymbols: {
       tools: 'y-down',
@@ -85,14 +88,11 @@ export const WidgetDemo: React.FunctionComponent<WigetDemoPros> = (
       markerLine: 'rgba(0, 0, 0,1)',
       markerFill: 'rgba(255, 255, 255,1)',
       markerSize: 11,
-      backgroundColor: '#f5f9fa'
-    }
+      backgroundColor: '#f5f9fa',
+    },
   }
 
-  const plotCallback = ({
-    facetValue,
-    type,
-  }: ClickCallbackParams) => {
+  const plotCallback = ({ facetValue, type }: ClickCallbackParams) => {
     alert(`facetValue: ${facetValue} type: ${type}`)
   }
 

--- a/src/lib/containers/EntityLink.tsx
+++ b/src/lib/containers/EntityLink.tsx
@@ -51,6 +51,9 @@ type EntityTypeIconProps = {
   type: string
 }
 const EntityTypeIcon: React.SFC<EntityTypeIconProps> = ({ type }) => {
+  if (!type) {
+    return <></>
+  }
   const splitType = type.split('.')
   const name = splitType[splitType.length - 1] as IconType
   const iconType = getIconTypeForEntity(name)

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -134,7 +134,7 @@ export default class QueryWrapper extends React.Component<
         showColumnFilter: true,
         showFacetFilter: true,
         showFacetVisualization: true,
-        showSearchBar: true,
+        showSearchBar: false,
       },
       searchQuery: {
         columnName: '',
@@ -363,37 +363,34 @@ export default class QueryWrapper extends React.Component<
    */
   public render() {
     const { isLoading } = this.state
-    const { facetAliases = {}, ...rest } = this.props
+    const { facetAliases = {}, children, ...rest } = this.props
     // inject props in children of this component
-    const childrenWithProps = React.Children.map(
-      this.props.children,
-      (child: any) => {
-        if (!child) {
-          return child
-        }
-        const queryWrapperChildProps: QueryWrapperChildProps = {
-          facetAliases,
-          isAllFilterSelectedForFacet: this.state.isAllFilterSelectedForFacet,
-          data: this.state.data,
-          hasMoreData: this.state.hasMoreData,
-          lastFacetSelection: this.state.lastFacetSelection,
-          chartSelectionIndex: this.state.chartSelectionIndex,
-          isLoading: this.state.isLoading,
-          isLoadingNewData: this.state.isLoadingNewData,
-          asyncJobStatus: this.state.asyncJobStatus,
-          topLevelControlsState: this.state.topLevelControlsState,
-          searchQuery: this.state.searchQuery,
-          executeInitialQueryRequest: this.executeInitialQueryRequest,
-          executeQueryRequest: this.executeQueryRequest,
-          getLastQueryRequest: this.getLastQueryRequest,
-          getNextPageOfData: this.getNextPageOfData,
-          updateParentState: this.updateParentState,
-          getInitQueryRequest: this.getInitQueryRequest,
-          ...rest,
-        }
-        return React.cloneElement(child, queryWrapperChildProps)
-      },
-    )
+    const childrenWithProps = React.Children.map(children, (child: any) => {
+      if (!child) {
+        return child
+      }
+      const queryWrapperChildProps: QueryWrapperChildProps = {
+        facetAliases,
+        isAllFilterSelectedForFacet: this.state.isAllFilterSelectedForFacet,
+        data: this.state.data,
+        hasMoreData: this.state.hasMoreData,
+        lastFacetSelection: this.state.lastFacetSelection,
+        chartSelectionIndex: this.state.chartSelectionIndex,
+        isLoading: this.state.isLoading,
+        isLoadingNewData: this.state.isLoadingNewData,
+        asyncJobStatus: this.state.asyncJobStatus,
+        topLevelControlsState: this.state.topLevelControlsState,
+        searchQuery: this.state.searchQuery,
+        executeInitialQueryRequest: this.executeInitialQueryRequest,
+        executeQueryRequest: this.executeQueryRequest,
+        getLastQueryRequest: this.getLastQueryRequest,
+        getNextPageOfData: this.getNextPageOfData,
+        updateParentState: this.updateParentState,
+        getInitQueryRequest: this.getInitQueryRequest,
+        ...rest,
+      }
+      return React.cloneElement(child, queryWrapperChildProps)
+    })
 
     const loadingCusrorClass = isLoading ? 'SRC-logo-cursor' : ''
     return (

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -24,7 +24,19 @@ export type QueryWrapperProps = {
   shouldDeepLink?: boolean
 }
 
-export type QueryWrapperState = {
+export type TopLevelControlsState = {
+  showFacetVisualization: boolean
+  showFacetFilter: boolean
+  showColumnFilter: boolean
+  showSearchBar: boolean
+}
+
+export type SearchQuery = {
+  columnName: string
+  searchText: string
+}
+
+type QueryWrapperState = {
   /*
     isAllFilterSelectedForFacet tracks whether for a particular
      facet if the 'All' button has been selected, this tracks the
@@ -41,6 +53,8 @@ export type QueryWrapperState = {
   asyncJobStatus?: AsynchronousJobStatus
   facetAliases?: {}
   loadNowStarted: boolean
+  topLevelControlsState?: TopLevelControlsState
+  searchQuery: SearchQuery
 }
 
 export type FacetSelection = {
@@ -63,7 +77,9 @@ export type QueryWrapperChildProps = {
   getInitQueryRequest?: () => QueryBundleRequest
   data?: QueryResultBundle
   facet?: string
-  updateParentState?: (param: any) => void
+  updateParentState?: <K extends keyof QueryWrapperState>(
+    param: Pick<QueryWrapperState, K>,
+  ) => void
   rgbIndex?: number
   unitDescription?: string
   facetAliases?: {}
@@ -72,6 +88,8 @@ export type QueryWrapperChildProps = {
   asyncJobStatus?: AsynchronousJobStatus
   showBarChart?: boolean
   hasMoreData?: boolean
+  topLevelControlsState?: TopLevelControlsState
+  searchQuery?: SearchQuery
 }
 
 /**
@@ -112,6 +130,16 @@ export default class QueryWrapper extends React.Component<
       isAllFilterSelectedForFacet: {},
       loadNowStarted: false,
       lastQueryRequest: cloneDeep(this.props.initQueryRequest!),
+      topLevelControlsState: {
+        showColumnFilter: true,
+        showFacetFilter: true,
+        showFacetVisualization: true,
+        showSearchBar: true,
+      },
+      searchQuery: {
+        columnName: '',
+        searchText: '',
+      },
     }
     this.componentIndex = props.componentIndex || 0
   }
@@ -241,7 +269,7 @@ export default class QueryWrapper extends React.Component<
       queryRequest,
       this.state.data!,
       this.props.token,
-    ).then((newState) => {
+    ).then(newState => {
       this.setState({
         ...newState,
         isLoading: false,
@@ -286,20 +314,20 @@ export default class QueryWrapper extends React.Component<
             )
           }
           const enumFacets = data.facets.filter(
-            (el) => el.facetType === 'enumeration',
+            el => el.facetType === 'enumeration',
           ) as FacetColumnResultValues[]
-          enumFacets.forEach((el) => {
+          enumFacets.forEach(el => {
             // isAll is only true iff there are no facets selected or all elements are selected
             const { facetValues } = el
-            const isAllFalse = facetValues.every((facet) => !facet.isSelected)
-            const isAllTrue = facetValues.every((facet) => facet.isSelected)
+            const isAllFalse = facetValues.every(facet => !facet.isSelected)
+            const isAllTrue = facetValues.every(facet => facet.isSelected)
             const isByDefaultSelected = isAllFalse || isAllTrue
             isAllFilterSelectedForFacet[el.columnName] = isByDefaultSelected
             if (el.columnName === this.props.facet && !isAllFalse) {
               // Note - this picks the first selected facet
               chartSelectionIndex = facetValues
                 .sort((a, b) => b.count - a.count)
-                .findIndex((facet) => facet.isSelected)
+                .findIndex(facet => facet.isSelected)
             }
           })
         }
@@ -313,7 +341,7 @@ export default class QueryWrapper extends React.Component<
         }
         this.setState(newState)
       })
-      .catch((err) => {
+      .catch(err => {
         console.log('Failed to get data ', err)
       })
       .finally(() => {
@@ -324,7 +352,9 @@ export default class QueryWrapper extends React.Component<
       })
   }
 
-  public updateParentState(update: QueryWrapperState) {
+  public updateParentState<K extends keyof QueryWrapperState>(
+    update: Pick<QueryWrapperState, K>,
+  ) {
     this.setState(update)
   }
 
@@ -333,32 +363,33 @@ export default class QueryWrapper extends React.Component<
    */
   public render() {
     const { isLoading } = this.state
-    const { facetAliases = {} } = this.props
+    const { facetAliases = {}, ...rest } = this.props
     // inject props in children of this component
     const childrenWithProps = React.Children.map(
       this.props.children,
       (child: any) => {
+        if (!child) {
+          return child
+        }
         const queryWrapperChildProps: QueryWrapperChildProps = {
           facetAliases,
           isAllFilterSelectedForFacet: this.state.isAllFilterSelectedForFacet,
           data: this.state.data,
-          token: this.props.token,
+          hasMoreData: this.state.hasMoreData,
+          lastFacetSelection: this.state.lastFacetSelection,
+          chartSelectionIndex: this.state.chartSelectionIndex,
+          isLoading: this.state.isLoading,
+          isLoadingNewData: this.state.isLoadingNewData,
+          asyncJobStatus: this.state.asyncJobStatus,
+          topLevelControlsState: this.state.topLevelControlsState,
+          searchQuery: this.state.searchQuery,
           executeInitialQueryRequest: this.executeInitialQueryRequest,
           executeQueryRequest: this.executeQueryRequest,
           getLastQueryRequest: this.getLastQueryRequest,
           getNextPageOfData: this.getNextPageOfData,
-          isLoading: this.state.isLoading,
-          isLoadingNewData: this.state.isLoadingNewData,
-          facet: this.props.facet,
-          rgbIndex: this.props.rgbIndex,
-          unitDescription: this.props.unitDescription,
           updateParentState: this.updateParentState,
-          hasMoreData: this.state.hasMoreData,
-          lastFacetSelection: this.state.lastFacetSelection,
-          chartSelectionIndex: this.state.chartSelectionIndex,
           getInitQueryRequest: this.getInitQueryRequest,
-          asyncJobStatus: this.state.asyncJobStatus,
-          showBarChart: this.props.showBarChart,
+          ...rest,
         }
         return React.cloneElement(child, queryWrapperChildProps)
       },

--- a/src/lib/containers/QueryWrapperMenu.tsx
+++ b/src/lib/containers/QueryWrapperMenu.tsx
@@ -310,7 +310,6 @@ export default class QueryWrapperMenu extends React.Component<
         facet: facetValueFromSearchParams = '',
       } = searchParams)
     }
-
     return menuConfig.map((config: MenuConfig, index: number) => {
       const isSelected: boolean =
         groupIndex === accordionGroupIndex &&

--- a/src/lib/containers/SearchV2.tsx
+++ b/src/lib/containers/SearchV2.tsx
@@ -28,12 +28,6 @@ export type SearchProps = {
 
 type InternalSearchProps = QueryWrapperChildProps & SearchProps
 
-/*
-  Do we want to encode the like clause in the URL?
-  How can we remove the clause?
-
-*/
-
 class Search extends React.Component<InternalSearchProps, SearchState> {
   public searchFormRef: React.RefObject<HTMLFormElement>
   public radioFormRef: React.RefObject<HTMLFormElement>
@@ -85,8 +79,7 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
     // escape ' by adding additional '
     escapedSearchText = escapedSearchText.split("'").join("''")
     // escape % by adding \
-    // eslint-disable-next-line no-useless-escape
-    escapedSearchText = escapedSearchText.split('%').join('%')
+    escapedSearchText = escapedSearchText.split('%').join(`\%`)
     // escape \ by adding \
     escapedSearchText = escapedSearchText.split('\\').join('\\\\')
     return escapedSearchText
@@ -122,6 +115,10 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
       searchText,
     }
     updateParentState!({ searchQuery })
+    this.setState({
+      columnName: '',
+      searchText: '',
+    })
   }
 
   public handleChange = (event: React.FormEvent<HTMLInputElement>) => {

--- a/src/lib/containers/SearchV2.tsx
+++ b/src/lib/containers/SearchV2.tsx
@@ -1,0 +1,230 @@
+import * as React from 'react'
+import { QueryWrapperChildProps } from './QueryWrapper'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import {
+  faCaretDown,
+  faCaretUp,
+  faSearch,
+  faTimes,
+} from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { insertConditionsFromSearchParams } from '../utils/functions/sqlFunctions'
+import { unCamelCase } from '../utils/functions/unCamelCase'
+
+library.add(faCaretDown)
+library.add(faCaretUp)
+library.add(faSearch)
+library.add(faTimes)
+
+type SearchState = {
+  dropdownIndex: number
+  show: boolean
+  searchText: string
+  submittedSearchText: string
+  lastSearchedFacet: string
+  columnName: string
+}
+
+export type SearchProps = {
+  isQueryWrapperMenuChild?: boolean
+}
+
+type InternalSearchProps = QueryWrapperChildProps & SearchProps
+
+/*
+  Do we want to encode the like clause in the URL?
+  How can we remove the clause?
+
+*/
+
+class Search extends React.Component<InternalSearchProps, SearchState> {
+  public searchFormRef: React.RefObject<HTMLFormElement>
+  public radioFormRef: React.RefObject<HTMLFormElement>
+
+  constructor(props: InternalSearchProps) {
+    super(props)
+    this.state = {
+      dropdownIndex: 0,
+      show: false,
+      searchText: '',
+      submittedSearchText: '',
+      lastSearchedFacet: '',
+      columnName: '',
+    }
+    this.searchFormRef = React.createRef()
+    this.radioFormRef = React.createRef()
+  }
+
+  componentDidMount() {
+    // @ts-ignore
+    document.addEventListener('click', this.handleClickOutsideForm)
+  }
+
+  componentWillUnmount() {
+    // @ts-ignore
+    document.removeEventListener('click', this.handleClickOutsideForm)
+  }
+
+  handleClickOutsideForm = (event: React.SyntheticEvent) => {
+    if (
+      // @ts-ignore
+      !this.searchFormRef.current?.contains(event?.target) &&
+      // @ts-ignore
+      !this.radioFormRef.current?.contains(event?.target)
+    ) {
+      this.setState({
+        show: false,
+      })
+    }
+  }
+
+  public toggleDropdown = (value: boolean) => (_: React.SyntheticEvent) => {
+    this.setState({
+      show: value,
+    })
+  }
+
+  public static addEscapeCharacters = (searchText: string) => {
+    // We have to escape the following characters
+    // ' % \
+    let escapedSearchText = searchText
+    // escape ' by adding additional '
+    escapedSearchText = escapedSearchText.split("'").join("''")
+    // escape % by adding \
+    // eslint-disable-next-line no-useless-escape
+    escapedSearchText = escapedSearchText.split('%').join('%')
+    // escape \ by adding \
+    escapedSearchText = escapedSearchText.split('\\').join('\\\\')
+    return escapedSearchText
+  }
+
+  public clearSearchText = () => {
+    this.setState({
+      searchText: '',
+    })
+  }
+
+  public search = (event: React.SyntheticEvent<HTMLFormElement>) => {
+    // form completion by default causes the page to reload, so we prevent that
+    event.preventDefault()
+    const { searchText, columnName } = this.state
+    const {
+      updateParentState,
+      getInitQueryRequest,
+      executeQueryRequest,
+      getLastQueryRequest,
+    } = this.props
+
+    const lastQueryRequest = getLastQueryRequest!()
+
+    // Always grabs initQueryRequest to get version of the sql
+    const initQueryRequestDeepCopy = getInitQueryRequest!()
+    const { sql } = initQueryRequestDeepCopy.query
+    const searchParams = {
+      [columnName]: Search.addEscapeCharacters(searchText),
+    }
+    const newSql = insertConditionsFromSearchParams(searchParams, sql)
+    lastQueryRequest.query.sql = newSql
+    this.setState({
+      submittedSearchText: searchText,
+      lastSearchedFacet: columnName,
+    })
+    executeQueryRequest!(lastQueryRequest)
+    updateParentState!({
+      searchQuery: {
+        columnName,
+        searchText,
+      },
+    })
+  }
+
+  public handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+    this.setState({
+      searchText: event.currentTarget.value,
+    })
+  }
+
+  render() {
+    const { data, topLevelControlsState } = this.props
+    const {
+      searchText,
+      show,
+      // submittedSearchText,
+      // lastSearchedFacet,
+    } = this.state
+    const outerClassName = `SearchV2 ${
+      topLevelControlsState?.showSearchBar ? '' : 'hidden'
+    }`
+    return (
+      <div className={outerClassName}>
+        <form
+          className="SearchV2__searchbar"
+          onSubmit={this.search}
+          onClick={() => {
+            this.setState({ show: true })
+            this.searchFormRef.current?.focus()
+          }}
+          ref={this.searchFormRef}
+        >
+          <FontAwesomeIcon
+            className="SearchV2__searchbar__searchicon"
+            size={'sm'}
+            icon={'search'}
+          />
+          <input
+            onChange={this.handleChange}
+            onClick={() => {
+              this.setState({
+                show: true,
+              })
+            }}
+            placeholder="Enter Search Terms"
+            value={searchText}
+            type="text"
+          />
+        </form>
+        <div
+          className={
+            show
+              ? 'SearchV2__form-container'
+              : 'SearchV2__form-container hidden'
+          }
+        >
+          <form ref={this.radioFormRef} className="SearchV2__column-select">
+            <p className="deemphasized">
+              <i> Search In Field: </i>
+            </p>
+            {data?.columnModels?.slice(0, 5).map(el => {
+              const name = el.name
+              const displayName = unCamelCase(el.name)
+              return (
+                <div className="radio">
+                  <label>
+                    <span>
+                      <input
+                        id={name}
+                        type="radio"
+                        value={name}
+                        checked={name === this.state.columnName}
+                        onClick={(
+                          event: React.MouseEvent<HTMLInputElement>,
+                        ) => {
+                          this.setState({
+                            columnName: event?.currentTarget.value,
+                          })
+                        }}
+                      />
+                      <span>{displayName}</span>
+                    </span>
+                  </label>
+                </div>
+              )
+            })}
+          </form>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default Search

--- a/src/lib/containers/SearchV2.tsx
+++ b/src/lib/containers/SearchV2.tsx
@@ -95,10 +95,10 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
   public search = (event: React.SyntheticEvent<HTMLFormElement>) => {
     // form completion by default causes the page to reload, so we prevent that
     event.preventDefault()
+    const { searchText, columnName } = this.state
     this.setState({
       show: false,
     })
-    const { searchText, columnName } = this.state
     const {
       updateParentState,
       getInitQueryRequest,

--- a/src/lib/containers/StackedBarChart.tsx
+++ b/src/lib/containers/StackedBarChart.tsx
@@ -6,7 +6,10 @@ import ReactMeasure from 'react-measure'
 import ReactTooltip from 'react-tooltip'
 import { getColorPallette } from './ColorGradient'
 import { QueryWrapperChildProps } from './QueryWrapper'
-import { FacetColumnResultValueCount } from '../utils/synapseTypes/'
+import {
+  FacetColumnResultValueCount,
+  QueryResultBundle,
+} from '../utils/synapseTypes/'
 import { getIsValueSelected } from '../utils/functions/facetUtils'
 import { unCamelCase } from '../utils/functions/unCamelCase'
 library.add(faAngleLeft)
@@ -341,11 +344,11 @@ export default class StackedBarChart extends React.Component<
       </React.Fragment>
     )
   }
-  public extractPropsData(data: any) {
+  public extractPropsData(data?: QueryResultBundle) {
     const xData: any[] = []
     const { facet } = this.props
     // pull out the data corresponding to the filter in question
-    data.facets.forEach((item: any) => {
+    data?.facets?.forEach((item: any) => {
       if (item.facetType === 'enumeration' && item.columnName === facet) {
         item.facetValues.forEach((facetValue: any) => {
           if (item.columnName) {

--- a/src/lib/containers/TotalQueryResults.tsx
+++ b/src/lib/containers/TotalQueryResults.tsx
@@ -25,6 +25,7 @@ import {
 } from '../containers/widgets/query-filter/QueryFilter'
 import { RadioValuesEnum } from '../containers/widgets/query-filter/RangeFacetFilter'
 import { useState, FunctionComponent } from 'react'
+import { SearchQuery } from './QueryWrapper'
 
 export type TotalQueryResultsProps = {
   isLoading: boolean
@@ -35,6 +36,7 @@ export type TotalQueryResultsProps = {
   unitDescription: string
   frontText: string
   applyChanges?: Function
+  searchQuery?: SearchQuery
 }
 
 // This is a stateful component so that during load the component can hold onto the previous
@@ -48,6 +50,7 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
   token,
   isLoading: parentLoading,
   executeQueryRequest,
+  searchQuery,
 }) => {
   const [total, setTotal] = useState<number | undefined>(undefined) // undefined to start
   const [isLoading, setIsLoading] = useState(false)
@@ -181,9 +184,10 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
     calculateTotal()
   }, [parentLoading, token, lastQueryRequest])
 
-  const removeSelection = ({ facet, selectedValue }: FacetWithSelection) => {
-    console.log(facet)
-    console.log(selectedValue)
+  const removeFacetSelection = ({
+    facet,
+    selectedValue,
+  }: FacetWithSelection) => {
     if (facet.facetType === 'enumeration') {
       applyChangesToValuesColumn(
         lastQueryRequest,
@@ -202,12 +206,23 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
     }
   }
 
+  const searchSelectionCriteriaPill = searchQuery?.columnName ? (
+    <SelectionCriteriaPill
+      index={facetsWithSelection.length + 1}
+      searchQuery={searchQuery}
+      onRemove={removeFacetSelection}
+    />
+  ) : (
+    <></>
+  )
+
   return (
     <div className="TotalQueryResults" style={style}>
       <span className="SRC-boldText SRC-text-title SRC-centerContent">
         {frontText} {total} {unitDescription}{' '}
       </span>
       <div className="TotalQueryResults__selections">
+        {searchSelectionCriteriaPill}
         {facetsWithSelection.map((selectedFacet, index) => (
           <SelectionCriteriaPill
             key={
@@ -215,7 +230,7 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
             }
             facetWithSelection={selectedFacet}
             index={index}
-            onRemove={removeSelection}
+            onRemove={removeFacetSelection}
           ></SelectionCriteriaPill>
         ))}
       </div>

--- a/src/lib/containers/query_wrapper_plot_nav/FilterAndView.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/FilterAndView.tsx
@@ -8,20 +8,29 @@ import { CardConfiguration } from '../CardContainerLogic'
 export type OwnProps = {
   tableConfiguration: SynapseTableProps | undefined
   cardConfiguration: CardConfiguration | undefined
-  showFilter: boolean
 }
 
 const FilterAndView = (props: QueryWrapperChildProps & OwnProps) => {
-  const { showFilter, tableConfiguration, cardConfiguration, ...rest } = props
+  const {
+    topLevelControlsState,
+    tableConfiguration,
+    cardConfiguration,
+    ...rest
+  } = props
+  const { showFacetFilter } = topLevelControlsState!
   return (
     <div className="row">
       <div
-        className={showFilter ? 'col-xs-12 col-sm-3 col-lg-3' : 'hidden'}
+        className={showFacetFilter ? 'col-xs-12 col-sm-3 col-lg-3' : 'hidden'}
         style={{ paddingRight: '0px' }}
       >
         <QueryFilter {...rest} />
       </div>
-      <div className={showFilter ? 'col-xs-12 col-sm-9 col-lg-9' : 'col-xs-12'}>
+      <div
+        className={
+          showFacetFilter ? 'col-xs-12 col-sm-9 col-lg-9' : 'col-xs-12'
+        }
+      >
         {tableConfiguration ? (
           <SynapseTable
             enableLeftFacetFilter={true}

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -7,27 +7,14 @@ import {
   SQLOperator,
 } from '../../utils/functions/sqlFunctions'
 import { SynapseConstants } from '../../utils/'
-import QueryCount from '../QueryCount'
 import { QueryBundleRequest } from '../../utils/synapseTypes'
 import { CardConfiguration } from '../CardContainerLogic'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { library } from '@fortawesome/fontawesome-svg-core'
-import {
-  faSearch,
-  faFilter,
-  faChartBar,
-  faDownload,
-} from '@fortawesome/free-solid-svg-icons'
 import FilterAndView from './FilterAndView'
-// import { DownloadConfirmation } from '../download_list'
-
-library.add(faSearch)
-library.add(faFilter)
-library.add(faChartBar)
-library.add(faDownload)
+import { TopLevelControlsProps } from './TopLevelControls'
+import TopLevelControls from './TopLevelControls'
+import SearchV2 from '../SearchV2'
 
 type OwnProps = {
-  name: string
   sql: string
   entityId: string
   shouldDeepLink?: boolean
@@ -36,7 +23,7 @@ type OwnProps = {
   token?: string
   rgbIndex?: number
   facetsToPlot?: string[]
-}
+} & TopLevelControlsProps
 
 type SearchParams = {
   searchParams?: {
@@ -52,11 +39,6 @@ export type QueryWrapperPlotNavProps = SearchParams &
   OwnProps
 
 const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = props => {
-  // const [showSearch, setShowSearch] = React.useState(true)
-  const [showVisualization, setShowVisualization] = React.useState(true)
-  const [showFilter, setShowFilter] = React.useState(true)
-  // const [showDownload, setShowDownload] = React.useState(false)
-
   const {
     searchParams,
     sql,
@@ -96,39 +78,16 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
   }
   return (
     <div className="QueryWrapperPlotNav">
-      <h3 className="QueryWrapperPlotNav__title">
-        <div className="QueryWrapperPlotNav__querycount">
-          <QueryCount entityId={entityId} token={token} name={name} sql={sql} />
-        </div>
-        <div className="QueryWrapperPlotNav__actions">
-          {/* <button  className="SRC-primary-action-color"onClick={() => setShowSearch(!showSearch)}>
-            <FontAwesomeIcon icon="search" size="1x" />
-          </button> */}
-          <button
-            className="SRC-primary-action-color"
-            onClick={() => setShowVisualization(!showVisualization)}
-          >
-            <FontAwesomeIcon icon="chart-bar" size="1x" />
-          </button>
-          <button
-            className="SRC-primary-action-color"
-            onClick={() => setShowFilter(!showFilter)}
-          >
-            <FontAwesomeIcon icon="filter" size="1x" />
-          </button>
-          {/* <button  className="SRC-primary-action-color"onClick={() => setShowDownload(!showDownload)}>
-            <FontAwesomeIcon icon="download" size="1x" />
-          </button> */}
-        </div>
-      </h3>
       <QueryWrapper {...rest} initQueryRequest={initQueryRequest}>
-        <FacetNav
-          show={showVisualization}
-          facetsToPlot={facetsToPlot}
-          loadingScreen={loadingScreen}
+        <TopLevelControls
+          name={name}
+          token={token}
+          entityId={entityId}
+          sql={sqlUsed}
         />
+        <SearchV2 />
+        <FacetNav facetsToPlot={facetsToPlot} loadingScreen={loadingScreen} />
         <FilterAndView
-          showFilter={showFilter}
           tableConfiguration={tableConfiguration}
           cardConfiguration={cardConfiguration}
         />

--- a/src/lib/containers/query_wrapper_plot_nav/TopLevelControls.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/TopLevelControls.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import QueryCount from '../QueryCount'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import {
+  faSearch,
+  faFilter,
+  faChartBar,
+} from '@fortawesome/free-solid-svg-icons'
+import { QueryWrapperChildProps, TopLevelControlsState } from '../QueryWrapper'
+
+library.add(faSearch)
+library.add(faFilter)
+library.add(faChartBar)
+
+export type TopLevelControlsProps = {
+  name: string
+  entityId: string
+  sql: string
+  token?: string
+}
+
+const TopLevelControls = (
+  props: QueryWrapperChildProps & TopLevelControlsProps,
+) => {
+  const {
+    entityId,
+    token,
+    name,
+    sql,
+    updateParentState,
+    topLevelControlsState,
+  } = props
+
+  const setControlState = (control: keyof TopLevelControlsState) => {
+    const updatedTopLevelControlsState: TopLevelControlsState = {
+      ...topLevelControlsState!,
+      [control]: !topLevelControlsState![control],
+    }
+    updateParentState!({
+      topLevelControlsState: updatedTopLevelControlsState,
+    })
+  }
+
+  return (
+    <h3 className="QueryWrapperPlotNav__title">
+      <div className="QueryWrapperPlotNav__querycount">
+        <QueryCount entityId={entityId} token={token} name={name} sql={sql} />
+      </div>
+      <div className="QueryWrapperPlotNav__actions">
+        {/* <button  className="SRC-primary-action-color"onClick={() => setShowSearch(!showSearch)}>
+            <FontAwesomeIcon icon="search" size="1x" />
+          </button> */}
+        <button
+          className="SRC-primary-action-color"
+          onClick={() => setControlState('showFacetVisualization')}
+        >
+          <FontAwesomeIcon icon="chart-bar" size="1x" />
+        </button>
+        <button
+          className="SRC-primary-action-color"
+          onClick={() => setControlState('showFacetFilter')}
+        >
+          <FontAwesomeIcon icon="filter" size="1x" />
+        </button>
+        <button
+          className="SRC-primary-action-color"
+          onClick={() => setControlState('showSearchBar')}
+        >
+          <FontAwesomeIcon icon="search" size="1x" />
+        </button>
+        {/* <button
+          className="SRC-primary-action-color"
+          onClick={() => setControlState('showColumnFilter')}
+        >
+          <FontAwesomeIcon icon="download" size="1x" />
+        </button> */}
+      </div>
+    </h3>
+  )
+}
+
+export default TopLevelControls

--- a/src/lib/containers/synapse_form_wrapper/StepsSideNav.tsx
+++ b/src/lib/containers/synapse_form_wrapper/StepsSideNav.tsx
@@ -37,9 +37,9 @@ export default function StepsSideNav(props: StepsSideNavProps) {
     if (isExcluded) {
       iconDef = faBan
       flip = 'horizontal'
-    } else if (state == StepStateEnum.COMPLETED) {
+    } else if (state === StepStateEnum.COMPLETED) {
       iconDef = faCheckCircle
-    } else if (state == StepStateEnum.ERROR) {
+    } else if (state === StepStateEnum.ERROR) {
       iconDef = faExclamationCircle
     }
     return { iconDef, flip }

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -1158,7 +1158,7 @@ export default class SynapseTable extends React.Component<
     isAllFilterSelectedForFacet![columnName] = selector === SELECT_ALL
     this.props.updateParentState!({
       lastFacetSelection,
-      isAllFilterSelectedForFacet,
+      isAllFilterSelectedForFacet: isAllFilterSelectedForFacet!,
     })
 
     this.props.executeQueryRequest!(newQueryRequest)

--- a/src/lib/containers/widgets/ElementWithTooltip.tsx
+++ b/src/lib/containers/widgets/ElementWithTooltip.tsx
@@ -98,8 +98,8 @@ export const ElementWithTooltip: FunctionComponent<ElementWithTooltipProps> = ({
     tooltipTrigger = React.cloneElement(outerChild, {
       className: `${outerChild.props.className} SRC-hand-cursor`,
       id: idForToolTip,
-      ['data-for']: idForToolTip,
-      ['data-tip']: tooltipText,
+      'data-for': idForToolTip,
+      'data-tip': tooltipText,
     })
   }
 

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -14,7 +14,6 @@ import TotalQueryResults from '../../../containers/TotalQueryResults'
 
 export type FacetNavOwnProps = {
   loadingScreen?: React.FunctionComponent | JSX.Element
-  show: boolean
   facetsToPlot?: string[]
 }
 
@@ -43,12 +42,14 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   executeQueryRequest,
   token,
   asyncJobStatus,
-  show,
+  topLevelControlsState,
   facetsToPlot,
+  searchQuery,
 }: FacetNavProps): JSX.Element => {
   const [facetUiStateArray, setFacetUiStateArray] = useState<UiFacetState[]>([])
   const [expandedFacets, setExpandedFacets] = useState<ExpandedFacet[]>([])
   const [isFirstTime, setIsFirstTime] = useState(true)
+  const { showFacetVisualization } = topLevelControlsState!
 
   const request = getLastQueryRequest!()
   const getFacets = (
@@ -199,7 +200,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   } else {
     return (
       <>
-        <div className={`FacetNav ${show ? '' : 'hidden'}`}>
+        <div className={`FacetNav ${showFacetVisualization ? '' : 'hidden'}`}>
           <div className="FacetNav__expanded">
             {expandedFacets.map(item => (
               <div key={`facetPanel_${item.index}`}>
@@ -280,6 +281,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
           token={token}
           unitDescription={hasSelectedFacets ? 'results via:' : 'results'}
           frontText={'Showing'}
+          searchQuery={searchQuery}
         />
       </>
     )

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -29,7 +29,7 @@ type ExpandedFacet = {
   index: number
 }
 
-type FacetNavProps = FacetNavOwnProps & QueryWrapperChildProps
+export type FacetNavProps = FacetNavOwnProps & QueryWrapperChildProps
 
 type ShowMoreState = 'MORE' | 'LESS' | 'NONE'
 

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -45,6 +45,8 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   topLevelControlsState,
   facetsToPlot,
   searchQuery,
+  getInitQueryRequest,
+  updateParentState,
 }: FacetNavProps): JSX.Element => {
   const [facetUiStateArray, setFacetUiStateArray] = useState<UiFacetState[]>([])
   const [expandedFacets, setExpandedFacets] = useState<ExpandedFacet[]>([])
@@ -278,6 +280,8 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
           isLoading={isLoading!}
           executeQueryRequest={executeQueryRequest!}
           lastQueryRequest={getLastQueryRequest?.()!}
+          updateParentState={updateParentState}
+          getInitQueryRequest={getInitQueryRequest}
           token={token}
           unitDescription={hasSelectedFacets ? 'results via:' : 'results'}
           frontText={'Showing'}

--- a/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
+++ b/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
@@ -11,6 +11,7 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ElementWithTooltip } from '../ElementWithTooltip'
 import _ from 'lodash'
+import { SearchQuery } from 'lib/containers/QueryWrapper'
 
 export type FacetWithSelection = {
   facet: FacetColumnResult
@@ -19,30 +20,38 @@ export type FacetWithSelection = {
 }
 
 export type SelectionCriteriaPillProps = {
-  facetWithSelection: FacetWithSelection
+  facetWithSelection?: FacetWithSelection
   index: number
   className?: string
   onRemove: Function
+  searchQuery?: SearchQuery
 }
 
 const SelectionCriteriaPill: FunctionComponent<SelectionCriteriaPillProps> = ({
   facetWithSelection,
   index,
   onRemove,
+  searchQuery,
 }) => {
   let innerText,
     tooltipText: string | null = ''
-  if (facetWithSelection.facet.facetType === 'enumeration') {
-    innerText = facetWithSelection.displayValue || ''
+  if (facetWithSelection) {
+    if (facetWithSelection.facet.facetType === 'enumeration') {
+      innerText = facetWithSelection.displayValue || ''
+    } else {
+      innerText =
+        (facetWithSelection.facet as FacetColumnResultRange).selectedMin +
+        ' - ' +
+        (facetWithSelection.facet as FacetColumnResultRange).selectedMax
+    }
+    tooltipText = `${unCamelCase(
+      facetWithSelection.facet.columnName,
+    )}: ${innerText}`
   } else {
-    innerText =
-      (facetWithSelection.facet as FacetColumnResultRange).selectedMin +
-      ' - ' +
-      (facetWithSelection.facet as FacetColumnResultRange).selectedMax
+    innerText = `"${searchQuery?.searchText}" in ${unCamelCase(
+      searchQuery?.columnName,
+    )}`
   }
-  tooltipText = `${unCamelCase(
-    facetWithSelection.facet.columnName,
-  )}: ${innerText}`
   return (
     <ElementWithTooltip
       idForToolTip={`selectionCriteria_${+index}`}

--- a/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
+++ b/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
@@ -11,7 +11,7 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ElementWithTooltip } from '../ElementWithTooltip'
 import _ from 'lodash'
-import { SearchQuery } from 'lib/containers/QueryWrapper'
+import { SearchQuery } from '../../../containers/QueryWrapper'
 
 export type FacetWithSelection = {
   facet: FacetColumnResult

--- a/src/lib/style/base/_helpers.scss
+++ b/src/lib/style/base/_helpers.scss
@@ -58,3 +58,7 @@
   align-items: center;
   justify-content: center;
 }
+
+.deemphasized {
+  color: #ababac;
+}

--- a/src/lib/style/components/_all.scss
+++ b/src/lib/style/components/_all.scss
@@ -3,4 +3,4 @@
   './synapse_form_wrapper/synapse-form-wrapper', './query-filter',
   './range-slider', './markdown', './access-requirement-list', './themes-plot',
   './download-link', './total-query-results', './facet_nav/all',
-  './query-wrapper-plot-nav';
+  './query-wrapper-plot-nav', './searchv2';

--- a/src/lib/style/components/_searchv2.scss
+++ b/src/lib/style/components/_searchv2.scss
@@ -1,10 +1,10 @@
 .SearchV2 {
-  margin-bottom: 25px;
-
   &__searchbar {
     height: 50px;
     background: #f9f9f9;
     border: 1px solid #dddddf;
+    display: flex;
+    align-items: center;
     &:focus-within {
       outline-color: $primary-action-color;
       outline-style: auto;
@@ -14,8 +14,12 @@
       color: #dcdcdc;
       margin-left: 10px;
       font-size: 17px;
+      flex: 1;
+      flex-grow: 0;
+      flex-shrink: 0;
     }
     input {
+      flex: 1;
       &:focus {
         outline-width: 0px;
       }
@@ -25,6 +29,11 @@
       display: inline-block;
       border: none;
       background: #f9f9f9;
+    }
+    &__clearbutton {
+      flex: 1;
+      flex-grow: 0;
+      flex-shrink: 0;
     }
   }
   &__form-container {

--- a/src/lib/style/components/_searchv2.scss
+++ b/src/lib/style/components/_searchv2.scss
@@ -1,0 +1,48 @@
+.SearchV2 {
+  margin-bottom: 25px;
+
+  &__searchbar {
+    height: 50px;
+    background: #f9f9f9;
+    border: 1px solid #dddddf;
+    &:focus-within {
+      outline-color: $primary-action-color;
+      outline-style: auto;
+      outline-width: 5px;
+    }
+    &__searchicon {
+      color: #dcdcdc;
+      margin-left: 10px;
+      font-size: 17px;
+    }
+    input {
+      &:focus {
+        outline-width: 0px;
+      }
+      margin-left: 10px;
+      width: fit-content;
+      height: 100%;
+      display: inline-block;
+      border: none;
+      background: #f9f9f9;
+    }
+  }
+  &__form-container {
+    position: relative;
+    width: 100%;
+    margin-top: 5px;
+  }
+  &__column-select {
+    background: #ffffff;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    padding-left: 30px;
+    padding-top: 15px;
+    padding-bottom: 5px;
+    color: #515359;
+    max-height: 300px;
+    position: absolute;
+    overflow: auto;
+    z-index: 5;
+    width: inherit;
+  }
+}

--- a/src/lib/style/components/_total-query-results.scss
+++ b/src/lib/style/components/_total-query-results.scss
@@ -10,7 +10,21 @@
 
   &__selections {
     display: flex;
+    flex: 1;
     flex-wrap: wrap;
+  }
+
+  &__clearall {
+    padding: 5px 10px;
+    margin-left: 5px;
+    flex: 1;
+    flex-grow: 0;
+    flex-shrink: 1;
+    color: #515359;
+    background: #ececec;
+    border-radius: 2px;
+    white-space: nowrap;
+    height: fit-content;
   }
 }
 

--- a/src/lib/utils/functions/sqlFunctions.ts
+++ b/src/lib/utils/functions/sqlFunctions.ts
@@ -88,25 +88,23 @@ export const formatSQLFromParser = (tokens: string[][]) => {
 
 //parses synapse entity id from a sql query string
 //look for a pattern of 'from[some number of spaces]syn[somenumbers]` case insensitive
-export const parseEntityIdFromSqlStatement = (sql:string): string => {
+export const parseEntityIdFromSqlStatement = (sql: string): string => {
   const matches = sql.match(/(from)\s+(syn)\d+/gi)
-  return  (matches && matches[0])? matches[0].substr(5).trim() : ''
+  return matches && matches[0] ? matches[0].substr(5).trim() : ''
 }
 
-export const resultToJson = <T>(  
+export const resultToJson = <T>(
   headerColumns: SelectColumn[],
-     rowColumns: Row[]
-   ): T[] => {
-     const result: T[] = [];
-     const rows = rowColumns.map(row => row.values);
-     const headers = headerColumns.map(column => column.name);
-     rows.forEach((row, index) => {
-       result[index] = {} as T;
-       row.forEach((text, cellIndex) => {
-         result[index][headers[cellIndex]] = text;
-       });
-     });
-     return result;
-   };
-  
-
+  rowColumns: Row[],
+): T[] => {
+  const result: T[] = []
+  const rows = rowColumns.map(row => row.values)
+  const headers = headerColumns.map(column => column.name)
+  rows.forEach((row, index) => {
+    result[index] = {} as T
+    row.forEach((text, cellIndex) => {
+      result[index][headers[cellIndex]] = text
+    })
+  })
+  return result
+}

--- a/src/mocks/mock_query_data.tsx
+++ b/src/mocks/mock_query_data.tsx
@@ -1,5 +1,5 @@
 import { ColumnType } from '../lib/utils/synapseTypes/'
-let mockData =  {
+const mockData = {
   concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
   columnModels: [
     {
@@ -34,7 +34,7 @@ let mockData =  {
           isSelected: true,
         },
       ],
-    } 
+    },
   ],
   queryResult: {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',


### PR DESCRIPTION
- Refactored QueryWrapperPlotNav to place the top level controls under QueryWrapper, allowing for search and add to download to get implemented
- Added Clear All button
- Add new state variables to QueryWrapper: `searchQuery`, `topLevelControlsState`
- Put in intermediate search component with updated UI -- SearchV2.tsx

Search with dropdown open
![image](https://user-images.githubusercontent.com/20282487/80742305-03cfc480-8ad0-11ea-95b1-fc21c8f6a984.png)

Search with selection made (note the chiclet with the search query having been made)
![image](https://user-images.githubusercontent.com/20282487/80742585-79d42b80-8ad0-11ea-9d54-7a8dc7e9e110.png)