### PR TITLE
Fix PORTALS-1425/1178

### DIFF
--- a/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
+++ b/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
@@ -31,7 +31,7 @@ class QueryWrapperPlotNavDemo extends React.Component<
    */
   constructor(props: any) {
     super(props)
-    const sql: string = 'SELECT * FROM syn16858331'
+    const sql: string = 'SELECT * FROM syn11346063'
     this.state = {
       isLoading: true,
       ownerId: '',
@@ -40,6 +40,7 @@ class QueryWrapperPlotNavDemo extends React.Component<
       propsWithTable: {
         tableConfiguration: {
           loadingScreen: <> I'm loading as fast as I can!!!! </>,
+          showAccessColumn: true,
         },
         searchConfiguration: {
           searchable: [
@@ -63,7 +64,7 @@ class QueryWrapperPlotNavDemo extends React.Component<
         name: 'PlotNav Demo',
         sqlOperator: '=',
         sql,
-        entityId: 'syn16858331',
+        entityId: 'syn11346063',
         // facetsToPlot: ['assay', 'dataType'],
         loadingScreen: (
           <div>
@@ -76,7 +77,7 @@ class QueryWrapperPlotNavDemo extends React.Component<
         name: 'PlotNav Demo',
         sqlOperator: '=',
         sql,
-        entityId: 'syn16858331',
+        entityId: 'syn11346063',
         cardConfiguration: {
           type: SynapseConstants.GENERIC_CARD,
           genericCardSchema: {
@@ -195,11 +196,11 @@ class QueryWrapperPlotNavDemo extends React.Component<
         </button>
         <QueryWrapperPlotNav token={this.props.token} {...propsForPlotNav} />
         <hr></hr>
-        <h3>Now with custom commands</h3>
-        <QueryWrapperPlotNav
+        {/* <h3>Now with custom commands</h3> */}
+        {/* <QueryWrapperPlotNav
           token={this.props.token}
           {...this.state.propsWithCustomCommands}
-        />
+        /> */}
       </div>
     )
   }

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -131,10 +131,9 @@ export default class CardContainerLogic extends React.Component<
       prevSearchParams,
       currentSearchParams,
     )
-    const hasTokenBeenAquired =
-      this.props.token !== '' && prevProps.token === ''
+    const hasTokenChanged = this.props.token !== prevProps.token
     const hasSqlChanged = this.props.sql !== prevProps.sql
-    if (hasTokenBeenAquired || hasSqlChanged || hasSearchParamsChanged) {
+    if (hasTokenChanged || hasSqlChanged || hasSearchParamsChanged) {
       this.executeInitialQueryRequest()
     }
   }

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -155,8 +155,7 @@ export default class HasAccess extends React.Component<
   }
 
   componentDidUpdate(prevProps: HasAccessProps) {
-    const forceRefresh =
-      prevProps.token === undefined && this.props.token !== undefined
+    const forceRefresh = prevProps.token !== this.props.token
     // if there token has updated then force refresh the component state
     this.refresh(forceRefresh)
   }
@@ -211,7 +210,7 @@ export default class HasAccess extends React.Component<
     // fileHandle was not passed to us, ask for it.
     // is this a FileEntity?
     return SynapseClient.getEntity(token, entityId, entityVersionNumber)
-      .then((entity) => {
+      .then(entity => {
         if (entity.hasOwnProperty('dataFileHandleId')) {
           // looks like a FileEntity, get the FileHandle
           return SynapseClient.getFileEntityFileHandle(
@@ -235,7 +234,7 @@ export default class HasAccess extends React.Component<
           return Promise.resolve()
         }
       })
-      .catch((err) => {
+      .catch(err => {
         console.error('Error on get Entity = ', err)
         // could not get entity
         this.updateStateFileHandleAccessBlocked()
@@ -258,12 +257,12 @@ export default class HasAccess extends React.Component<
       objectId: entityId,
     }
     return SynapseClient.getRestrictionInformation(request, token)
-      .then((restrictionInformation) => {
+      .then(restrictionInformation => {
         this.setState({
           restrictionInformation,
         })
       })
-      .catch((err) => {
+      .catch(err => {
         console.error('Error on getRestrictionInformation: ', err)
       })
       .finally(() => {
@@ -326,7 +325,7 @@ export default class HasAccess extends React.Component<
   handleGetAccess = () => {
     const { token, entityId, set_arPropsFromHasAccess } = this.props
     SynapseClient.getAllAccessRequirements(token, entityId).then(
-      (requirements) => {
+      requirements => {
         if (checkHasUnsportedRequirement(requirements)) {
           window.open(
             `${getEndpoint(

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -223,6 +223,7 @@ export default class HasAccess extends React.Component<
             )
             this.setState({
               fileHandleDownloadType,
+              isGettingEntityInformation: false,
             })
           })
         } else {

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -96,8 +96,8 @@ export type QueryWrapperChildProps = {
   hasMoreData?: boolean
   topLevelControlsState?: TopLevelControlsState
   searchQuery?: SearchQuery
-  isColumnSelected?: string[],
-  selectedRowIndices?: number[],
+  isColumnSelected?: string[]
+  selectedRowIndices?: number[]
 }
 
 /**
@@ -181,7 +181,7 @@ export default class QueryWrapper extends React.Component<
     const { loadNow = true } = this.props
     if (loadNow && !this.state.loadNowStarted) {
       this.executeInitialQueryRequest()
-    } else if (loadNow && this.props.token && !prevProps.token) {
+    } else if (loadNow && this.props.token !== prevProps.token) {
       // if loadNow is true and they've logged in with a token that is not undefined, null, or an empty string when it was before
       this.executeQueryRequest(this.getLastQueryRequest())
     } else if (
@@ -225,7 +225,7 @@ export default class QueryWrapper extends React.Component<
     this.setState({
       isLoading: true,
       lastQueryRequest: clonedQueryRequest,
-      selectedRowIndices: [] // reset selected row indices any time the query is re-run
+      selectedRowIndices: [], // reset selected row indices any time the query is re-run
     })
 
     if (clonedQueryRequest.query) {
@@ -400,7 +400,7 @@ export default class QueryWrapper extends React.Component<
         getLastQueryRequest: this.getLastQueryRequest,
         getNextPageOfData: this.getNextPageOfData,
         updateParentState: this.updateParentState,
-        getInitQueryRequest: this.getInitQueryRequest,        
+        getInitQueryRequest: this.getInitQueryRequest,
         ...rest,
       }
       return React.cloneElement(child, queryWrapperChildProps)

--- a/src/lib/containers/access_requirement_list/AccessRequirementList.tsx
+++ b/src/lib/containers/access_requirement_list/AccessRequirementList.tsx
@@ -151,7 +151,10 @@ export default function AccessRequirementList({
     getAccessRequirements()
   }, [token, entityId, accessRequirementFromProps, shouldUpdateData])
 
-  const isSignedIn: boolean = token !== undefined
+  // Using Boolean(value) converts undefined,null, 0,'',false -> false
+  // one alternative to using Boolean(value) is the double bang operator !!value,
+  // but doesn't ready well
+  const isSignedIn: boolean = Boolean(token)
 
   /**
    * Returns rendering for the access requirement.

--- a/src/lib/containers/access_requirement_list/AccessRequirementList.tsx
+++ b/src/lib/containers/access_requirement_list/AccessRequirementList.tsx
@@ -265,14 +265,10 @@ export default function AccessRequirementList({
       <div className="requirement-container">
         <AccessApprovalCheckMark isCompleted={isSignedIn} />
         <div>
-          {!token && (
+          {!isSignedIn && (
             <p className="AccessRequirementList__signin">
               <button
-                className={`${
-                  SynapseConstants.SRC_SIGN_IN_CLASS
-                } sign-in-btn_access-requirement ${
-                  isSignedIn ? 'default' : 'blue'
-                }`}
+                className={`${SynapseConstants.SRC_SIGN_IN_CLASS} SRC-primary-text-color SRC-boldText `}
               >
                 Sign in
               </button>

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -941,26 +941,6 @@ button {
   margin: 10px;
 }
 
-.SRC-SIGN-IN-CLASS.sign-in-btn {
-  &.AccessRequirementList {
-    margin-top: 5px;
-
-    &.default {
-      padding: 15px 5px 0px 0px;
-      color: black;
-    }
-    &.blue {
-      padding: 15px 5px 0px 0px;
-      color: $primary-action-color;
-    }
-  }
-
-  &.default {
-    padding-left: 5px;
-    color: $primary-action-color;
-  }
-}
-
 a.dropdown-item {
   $color: #212529;
   display: block;

--- a/src/lib/style/components/_access-requirement-list.scss
+++ b/src/lib/style/components/_access-requirement-list.scss
@@ -37,8 +37,10 @@
     padding-left: 25px;
   }
 
-  &__AccessRequirementList__signin .terms-of-use-content {
-    margin-top: 20px;
+  &__signin {
+    button {
+      padding-left: 0px;
+    }
   }
 
   .button-container {

--- a/src/lib/utils/functions/deepLinkingUtils.ts
+++ b/src/lib/utils/functions/deepLinkingUtils.ts
@@ -3,7 +3,6 @@ import { Query } from '../synapseTypes'
 import { SynapseConstants } from '..'
 import { parseEntityIdFromSqlStatement } from './sqlFunctions'
 
-
 //id consists of a component class/function name and it's index
 function getComponentSearchHashId(
   componentName: string,
@@ -12,13 +11,13 @@ function getComponentSearchHashId(
   return `${componentName}${componentIndex}`
 }
 
-//returns updated search string with the component's info 
+//returns updated search string with the component's info
 function patchSearchString(
   componentSearchHashId: string,
   stringifiedQuery: string,
 ): string | undefined {
   const searchString = window.location.search
-  
+
   const searchFragment = `${componentSearchHashId}=${stringifiedQuery}`
   if (!searchString) {
     return searchFragment
@@ -72,13 +71,13 @@ export function getSearchParamValueFromUrl(
 //updates the url with the components new search params
 export function updateUrlWithNewSearchParam(
   componentName: string,
-  componentIndex: number|undefined,
+  componentIndex: number | undefined,
   stringifiedQuery: string,
 ) {
-  const componentSearchHashId = componentIndex !== undefined? getComponentSearchHashId(
-    componentName,
-    componentIndex,
-  ) : componentName
+  const componentSearchHashId =
+    componentIndex !== undefined
+      ? getComponentSearchHashId(componentName, componentIndex)
+      : componentName
   const searchString = patchSearchString(
     componentSearchHashId,
     stringifiedQuery,
@@ -92,28 +91,29 @@ export function updateUrlWithNewSearchParam(
 }
 
 export function getQueryRequestFromLink(
-    componentName: string,
-    componentIndex: number,
-  ): QueryBundleRequest | undefined {
-    const searchParamValue = getSearchParamValueFromUrl(
-      componentName,
-      componentIndex,
-    )
-  
-    let initQueryRequest: QueryBundleRequest | undefined = undefined
-    if (searchParamValue) {
-      const query = JSON.parse(searchParamValue) as Query
-      if (query.sql) {
-        initQueryRequest = {
-          concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
-          partMask:
-            SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
-            SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
-            SynapseConstants.BUNDLE_MASK_QUERY_RESULTS,
-          entityId: parseEntityIdFromSqlStatement(query.sql),
-          query: query,
-        }
+  componentName: string,
+  componentIndex: number,
+): QueryBundleRequest | undefined {
+  const searchParamValue = getSearchParamValueFromUrl(
+    componentName,
+    componentIndex,
+  )
+
+  let initQueryRequest: QueryBundleRequest | undefined = undefined
+  if (searchParamValue) {
+    const query = JSON.parse(searchParamValue) as Query
+    if (query.sql) {
+      initQueryRequest = {
+        concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+        partMask:
+          SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
+          SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
+          SynapseConstants.BUNDLE_MASK_QUERY_SELECT_COLUMNS |
+          SynapseConstants.BUNDLE_MASK_QUERY_RESULTS,
+        entityId: parseEntityIdFromSqlStatement(query.sql),
+        query,
       }
     }
-    return initQueryRequest
   }
+  return initQueryRequest
+}


### PR DESCRIPTION
PORTALS-1425: Needed partMask to include select_columns, otherwise zero results will show up on render when there are search params

PORTALS-1178: Fix is two fold - first the check for the token change, see if it is different from before, also fixed a state variable that wasn't being set properly.

Made a few changes in other components to change their 'did update' to see if the token changes for both sign-in and sign-out, before it only checked sign-in.

fixed text color of sign in button in access requirement list, also fixed check mark showing that someone was signed in when they were not.