### PR TITLE
PLFM-6322 - OIDCAuthorizationRequest.claims is now an object

### DIFF
--- a/src/lib/utils/synapseTypes/OIDCAuthorizationRequest.ts
+++ b/src/lib/utils/synapseTypes/OIDCAuthorizationRequest.ts
@@ -3,7 +3,22 @@
 export type OIDCAuthorizationRequest = {
   clientId: string
   scope: string
-  claims: string
+  claims: {
+    id_token: {
+      [key: string]: {
+        essential: boolean
+        value: string,
+        values: string[],
+      }
+    }
+    userinfo: {
+      [key: string]: {
+        essential: boolean
+        value: string,
+        values: string[],
+      }
+    }
+  }
   responseType: 'code'
   redirectUri: string
   nonce?: string

--- a/src/lib/utils/synapseTypes/OIDCAuthorizationRequest.ts
+++ b/src/lib/utils/synapseTypes/OIDCAuthorizationRequest.ts
@@ -3,19 +3,19 @@
 export type OIDCAuthorizationRequest = {
   clientId: string
   scope: string
-  claims: {
-    id_token: {
+  claims?: {
+    id_token?: {
       [key: string]: {
         essential: boolean
         value: string,
         values: string[],
       }
     }
-    userinfo: {
+    userinfo?: {
       [key: string]: {
-        essential: boolean
-        value: string,
-        values: string[],
+        essential?: boolean
+        value?: string,
+        values?: string[],
       }
     }
   }


### PR DESCRIPTION
This doesn't affect the necessary change in the OAuth sign-in app: https://github.com/Sage-Bionetworks/synapse-oauth-signin/pull/27

Just creating a PR here to keep the object definition up-to-date