### PR TITLE
PORTALS-1393

### DIFF
--- a/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
+++ b/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
@@ -3,7 +3,10 @@ import QueryWrapperPlotNav, {
   QueryWrapperPlotNavProps,
 } from '../../../lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav'
 import { SynapseConstants, SynapseClient } from '../../../lib'
-import { TableUpdateTransactionRequest, PartialRow } from '../../../lib/utils/synapseTypes/Table/TableUpdate'
+import {
+  TableUpdateTransactionRequest,
+  PartialRow,
+} from '../../../lib/utils/synapseTypes/Table/TableUpdate'
 import { Row } from '../../../lib/utils/synapseTypes'
 
 type DemoState = {
@@ -38,6 +41,22 @@ class QueryWrapperPlotNavDemo extends React.Component<
         tableConfiguration: {
           loadingScreen: <> I'm loading as fast as I can!!!! </>,
         },
+        searchConfiguration: {
+          searchable: [
+            {
+              columnName: 'assay',
+              hintText: 'RNASeq',
+            },
+            {
+              columnName: 'name',
+              hintText: 'SynOdos',
+            },
+            {
+              columnName: 'consortium',
+              hintText: 'amp-ad',
+            },
+          ],
+        },
         visibleColumnCount: 10,
         facetsToPlot: ['assay'],
         rgbIndex: 1,
@@ -69,7 +88,7 @@ class QueryWrapperPlotNavDemo extends React.Component<
       propsWithCustomCommands: {
         tableConfiguration: {
           loadingScreen: <> I'm loading as fast as I can!!!! </>,
-          isRowSelectionVisible: true
+          isRowSelectionVisible: true,
         },
         visibleColumnCount: 10,
         facetsToPlot: ['Ethnicity', 'Sex'],
@@ -83,48 +102,64 @@ class QueryWrapperPlotNavDemo extends React.Component<
             <div className="spinner"> </div>Im loading as fast I can !!!{' '}
           </div>
         ),
-        customControls: [{
-          buttonText: 'Update WorkflowState',
-          classNames: 'exampleClassNameToAddToButton',
-          onClick: (event => {
-            // Demo custom control updates all values in a particular column for the selected rows (CRC)
-            // test Updating a Synapse Table for the first time from SRC, by updating the WorkflowState column value
-            const entityId:string = event.data?.queryResult.queryResults.tableId!
-            // find target column
-            const targetColumn = event.data?.columnModels!.find(cm => cm.name === 'WorkflowState')
-            // collect all selected rows (create PartialRow objects)
-            const rowUpdates:PartialRow[] = []
-            const rows:Row[] = event.data?.queryResult.queryResults!.rows
-            for (let index = 0; index < event.selectedRowIndices!.length; index++) {
-              rowUpdates.push({
-                rowId: rows[event.selectedRowIndices![index]].rowId,
-                values: [{
-                  key: targetColumn?.id!,
-                  value: 'Selected'
-                }]
-              })
-            }
-            
-            const request: TableUpdateTransactionRequest = {
-              concreteType: 'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
-              entityId,
-              changes: [{
-                concreteType: 'org.sagebionetworks.repo.model.table.AppendableRowSetRequest',
+        customControls: [
+          {
+            buttonText: 'Update WorkflowState',
+            classNames: 'exampleClassNameToAddToButton',
+            onClick: event => {
+              // Demo custom control updates all values in a particular column for the selected rows (CRC)
+              // test Updating a Synapse Table for the first time from SRC, by updating the WorkflowState column value
+              const entityId: string = event.data?.queryResult.queryResults
+                .tableId!
+              // find target column
+              const targetColumn = event.data?.columnModels!.find(
+                cm => cm.name === 'WorkflowState',
+              )
+              // collect all selected rows (create PartialRow objects)
+              const rowUpdates: PartialRow[] = []
+              const rows: Row[] = event.data?.queryResult.queryResults!.rows
+              for (
+                let index = 0;
+                index < event.selectedRowIndices!.length;
+                index++
+              ) {
+                rowUpdates.push({
+                  rowId: rows[event.selectedRowIndices![index]].rowId,
+                  values: [
+                    {
+                      key: targetColumn?.id!,
+                      value: 'Selected',
+                    },
+                  ],
+                })
+              }
+
+              const request: TableUpdateTransactionRequest = {
+                concreteType:
+                  'org.sagebionetworks.repo.model.table.TableUpdateTransactionRequest',
                 entityId,
-                toAppend: {
-                  concreteType: 'org.sagebionetworks.repo.model.table.PartialRowSet',
-                  tableId: entityId,
-                  rows: rowUpdates
-                }
-              }]
-            }
-            SynapseClient.updateTable(request, props.token).then(() => {
-              console.log('updated!')
-              // refresh data after successful update
-              event.refresh()
-            })
-          }),
-        }]
+                changes: [
+                  {
+                    concreteType:
+                      'org.sagebionetworks.repo.model.table.AppendableRowSetRequest',
+                    entityId,
+                    toAppend: {
+                      concreteType:
+                        'org.sagebionetworks.repo.model.table.PartialRowSet',
+                      tableId: entityId,
+                      rows: rowUpdates,
+                    },
+                  },
+                ],
+              }
+              SynapseClient.updateTable(request, props.token).then(() => {
+                console.log('updated!')
+                // refresh data after successful update
+                event.refresh()
+              })
+            },
+          },
+        ],
       },
     }
     this.handleChange = this.handleChange.bind(this)
