### PR TITLE
PORTALS-1499

### DIFF
--- a/src/__tests__/lib/containers/CardContainer.test.tsx
+++ b/src/__tests__/lib/containers/CardContainer.test.tsx
@@ -14,7 +14,7 @@ import { cloneDeep } from 'lodash-es'
 
 const createShallowComponent = (props: CardContainerProps) => {
   const wrapper = shallow(<CardContainer {...props} />)
-  const instance = wrapper.instance() as CardContainer
+  const instance = wrapper.instance()
   return { wrapper, instance }
 }
 
@@ -24,6 +24,7 @@ describe('it performs all functionality', () => {
   const sql = 'SELECT * FROM syn16787123'
   const lastQueryRequest: QueryBundleRequest = {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+    entityId: 'syn16787123',
     partMask:
       SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
       SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
@@ -75,9 +76,9 @@ describe('it performs all functionality', () => {
   })
 
   it('handleViewMore works', () => {
-    const { instance } = createShallowComponent(props)
+    const { wrapper } = createShallowComponent(props)
     // go through calling handle view more
-    instance.handleViewMore()
+    wrapper.find('button').simulate('click')
     expect(getLastQueryRequest).toHaveBeenCalled()
     expect(getNextPageOfData).toHaveBeenCalled()
   })

--- a/src/__tests__/lib/containers/GenericCard.test.tsx
+++ b/src/__tests__/lib/containers/GenericCard.test.tsx
@@ -205,7 +205,7 @@ describe('it makes the correct URL for the title', () => {
     expect(target).toEqual(SELF)
   })
 
-  describe.only('creates a link for a file handle ', () => {
+  describe('creates a link for a file handle ', () => {
     const FILE_HANDLE_COLUMN_TYPE = ColumnType.FILEHANDLEID
     it('creates a link for a file handle inside a file view', () => {
       const id = '123'
@@ -242,7 +242,7 @@ describe('it makes the correct URL for the title', () => {
       )
     })
 
-    it.only('creates a link for a file handle inside a table', () => {
+    it('creates a link for a file handle inside a table', () => {
       const id = '123'
       const schema = {
         id: 0,

--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -5,12 +5,17 @@ import {
   GENERIC_CARD,
   MEDIUM_USER_CARD,
 } from '../utils/SynapseConstants'
-import { QueryBundleRequest, QueryResultBundle } from '../utils/synapseTypes/'
+import {
+  QueryBundleRequest,
+  QueryResultBundle,
+  EntityHeader,
+} from '../utils/synapseTypes/'
 import { CardConfiguration } from './CardContainerLogic'
 import GenericCard from './GenericCard'
 import { Dataset, Funder } from './row_renderers'
 import TotalQueryResults from './TotalQueryResults'
 import UserCardList from './UserCardList'
+import useGetInfoFromIds from '../utils/hooks/useGetInfoFromIds'
 
 const PAGE_SIZE: number = 25
 
@@ -32,34 +37,22 @@ export type CardContainerProps = {
   token?: string
 } & CardConfiguration
 
-type CardContainerState = {
-  cardLimit: number
-}
-
-export class CardContainer extends React.Component<
-  CardContainerProps,
-  CardContainerState
-> {
-  constructor(props: CardContainerProps) {
-    super(props)
-    this.handleViewMore = this.handleViewMore.bind(this)
-  }
-
+export const CardContainer = (props: CardContainerProps) => {
   /**
    * Handle a click on next or previous
    *
    * @memberof SynapseTable
    */
-  public handleViewMore() {
-    const queryRequest = this.props.getLastQueryRequest!()
+  const handleViewMore = () => {
+    const queryRequest = props.getLastQueryRequest!()
     let offset = queryRequest.query.offset!
     // paginate forward
     offset += PAGE_SIZE
     queryRequest.query.offset = offset
-    this.props.getNextPageOfData!(queryRequest)
+    props.getNextPageOfData!(queryRequest)
   }
 
-  public renderCard = (props: any, type: string) => {
+  const renderCard = (props: any, type: string) => {
     switch (type) {
       case DATASET:
         return <Dataset {...props} />
@@ -71,117 +64,124 @@ export class CardContainer extends React.Component<
         return <div /> // this should never happen
     }
   }
-  public render() {
-    const {
-      data,
-      limit = Infinity,
-      isHeader = false,
-      facet,
-      unitDescription,
-      type,
-      isLoading,
-      loadingScreen,
-      secondaryLabelLimit = 3,
-      showBarChart = true,
-      title,
-      token,
-      getLastQueryRequest,
-      ...rest
-    } = this.props
-    // the cards only show the loading screen on initial load, this occurs when data is undefined
-    if (!data) {
-      return <div>{isLoading && loadingScreen}</div>
-    } else if (data && data.queryResult.queryResults.rows.length === 0) {
-      // data was retrieved from the backend but there is none to show, we return a empty fragment
-      // there could be a more informed UX decision here but the current use case right now
-      // should display nothing
-      return <React.Fragment />
-    }
-    const schema = {}
-    data.queryResult.queryResults.headers.forEach((element, index) => {
-      schema[element.name] = index
-    })
 
-    // We want to hide the view more button if:
-    //   1. The data fed in has !== PAGE_SIZE number of results
-    //   2. The hasMoreData prop is false
-    //   3. The limit is set to less than PAGE_SIZE
-    // below we show the view more button by following the opposite logic from above.
-    let showViewMore: boolean =
-      limit >= PAGE_SIZE &&
-      data.queryResult.queryResults.rows.length >= PAGE_SIZE
-    showViewMore = showViewMore && this.props.hasMoreData!
-
-    const showViewMoreButton = showViewMore && (
-      <div>
-        <button
-          onClick={this.handleViewMore}
-          className="pull-right SRC-standard-button-shape SRC-light-button"
-        >
-          View More
-        </button>
-      </div>
-    )
-    let cards
-    if (type === MEDIUM_USER_CARD) {
-      // Hard coding ownerId as a column name containing the user profile ownerId
-      // for each row, grab the column with the ownerId
-      const userIdColumnIndex = data.queryResult.queryResults.headers.findIndex(
-        el => el.columnType === 'USERID',
-      )
-      if (userIdColumnIndex === -1) {
-        throw Error(
-          'Type MEDIUM_USER_CARD specified but no columnType USERID found',
-        )
-      }
-      const listIds = data.queryResult.queryResults.rows.map(
-        el => el.values[userIdColumnIndex],
-      )
-      cards = (
-        <UserCardList data={data} list={listIds} size={MEDIUM_USER_CARD} />
-      )
-    } else {
-      // render the cards
-      cards = data.queryResult.queryResults.rows.map((rowData: any, index) => {
-        if (index < limit) {
-          const key = JSON.stringify(rowData.values)
-          const propsForCard = {
-            key,
-            type,
-            schema,
-            isHeader,
-            secondaryLabelLimit,
-            data: rowData.values,
-            selectColumns: data.selectColumns,
-            columnModels: data.columnModels,
-            token,
-            ...rest,
-          }
-          return this.renderCard(propsForCard, type)
-        }
-        return false
-      })
-    }
-
-    return (
-      <div>
-        {title && <h2 className="SRC-card-overview-title">{title}</h2>}
-        {!title && unitDescription && showBarChart && (
-          <TotalQueryResults
-            token={token}
-            isLoading={isLoading!}
-            unitDescription={unitDescription}
-            executeQueryRequest={this.props.executeQueryRequest}
-            lastQueryRequest={getLastQueryRequest!()}
-            frontText={'Displaying'}
-          />
-        )}
-        {/* ReactCSSTransitionGroup adds css fade in property for cards that come into view */}
-        {cards}
-        {showViewMoreButton}
-      </div>
-    )
+  const ids = props.data?.queryResult.queryResults.tableId
+    ? [props.data?.queryResult.queryResults.tableId]
+    : []
+  const tableEntityType = useGetInfoFromIds<EntityHeader>({
+    ids,
+    type: 'ENTITY_HEADER',
+    token: props.token,
+  })
+  const {
+    data,
+    limit = Infinity,
+    isHeader = false,
+    facet,
+    unitDescription,
+    type,
+    isLoading,
+    loadingScreen,
+    secondaryLabelLimit = 3,
+    showBarChart = true,
+    title,
+    token,
+    getLastQueryRequest,
+    executeQueryRequest,
+    ...rest
+  } = props
+  // the cards only show the loading screen on initial load, this occurs when data is undefined
+  if (!data) {
+    return <div>{isLoading && loadingScreen}</div>
+  } else if (data && data.queryResult.queryResults.rows.length === 0) {
+    // data was retrieved from the backend but there is none to show, we return a empty fragment
+    // there could be a more informed UX decision here but the current use case right now
+    // should display nothing
+    return <React.Fragment />
   }
+  const schema = {}
+  data.queryResult.queryResults.headers.forEach((element, index) => {
+    schema[element.name] = index
+  })
+
+  // We want to hide the view more button if:
+  //   1. The data fed in has !== PAGE_SIZE number of results
+  //   2. The hasMoreData prop is false
+  //   3. The limit is set to less than PAGE_SIZE
+  // below we show the view more button by following the opposite logic from above.
+  let showViewMore: boolean =
+    limit >= PAGE_SIZE && data.queryResult.queryResults.rows.length >= PAGE_SIZE
+  showViewMore = showViewMore && props.hasMoreData!
+
+  const showViewMoreButton = showViewMore && (
+    <div>
+      <button
+        onClick={handleViewMore}
+        className="pull-right SRC-standard-button-shape SRC-light-button"
+      >
+        View More
+      </button>
+    </div>
+  )
+  let cards
+  if (type === MEDIUM_USER_CARD) {
+    // Hard coding ownerId as a column name containing the user profile ownerId
+    // for each row, grab the column with the ownerId
+    const userIdColumnIndex = data.queryResult.queryResults.headers.findIndex(
+      el => el.columnType === 'USERID',
+    )
+    if (userIdColumnIndex === -1) {
+      throw Error(
+        'Type MEDIUM_USER_CARD specified but no columnType USERID found',
+      )
+    }
+    const listIds = data.queryResult.queryResults.rows.map(
+      el => el.values[userIdColumnIndex],
+    )
+    cards = <UserCardList data={data} list={listIds} size={MEDIUM_USER_CARD} />
+  } else {
+    // render the cards
+    cards = data.queryResult.queryResults.rows.map((rowData: any, index) => {
+      if (index < limit) {
+        const key = JSON.stringify(rowData.values)
+        const propsForCard = {
+          key,
+          type,
+          schema,
+          isHeader,
+          secondaryLabelLimit,
+          data: rowData.values,
+          selectColumns: data.selectColumns,
+          columnModels: data.columnModels,
+          tableEntityType: tableEntityType[0] && tableEntityType[0].type,
+          tableId: props.data?.queryResult.queryResults.tableId,
+          token,
+          ...rest,
+        }
+        return renderCard(propsForCard, type)
+      }
+      return false
+    })
+  }
+
+  return (
+    <div>
+      {title && <h2 className="SRC-card-overview-title">{title}</h2>}
+      {!title && unitDescription && showBarChart && (
+        <TotalQueryResults
+          token={token}
+          isLoading={isLoading!}
+          unitDescription={unitDescription}
+          executeQueryRequest={executeQueryRequest}
+          lastQueryRequest={getLastQueryRequest!()}
+          frontText={'Displaying'}
+        />
+      )}
+      {/* ReactCSSTransitionGroup adds css fade in property for cards that come into view */}
+      {cards}
+      {showViewMoreButton}
+    </div>
+  )
 }
 
 export default CardContainer

--- a/src/lib/containers/HeaderCard.tsx
+++ b/src/lib/containers/HeaderCard.tsx
@@ -20,7 +20,7 @@ export type HeaderCardProps = {
   values?: string[][]
   isAlignToLeftNav?: boolean
   descriptionLinkConfig?: MarkdownValue
-  linkDisplay?: string
+  href?: string
   target?: string
 }
 
@@ -36,7 +36,7 @@ const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
   secondaryLabelLimit,
   isAlignToLeftNav,
   descriptionLinkConfig,
-  linkDisplay,
+  href,
   target,
   rgbIndex,
 }) => {
@@ -101,8 +101,8 @@ const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
                 className="SRC-boldText SRC-blackText"
                 style={{ margin: 'none' }}
               >
-                {linkDisplay ? (
-                  <a target={target} href={linkDisplay}>
+                {href ? (
+                  <a target={target} href={href}>
                     {title}
                   </a>
                 ) : (

--- a/src/lib/containers/row_renderers/utils/Icon.tsx
+++ b/src/lib/containers/row_renderers/utils/Icon.tsx
@@ -11,6 +11,7 @@ import {
   COMPUTATIONAL,
   CLINICAL,
   PROJECT,
+  GRANT,
 } from '../../../utils/SynapseConstants'
 
 import Data2Svg from '../../../assets/icons/Data2.svg'
@@ -49,6 +50,7 @@ const defaultIcons = {
   [COMPUTATIONAL]: ToolComputational,
   [CLINICAL]: ToolClinical,
   [PROJECT]: Project,
+  [GRANT]: Project,
 }
 const Icon: React.FunctionComponent<IconProps> = ({
   type,

--- a/src/lib/containers/widgets/FileHandleLink.tsx
+++ b/src/lib/containers/widgets/FileHandleLink.tsx
@@ -1,0 +1,61 @@
+import { FileHandleAssociateType } from '../../utils/synapseTypes'
+import React from 'react'
+import { SynapseConstants, SynapseClient } from '../../'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+type FileHandleLinkProps = {
+  token: string | undefined
+  fileHandleId: string
+  redirect?: boolean
+  showDownloadIcon: boolean
+  tableEntityType: string | undefined
+  rowId: string | undefined
+  tableId: string | undefined
+  displayValue: string | undefined
+}
+export const FileHandleLink = (props: FileHandleLinkProps) => {
+  const {
+    token,
+    fileHandleId,
+    showDownloadIcon,
+    tableEntityType,
+    rowId,
+    tableId,
+    redirect = false,
+    displayValue,
+  } = props
+
+  if (!tableEntityType) {
+    // still loading
+    return <></>
+  }
+  const isFileView = tableEntityType.includes('EntityView')
+  const fileAssociateType: FileHandleAssociateType = isFileView
+    ? FileHandleAssociateType.FileEntity
+    : FileHandleAssociateType.TableEntity
+  const fileAssociateId = isFileView ? rowId : tableId
+  return (
+    <button
+      // @ts-ignore
+      onClick={() => {
+        if (token && fileAssociateId) {
+          SynapseClient.getActualFileHandleByIdURL(
+            fileHandleId,
+            token,
+            fileAssociateType,
+            fileAssociateId,
+            redirect,
+          )
+        }
+      }}
+      className={`SRC-primary-text-color ${SynapseConstants.SRC_SIGN_IN_CLASS}`}
+      type="button"
+      style={{ padding: 0 }}
+    >
+      {displayValue ?? fileHandleId}
+      {showDownloadIcon && (
+        <FontAwesomeIcon style={{ marginLeft: 5 }} icon="download" />
+      )}
+    </button>
+  )
+}

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -375,7 +375,35 @@ export const getFileHandleById = (
 }
 
 /**
+ * http://rest-docs.synapse.org/rest/GET/file/id.html
+ * Get the actual URL of the file from with an associated object .
+ * @return a short lived presignedURL to be redirected with
+ **/
+export const getActualFileHandleByIdURL = (
+  handleId: string,
+  sessionToken: string | undefined = undefined,
+  fileAssociateType: FileHandleAssociateType,
+  fileAssociateId: string,
+  redirect: boolean = true,
+) => {
+  // get the presigned URL for this file handle and open it in a new tab
+  doGet<string>(
+    `/file/v1/file/${handleId}?fileAssociateType=${fileAssociateType}&fileAssociateId=${fileAssociateId}&redirect=${redirect}`,
+    sessionToken,
+    undefined,
+    BackendDestinationEnum.REPO_ENDPOINT,
+  )
+    .then(url => {
+      window.open(url, '_blank')
+    })
+    .catch(err => {
+      console.error('Error on retrieving file handle url ', err)
+    })
+}
+
+/**
  * https://docs.synapse.org/rest/GET/fileHandle/handleId/url.html
+ * Note: Only the user that created the FileHandle can use this method for download.
  * @return a short lived presignedURL to be redirected with
  **/
 export const getFileHandleByIdURL = (

--- a/src/lib/utils/SynapseConstants.ts
+++ b/src/lib/utils/SynapseConstants.ts
@@ -40,6 +40,7 @@ export const COMPUTATIONAL: string = 'computational'
 export const EXPERIMENTAL: string = 'experimental'
 export const CLINICAL: string = 'clinical'
 export const PROJECT: string = 'Project'
+export const GRANT: string = 'Grant'
 export const PAGE_SIZE: number = 25
 // For User Profile Cards
 export const SMALL_USER_CARD: UserCardSize = 'SMALL USER CARD'
@@ -52,12 +53,12 @@ export const _TIME_DELAY = 75
 export const SRC_SIGN_IN_CLASS = 'SRC-SIGN-IN-CLASS'
 
 // UserBundle constants
-export const USER_BUNDLE_MASK_USER_PROFILE = 0X1;
-export const USER_BUNDLE_MASK_ORCID = 0X2;
-export const USER_BUNDLE_MASK_VERIFICATION_SUBMISSION = 0X4;
-export const USER_BUNDLE_MASK_IS_CERTIFIED = 0X8;
-export const USER_BUNDLE_MASK_IS_VERIFIED = 0X10;
-export const USER_BUNDLE_MASK_IS_ACT_MEMBER = 0X2;
+export const USER_BUNDLE_MASK_USER_PROFILE = 0x1
+export const USER_BUNDLE_MASK_ORCID = 0x2
+export const USER_BUNDLE_MASK_VERIFICATION_SUBMISSION = 0x4
+export const USER_BUNDLE_MASK_IS_CERTIFIED = 0x8
+export const USER_BUNDLE_MASK_IS_VERIFIED = 0x10
+export const USER_BUNDLE_MASK_IS_ACT_MEMBER = 0x2
 // SessionStorage keys for info from ids
-export const USER_PROFILE_STORAGE_KEY = 'INFO_FROM_IDS_USER_PROFILE';
-export const ENTITY_HEADER_STORAGE_KEY = 'INFO_FROM_IDS_ENTITY_HEADER';
+export const USER_PROFILE_STORAGE_KEY = 'INFO_FROM_IDS_USER_PROFILE'
+export const ENTITY_HEADER_STORAGE_KEY = 'INFO_FROM_IDS_ENTITY_HEADER'

--- a/src/lib/utils/hooks/useGetInfoFromIds.ts
+++ b/src/lib/utils/hooks/useGetInfoFromIds.ts
@@ -10,7 +10,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect'
 export type HookType = 'ENTITY_HEADER' | 'USER_PROFILE'
 export type UseGetInfoFromIdsProps = {
   ids: string[]
-  token?: string
+  token: string | undefined
   type: HookType
 }
 

--- a/src/lib/utils/synapseTypes/FileHandleAssociation.ts
+++ b/src/lib/utils/synapseTypes/FileHandleAssociation.ts
@@ -1,3 +1,4 @@
+// http://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/file/FileHandleAssociateType.html
 export enum FileHandleAssociateType {
   FileEntity = 'FileEntity',
   TableEntity = 'TableEntity',


### PR DESCRIPTION
CardContainer 
- Convert to a react hook so that the useGetInfoFromIds hook could retrieve the entity concrete type from the data being passed in

Generic Card
- Take in new props `tableId`, `tableEntityConcreteType` to support linking the filehandleId, initially only supporting the link from the title, but this will eventually need to get added to the secondary label rendering as well as the synapsetable cell renderer
- Added a test to validate that the FileHandleLink component receives the right props
- renamed variable returned from renderTitleLink: linkDisplay -> href

(clicking on the title **5XFAD** will take you to the file handle download)
![image](https://user-images.githubusercontent.com/20282487/87445861-6f90dc00-c5ad-11ea-9511-e1845d9ecbde.png)


SynapseClient
- Added new API call for getting file handle URL

