### PR TITLE
fix bug with searching the wrong column

### DIFF
--- a/src/lib/containers/SearchV2.tsx
+++ b/src/lib/containers/SearchV2.tsx
@@ -95,9 +95,13 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
     event.preventDefault()
     const { searchText } = this.state
     let { columnName } = this.state
+    const { searchable } = this.props
     if (columnName === '') {
       // default to the first one, will always be defined
-      columnName = this.props.data?.columnModels?.[0].name ?? ''
+      columnName =
+        this.props.data?.columnModels?.filter(el =>
+          this.isSupportedColumnAndInProps(el, searchable),
+        )?.[0].name ?? ''
     }
     this.setState({
       show: false,


### PR DESCRIPTION
didn't filter the columns in the search function, this caused an issue where the column that was searched through was different than the one that was being displayed