### PR TITLE
simplify api retry logic, add error message to querywrapper

### DIFF
--- a/src/__tests__/lib/containers/TotalQueryResults.test.tsx
+++ b/src/__tests__/lib/containers/TotalQueryResults.test.tsx
@@ -7,6 +7,7 @@ import {
   QueryResultBundle,
   RowSet,
   QueryBundleRequest,
+  ColumnType,
 } from '../../../lib/utils/synapseTypes/'
 import { SynapseConstants } from 'lib'
 import { act } from 'react-dom/test-utils'
@@ -46,14 +47,14 @@ describe('it works', () => {
       {
         id: '111488',
         name: 'studyStatus',
-        columnType: 'STRING',
+        columnType: ColumnType.STRING,
         maximumSize: 50,
         facetType: 'enumeration',
       },
       {
         id: '111489',
         name: 'dataStatus',
-        columnType: 'STRING',
+        columnType: ColumnType.STRING,
         maximumSize: 20,
         facetType: 'enumeration',
       },
@@ -117,7 +118,7 @@ describe('it works', () => {
     const { wrapper } = await createMountedComponent(props)
     await actions(wrapper, () => {
       expect(wrapper.find('.SRC-boldText').text()).toContain(
-        `${displayText} ${mockQueryReturn.queryCount} ${unitDescription} `,
+        `${displayText} ${mockQueryReturn.queryCount} ${unitDescription}`,
       )
       expect(mockGetQueryTableResultsFn).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/lib/containers/Error.tsx
+++ b/src/lib/containers/Error.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SynapseClientError } from 'lib/utils/SynapseClient'
+import { SynapseClientError } from '../utils/SynapseClient'
 import SignInButton from './SignInButton'
 import Alert from 'react-bootstrap/Alert'
 type ErrorProps = {

--- a/src/lib/containers/Error.tsx
+++ b/src/lib/containers/Error.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { SynapseClientError } from 'lib/utils/SynapseClient'
+import SignInButton from './SignInButton'
+import Alert from 'react-bootstrap/Alert'
+type ErrorProps = {
+  error?: SynapseClientError
+}
+
+export const Error = (props: ErrorProps) => {
+  const { error } = props
+
+  if (!error) {
+    return <></>
+  }
+
+  return (
+    <div className="Error">
+      <Alert
+        dismissible={false}
+        show={true}
+        variant={'danger'}
+        transition={'div'}
+      >
+        {error.status === 403 && (
+          <p>
+            Please <SignInButton /> to view this resource.
+          </p>
+        )}
+        <p>{error.reason}</p>
+      </Alert>
+    </div>
+  )
+}

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -52,6 +52,7 @@ type HasAccessState = {
   accessRequirements?: Array<AccessRequirement>
   isGettingRestrictionInformation: boolean
   isGettingEntityInformation: boolean
+  errorOnGetRestrictionInformation: boolean
 }
 
 export enum ExternalFileHandleConcreteTypeEnum {
@@ -148,6 +149,7 @@ export default class HasAccess extends React.Component<
       accessRequirements: [],
       isGettingEntityInformation: false,
       isGettingRestrictionInformation: false,
+      errorOnGetRestrictionInformation: false,
     }
   }
 
@@ -164,7 +166,8 @@ export default class HasAccess extends React.Component<
   refresh = (forceRefresh?: boolean) => {
     if (
       this.state.isGettingEntityInformation ||
-      this.state.isGettingRestrictionInformation
+      this.state.isGettingRestrictionInformation ||
+      this.state.errorOnGetRestrictionInformation
     ) {
       return
     }
@@ -265,7 +268,13 @@ export default class HasAccess extends React.Component<
         })
       })
       .catch(err => {
-        console.error('Error on getRestrictionInformation: ', err)
+        console.error(
+          'Error on getRestrictionInformation. This should not happen: ',
+          err,
+        )
+        this.setState({
+          errorOnGetRestrictionInformation: true,
+        })
       })
       .finally(() => {
         this.setState({

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -363,7 +363,7 @@ export default class QueryWrapper extends React.Component<
         this.setState(newState)
       })
       .catch(error => {
-        console.log('Failed to get data ', error)
+        console.error('Failed to get data ', error)
         this.setState({
           error,
         })

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -10,6 +10,7 @@ import {
   QueryResultBundle,
 } from '../utils/synapseTypes/'
 import { cloneDeep } from 'lodash-es'
+import { SynapseClientError } from '../utils/SynapseClient'
 export type QueryWrapperProps = {
   visibleColumnCount?: number
   initQueryRequest: QueryBundleRequest
@@ -62,6 +63,7 @@ export type QueryWrapperState = {
   searchQuery: SearchQuery
   isColumnSelected: string[]
   selectedRowIndices?: number[]
+  error: SynapseClientError | undefined
 }
 
 export type FacetSelection = {
@@ -99,6 +101,7 @@ export type QueryWrapperChildProps = {
   searchQuery?: SearchQuery
   isColumnSelected?: string[]
   selectedRowIndices?: number[]
+  error?: SynapseClientError | undefined
 }
 
 /**
@@ -149,6 +152,7 @@ export default class QueryWrapper extends React.Component<
       },
       isColumnSelected: [],
       selectedRowIndices: [],
+      error: undefined,
     }
     this.componentIndex = props.componentIndex || 0
   }
@@ -253,13 +257,16 @@ export default class QueryWrapper extends React.Component<
         const newState = {
           hasMoreData,
           data,
-          isLoading: false,
           asyncJobStatus: undefined,
         }
         this.setState(newState)
       })
-      .catch((err: string) => {
-        console.log('Failed to get data ', err)
+      .catch(error => {
+        console.error('Failed to get data ', error)
+        this.setState(error)
+      })
+      .finally(() => {
+        this.setState({ isLoading: false, isLoadingNewData: false })
       })
   }
 
@@ -355,8 +362,11 @@ export default class QueryWrapper extends React.Component<
         }
         this.setState(newState)
       })
-      .catch(err => {
-        console.log('Failed to get data ', err)
+      .catch(error => {
+        console.log('Failed to get data ', error)
+        this.setState({
+          error,
+        })
       })
       .finally(() => {
         this.setState({
@@ -396,6 +406,7 @@ export default class QueryWrapper extends React.Component<
         searchQuery: this.state.searchQuery,
         isColumnSelected: this.state.isColumnSelected,
         selectedRowIndices: this.state.selectedRowIndices,
+        error: this.state.error,
         executeInitialQueryRequest: this.executeInitialQueryRequest,
         executeQueryRequest: this.executeQueryRequest,
         getLastQueryRequest: this.getLastQueryRequest,

--- a/src/lib/containers/SignInButton.tsx
+++ b/src/lib/containers/SignInButton.tsx
@@ -12,7 +12,7 @@ const SignInButton = ({ className, style }: SignInProps) => {
     <button
       type="button"
       style={style}
-      className={`${SRC_SIGN_IN_CLASS} ${className}`}
+      className={`SignInButton ${SRC_SIGN_IN_CLASS} SRC-primary-text-color ${className}`}
     >
       Sign In
     </button>

--- a/src/lib/containers/TotalQueryResults.tsx
+++ b/src/lib/containers/TotalQueryResults.tsx
@@ -53,6 +53,7 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
   updateParentState,
   searchQuery,
   showNotch = false,
+  error,
 }) => {
   const [total, setTotal] = useState<number | undefined>(undefined) // undefined to start
   const [isLoading, setIsLoading] = useState(false)
@@ -244,13 +245,16 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
     <></>
   )
 
+  if (error) {
+    return <></>
+  }
   return (
     <div
       className={`TotalQueryResults ${showNotch ? 'notch-down' : ''}`}
       style={style}
     >
       <span className="SRC-boldText SRC-text-title SRC-centerContent">
-        {frontText} {total} {unitDescription}{' '}
+        {frontText} {total} {unitDescription}
         {isLoading && (
           <span style={{ marginLeft: '2px' }} className={'spinner'} />
         )}

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -9,6 +9,7 @@ import {
 import { SynapseConstants } from '../../utils/'
 import { QueryBundleRequest } from '../../utils/synapseTypes'
 import { CardConfiguration } from '../CardContainerLogic'
+import { Error } from '../Error'
 import FilterAndView from './FilterAndView'
 import { TopLevelControlsProps } from './TopLevelControls'
 import TopLevelControls from './TopLevelControls'
@@ -94,6 +95,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
           hideDownload={hideDownload}
         />
         <SearchV2 {...searchConfiguration} />
+        <Error />
         <DownloadConfirmation />
         <FacetNav
           facetsToPlot={facetsToPlot}

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -523,11 +523,8 @@ export default class SynapseTable extends React.Component<
       </button>
     )
 
-    let isShowingAccessColumn: boolean | undefined = showAccessColumn
-    if (showAccessColumn && rows.length > 0) {
-      // PORTALS-924: verify that row actualy contains a defined rowId
-      isShowingAccessColumn = rows[0].rowId !== undefined
-    }
+    let isShowingAccessColumn: boolean | undefined =
+      showAccessColumn && this.state.isFileView
     /* min height ensure if no rows are selected that a dropdown menu is still accessible */
     return (
       <div style={{ minHeight: '300px' }} className="SRC-overflowAuto">

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -96,10 +96,10 @@ const PREVIOUS = 'PREVIOUS'
 type Direction = '' | 'ASC' | 'DESC'
 export const SORT_STATE: Direction[] = ['', 'DESC', 'ASC']
 export const DOWNLOAD_OPTIONS_CONTAINER_CLASS = 'SRC-download-options-container'
-const RESIZER_OPTIONS:any = {
+const RESIZER_OPTIONS: any = {
   resizeMode: 'overflow',
   partialRefresh: 'true',
-  liveDrag:true,
+  liveDrag: true,
   headerOnly: 'true',
 }
 type Info = {
@@ -151,9 +151,9 @@ export default class SynapseTable extends React.Component<
     this.advancedSearch = this.advancedSearch.bind(this)
     this.getLengthOfPropsData = this.getLengthOfPropsData.bind(this)
     this.configureFacetDropdown = this.configureFacetDropdown.bind(this)
-    this.enableResize = this.enableResize.bind(this);
-    this.disableResize = this.disableResize.bind(this);
-    
+    this.enableResize = this.enableResize.bind(this)
+    this.disableResize = this.disableResize.bind(this)
+
     // store the offset and sorted selection that is currently held
     this.state = {
       /* columnIconSortState tells what icon to display for a table
@@ -178,11 +178,10 @@ export default class SynapseTable extends React.Component<
     }
     this.getEntityHeadersInData = this.getEntityHeadersInData.bind(this)
   }
-  
-  // instance variables
-  resizer:any
-  tableElement:HTMLTableElement|null|undefined = undefined
 
+  // instance variables
+  resizer: any
+  tableElement: HTMLTableElement | null | undefined = undefined
 
   componentWillUnmount() {
     this.disableResize()
@@ -193,9 +192,15 @@ export default class SynapseTable extends React.Component<
     this.enableResize()
   }
 
-  shouldComponentUpdate(nextProps: QueryWrapperChildProps & SynapseTableProps, nextState: Readonly<SynapseTableState>, nextContext: any): boolean {
+  shouldComponentUpdate(
+    nextProps: QueryWrapperChildProps & SynapseTableProps,
+    nextState: Readonly<SynapseTableState>,
+    nextContext: any,
+  ): boolean {
     this.disableResize()
-    return super.shouldComponentUpdate ? super.shouldComponentUpdate(nextProps, nextState, nextContext) : true
+    return super.shouldComponentUpdate
+      ? super.shouldComponentUpdate(nextProps, nextState, nextContext)
+      : true
   }
   componentDidUpdate(prevProps: QueryWrapperChildProps & SynapseTableProps) {
     this.getEntityHeadersInData(prevProps.token !== this.props.token)
@@ -232,19 +237,16 @@ export default class SynapseTable extends React.Component<
   enableResize() {
     if (!this.resizer) {
       if (this.tableElement) {
-        this.resizer = new ColumnResizer(
-          this.tableElement,
-          RESIZER_OPTIONS
-        )
+        this.resizer = new ColumnResizer(this.tableElement, RESIZER_OPTIONS)
       }
     } else {
-      this.resizer.reset(RESIZER_OPTIONS);
+      this.resizer.reset(RESIZER_OPTIONS)
     }
   }
 
   disableResize() {
     if (this.resizer) {
-      this.resizer.reset({ disable: true });
+      this.resizer.reset({ disable: true })
     }
   }
 
@@ -343,8 +345,10 @@ export default class SynapseTable extends React.Component<
    * Display the view
    */
   public render() {
-    if (this.props.data === undefined) {
+    if (this.props.isLoadingNewData) {
       return this.props.loadingScreen ?? <div />
+    } else if (!this.props.data) {
+      return <></>
     }
     // unpack all the data
     const {
@@ -538,7 +542,10 @@ export default class SynapseTable extends React.Component<
             }
           />
         )}
-        <table ref={node => this.tableElement = node} className="table table-striped table-condensed">
+        <table
+          ref={node => (this.tableElement = node)}
+          className="table table-striped table-condensed"
+        >
           <thead className="SRC_bordered">
             <tr>
               {this.createTableHeader(

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -52,6 +52,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   updateParentState,
   facetAliases,
   showNotch = false,
+  error,
 }: FacetNavProps): JSX.Element => {
   const [facetUiStateArray, setFacetUiStateArray] = useState<UiFacetState[]>([])
   const [isFirstTime, setIsFirstTime] = useState(true)
@@ -186,7 +187,9 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   })
   const showMoreState = getShowMoreState()
 
-  if (isLoadingNewData || !data) {
+  if (error) {
+    return <></>
+  } else if (isLoadingNewData) {
     return (
       <div className="SRC-loadingContainer SRC-centerContentColumn">
         {loadingScreen}

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -1095,3 +1095,7 @@ hr ~ .SRC-wrapper {
     }
   }
 }
+
+.SignInButton {
+  padding: 0px;
+}

--- a/src/lib/style/components/_all.scss
+++ b/src/lib/style/components/_all.scss
@@ -5,4 +5,4 @@
   './download-link', './total-query-results', './facet_nav/all',
   './query-wrapper-plot-nav', './searchv2', './element-with-tooltip',
   './_column-selection.scss', './programmatic-options',
-  './query_filter/enum-facet-filter';
+  './query_filter/enum-facet-filter', './error';

--- a/src/lib/style/components/_cards.scss
+++ b/src/lib/style/components/_cards.scss
@@ -241,6 +241,7 @@ img.iconImg.SRC-datasetIcon {
   h3 {
     margin: $baseline-grid, 0, $baseline-grid/2, 0 !important;
     color: white;
+    line-height: 125%;
     padding: 0;
     font-size: $text-size-title !important;
     a {

--- a/src/lib/style/components/_error.scss
+++ b/src/lib/style/components/_error.scss
@@ -1,0 +1,8 @@
+.Error {
+  div {
+    text-align: center;
+  }
+  p {
+    color: rgb(102, 102, 102);
+  }
+}


### PR DESCRIPTION
Example of error message showing up -
![image](https://user-images.githubusercontent.com/20282487/87807405-0c04e980-c80d-11ea-926c-cdfeb052876e.png)

SynapseClient -
simplified logic
removed retry count and only use exponential backoff
expand number of cases when backoff is used, including 500 error codes
added new SynapseClientError type

HasAccess -
Catch 404 error and prevent infinite loop 😅 

SynapseTable - 
Fix check for rendering hasaccess column to see that underlying entity is of type EntityView