@@ -161,7 +196,10 @@ class QueryWrapperPlotNavDemo extends React.Component<
         <QueryWrapperPlotNav token={this.props.token} {...propsForPlotNav} />
         <hr></hr>
         <h3>Now with custom commands</h3>
-        <QueryWrapperPlotNav token={this.props.token} {...this.state.propsWithCustomCommands} />
+        <QueryWrapperPlotNav
+          token={this.props.token}
+          {...this.state.propsWithCustomCommands}
+        />
       </div>
     )
   }

--- a/src/lib/containers/SearchV2.tsx
+++ b/src/lib/containers/SearchV2.tsx
@@ -154,7 +154,7 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
 
   render() {
     const { data, topLevelControlsState, facetAliases, searchable } = this.props
-    const { searchText, show } = this.state
+    const { searchText, show, columnName } = this.state
 
     return (
       <div className="SearchV2">
@@ -226,13 +226,8 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
                 .map((el, index) => {
                   const name = el.name
                   const displayName = unCamelCase(el.name, facetAliases)
-                  const selectedColumn = this.state.columnName
                   const isSelected =
-                    (selectedColumn === '' && index === 0) ||
-                    selectedColumn === name
-                  const placeholder =
-                    searchable?.find(search => search.columnName === el.name)
-                      ?.hintText ?? ''
+                    (columnName === '' && index === 0) || columnName === name
                   return (
                     <div className="radio">
                       <label>
@@ -242,7 +237,6 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
                             type="radio"
                             value={name}
                             checked={isSelected}
-                            placeholder={placeholder}
                             onClick={() => {
                               this.setState({
                                 columnName: name,

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -12,7 +12,7 @@ import { CardConfiguration } from '../CardContainerLogic'
 import FilterAndView from './FilterAndView'
 import { TopLevelControlsProps } from './TopLevelControls'
 import TopLevelControls from './TopLevelControls'
-import SearchV2 from '../SearchV2'
+import SearchV2, { SearchV2Props } from '../SearchV2'
 import { DownloadConfirmation } from '../download_list'
 
 type OwnProps = {
@@ -21,6 +21,7 @@ type OwnProps = {
   shouldDeepLink?: boolean
   tableConfiguration?: SynapseTableProps
   cardConfiguration?: CardConfiguration
+  searchConfiguration?: SearchV2Props
   token?: string
   rgbIndex?: number
   facetsToPlot?: string[]
@@ -55,6 +56,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
     cardConfiguration,
     facetsToPlot,
     hideDownload,
+    searchConfiguration,
     ...rest
   } = props
   let sqlUsed = sql
@@ -91,7 +93,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
           sql={sqlUsed}
           hideDownload={hideDownload}
         />
-        <SearchV2 />
+        <SearchV2 {...searchConfiguration} />
         <DownloadConfirmation />
         <FacetNav
           facetsToPlot={facetsToPlot}


### PR DESCRIPTION
- Add back prop `searchable` to SearchV2, prop filters columns to those in the prop, if prop isn't specified it shows all columns
- Also added back filter `isSupportedColumn` on search columns, I missed it but in one the prs today that was accidentally removed
- Removed code that would reset the column and search text on submit