### PR TITLE
PORTALS-1508

### DIFF
--- a/src/__tests__/lib/containers/SynapseTable.test.tsx
+++ b/src/__tests__/lib/containers/SynapseTable.test.tsx
@@ -1,8 +1,12 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import { EntityLink } from 'lib/containers/EntityLink'
 import MarkdownSynapse from 'lib/containers/MarkdownSynapse'
-import { ColumnSelection } from 'lib/containers/table/table-top'
+import {
+  ColumnSelection,
+  EllipsisDropdown,
+  ExpandTable,
+} from 'lib/containers/table/table-top'
 import { EnumFacetFilter } from 'lib/containers/widgets/query-filter/EnumFacetFilter'
 import UserCard from 'lib/containers/UserCard'
 import { unCamelCase } from 'lib/utils/functions/unCamelCase'
@@ -31,13 +35,14 @@ import SynapseTable, {
 } from '../../../lib/containers/table/SynapseTable'
 import syn16787123Json from '../../../mocks/syn16787123.json'
 import { cloneDeep } from 'lodash-es'
+import { act } from '@testing-library/react'
+import HasAccess from 'lib/containers/HasAccess'
+import ModalDownload from 'lib/containers/ModalDownload'
 
 const createShallowComponent = (
   props: SynapseTableProps & QueryWrapperChildProps,
 ) => {
-  const wrapper = shallow<SynapseTable>(<SynapseTable {...props} />, {
-    disableLifecycleMethods: true,
-  })
+  const wrapper = mount<SynapseTable>(<SynapseTable {...props} />)
   const instance = wrapper.instance()
   return { wrapper, instance }
 }
@@ -116,6 +121,16 @@ describe('basic functionality', () => {
     expect(wrapper).toBeDefined()
   })
 
+  it('Does not renders HasAccess when the entity type is not EntityView', async () => {
+    const { wrapper, instance } = createShallowComponent({
+      ...props,
+      showAccessColumn: true,
+    })
+    expect(wrapper).toBeDefined()
+    expect(instance.state.isFileView).toEqual(false)
+    expect(wrapper.find(HasAccess)).toHaveLength(0)
+  })
+
   it('updates correctly', async () => {
     const mockEntityCall = jest.fn().mockResolvedValue({
       concreteType: 'EntityView',
@@ -154,22 +169,86 @@ describe('basic functionality', () => {
     })
   })
 
-  describe('Dropdown column menu works', () => {
+  describe('Dropdown column menu works when opened from the icon or ellipsis dreopdown', () => {
     it('renders with the correct props', async () => {
       const { wrapper } = createShallowComponent(props)
       expect(wrapper.find(ColumnSelection).props().headers).toEqual(
         syn16787123Json.queryResult.queryResults.headers,
       )
     })
+    it('opens from primary icon', () => {
+      const { wrapper } = createShallowComponent(props)
+      const columnSelection = wrapper.find(ColumnSelection)
+      expect(columnSelection.props().show).toEqual(false)
+      // click the dropdown menu open
+      act(() => {
+        columnSelection.find('button').simulate('click')
+      })
+      // see that the column selection is now open
+      expect(wrapper.update().find(ColumnSelection).props().show).toEqual(true)
+    })
+    it('opens from clicking the ellipsis dropdown menu', () => {
+      const { wrapper } = createShallowComponent(props)
+      const columnSelection = wrapper.find(ColumnSelection)
+      expect(columnSelection.props().show).toEqual(false)
+      const ellipsisDropdown = wrapper.find(EllipsisDropdown)
+      // click the dropdown menu open
+      act(() => {
+        ellipsisDropdown.find('button').simulate('click')
+      })
+      // click the column selection button
+      act(() => {
+        ellipsisDropdown.update().find('a').at(1).simulate('click')
+      })
+      // see that the column selection is now open
+      expect(wrapper.update().find(ColumnSelection).props().show).toEqual(true)
+    })
   })
-  describe('Expand modal opens when isExpanded is set to true', () => {
-    it('works', async () => {
-      const { wrapper } = await createShallowComponent(props)
+  describe('Expand modal opens from ExpandTable and the EllipsisDropdown', () => {
+    it('opens when clicking the expand icon', () => {
+      const { wrapper } = createShallowComponent(props)
       // No modal to start
       expect(wrapper.find(Modal)).toHaveLength(0)
-      await wrapper.setState({ isExpanded: true })
+      const expandTable = wrapper.find(ExpandTable)
+      act(() => {
+        expandTable.find('button').simulate('click')
+      })
       // Modal is open now
-      expect(wrapper.find(Modal)).toHaveLength(1)
+      expect(wrapper.update().find(Modal)).toHaveLength(1)
+    })
+    it('opens when clicking the ellipsis dropdown menu', () => {
+      const { wrapper } = createShallowComponent(props)
+      // No modal to start
+      expect(wrapper.find(Modal)).toHaveLength(0)
+      const ellipsisDropdown = wrapper.find(EllipsisDropdown)
+      // click the dropdown menu open
+      act(() => {
+        ellipsisDropdown.find('button').simulate('click')
+      })
+      // click the full screen button
+      act(() => {
+        ellipsisDropdown.update().find('a').at(2).simulate('click')
+      })
+      // Modal is open now
+      expect(wrapper.update().find(Modal)).toHaveLength(1)
+    })
+  })
+  describe('Export table works', () => {
+    it('works', () => {
+      const { wrapper } = createShallowComponent(props)
+      // No modal to start
+      expect(wrapper.find(ModalDownload)).toHaveLength(0)
+      const ellipsisDropdown = wrapper.find(EllipsisDropdown)
+      // click the dropdown menu open
+      act(() => {
+        ellipsisDropdown.find('button').simulate('click')
+      })
+      // click the downlaod table only button
+      act(() => {
+        ellipsisDropdown.update().find('a').at(0).simulate('click')
+      })
+      // Modal is open now
+      expect(wrapper.update().find(ModalDownload)).toHaveLength(1)
     })
   })
   describe('PORTALS-527: aggregate query support (show underlying data)', () => {

--- a/src/demo/containers/playground/Playground.tsx
+++ b/src/demo/containers/playground/Playground.tsx
@@ -16,6 +16,7 @@ import { WidgetDemo } from './WidgetDemo'
 import { RouteChildrenProps } from 'react-router'
 import { AccessRequirementDemo } from './AccessRequirementDemo'
 import TemplateComponentDemo from './TemplateComponentDemo'
+import { ThemesPlotDemo } from './ThemesPlotDemo'
 
 /**
  * Demo of features that can be used from src/demo/utils/SynapseClient
@@ -97,6 +98,9 @@ const App = ({
         </li>
         <li>
           <Link to={`${match.url}/ShowDownloadDemo`}>ShowDownloadDemo</Link>
+        </li>
+        <li>
+          <Link to={`${match.url}/ThemesPlotDemo`}>ThemesPlotDemo</Link>
         </li>
       </ul>
 
@@ -196,6 +200,12 @@ const App = ({
         exact={true}
         path={`${match.url}/ShowDownloadDemo`}
         component={() => <ShowDownloadDemo token={token} />}
+      />
+
+      <Route
+        exact={true}
+        path={`${match.url}/ThemesPlotDemo`}
+        component={ThemesPlotDemo}
       />
 
       <Route exact={true} path={match.path} component={() => <div />} />

--- a/src/demo/containers/playground/QueryWrapperMenuDemo.tsx
+++ b/src/demo/containers/playground/QueryWrapperMenuDemo.tsx
@@ -86,7 +86,7 @@ class QueryWrapperMenuDemo extends React.Component<
         menuConfig: [
           {
             facet: 'resourceType',
-            sql: 'SELECT id, name, resourceType FROM syn11346063 LIMIT 1000',
+            sql: 'SELECT id, name, resourceType FROM syn11346063 LIMIT 1',
           },
           {
             facet: 'study',

--- a/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
+++ b/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
@@ -31,7 +31,7 @@ class QueryWrapperPlotNavDemo extends React.Component<
    */
   constructor(props: any) {
     super(props)
-    const sql: string = 'SELECT assay FROM syn11346063'
+    const sql: string = 'SELECT assay FROM syn11346063 limit 1'
     this.state = {
       isLoading: true,
       ownerId: '',

--- a/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
+++ b/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
@@ -31,7 +31,7 @@ class QueryWrapperPlotNavDemo extends React.Component<
    */
   constructor(props: any) {
     super(props)
-    const sql: string = 'SELECT assay FROM syn11346063 limit 1'
+    const sql: string = 'SELECT assay FROM syn11346063 limit 1000'
     this.state = {
       isLoading: true,
       ownerId: '',

--- a/src/demo/containers/playground/ThemesPlotDemo.tsx
+++ b/src/demo/containers/playground/ThemesPlotDemo.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import ThemesPlot from 'lib/containers/widgets/themes-plot/ThemesPlot'
+
+export const ThemesPlotDemo = () => {
+  return (
+    <ThemesPlot
+      onPointClick={e => {
+        console.log(e.event.shiftKey) // shift
+        console.log(e.event.ctrlKey) // ctrl
+        console.log(e.event.altKey) // alt
+        console.log(e.event.metaKey) // command/windows (meta) key
+      }}
+      topBarPlot={{
+        entityId: 'syn21641485',
+        xField: 'totalCount',
+        yField: 'groupBy',
+        groupField: 'consortium',
+        colors: {
+          CSBC: 'rgba(64,123,160, 1)',
+          'PS-ON': 'rgba(91,176,181,1)',
+          ICBP: 'rgba(197, 191, 223, 1)',
+          TEC: 'rgba(156, 196, 233, 1)',
+        },
+        whereClause: 'totalCount is not NULL',
+      }}
+      sideBarPlot={{
+        entityId: 'syn21649281',
+        xField: 'totalCount',
+        yField: 'theme',
+        groupField: 'consortium',
+        countLabel: 'grants',
+        plotStyle: {
+          backgroundColor: '#f5f9fa',
+        },
+        colors: {
+          CSBC: '#1c76af',
+          'PS-ON': '#5bb0b5',
+          ICBP: '#9cc4e9',
+          TEC: '#c5bfdf',
+        },
+      }}
+      dotPlot={{
+        entityId: 'syn21639584',
+        xField: 'totalCount',
+        yField: 'theme',
+        groupField: 'groupBy',
+        infoField: 'themeDescription',
+        whereClause: "groupBy IN ('publications', 'tools', 'datasets')",
+        markerSymbols: {
+          tools: 'y-down',
+          datasets: 'diamond-x',
+          publications: 'circle',
+        },
+        plotStyle: {
+          markerLine: 'rgba(0, 0, 0,1)',
+          markerFill: 'rgba(255, 255, 255,1)',
+          markerSize: 11,
+          backgroundColor: '#f5f9fa',
+        },
+      }}
+    />
+  )
+}

--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -114,10 +114,10 @@ export const CardContainer = (props: CardContainerProps) => {
   showViewMore = showViewMore && props.hasMoreData!
 
   const showViewMoreButton = showViewMore && (
-    <div>
+    <div className="SRC-viewMore">
       <button
         onClick={handleViewMore}
-        className="pull-right SRC-standard-button-shape SRC-light-button"
+        className="SRC-standard-button-shape SRC-light-button"
       >
         View More
       </button>

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -240,7 +240,10 @@ export default class HasAccess extends React.Component<
         }
       })
       .catch(err => {
-        console.error('Error on get Entity = ', err)
+        // this could be a self-imposed error or one from the backend, only log the latter
+        if (err.reason) {
+          console.error('Error on get Entity = ', err)
+        }
         // could not get entity
         this.updateStateFileHandleAccessBlocked()
         this.setState({

--- a/src/lib/containers/query_wrapper_plot_nav/TopLevelControls.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/TopLevelControls.tsx
@@ -204,7 +204,6 @@ const TopLevelControls = (
           <ColumnSelection
             headers={data?.selectColumns}
             isColumnSelected={isColumnSelected!}
-            show={topLevelControlsState?.showColumnSelectDropdown ?? false}
             toggleColumnSelection={toggleColumnSelection}
             darkTheme={true}
             facetAliases={facetAliases}

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -425,14 +425,8 @@ export default class SynapseTable extends React.Component<
                 />
               </div>
             )}
-
           {!isFilterAndViewChild && this.renderTableTop(headers)}
-          {!enableLeftFacetFilter && (
-            <>
-              <div className="row">{table}</div>
-            </>
-          )}
-          {enableLeftFacetFilter && <div className={'col-xs-12'}>{table}</div>}
+          {enableLeftFacetFilter ? table : <div className="row">{table}</div>}
         </div>
       </>
     )

--- a/src/lib/containers/table/table-top/ColumnSelection.tsx
+++ b/src/lib/containers/table/table-top/ColumnSelection.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { Dropdown } from 'react-bootstrap'
 import { ElementWithTooltip } from '../../widgets/ElementWithTooltip'
 import { SelectColumn } from '../../../utils/synapseTypes/'
@@ -15,7 +15,8 @@ type ColumnSelectionProps = {
       The dropdown state is held in SynapseTable because the EllipsisDropdown has
       an option to open the dropdown, 'show columns'
     */
-  show: boolean
+  show?: boolean
+  onChange?: Function
   toggleColumnSelection: (name: string) => void
   darkTheme?: boolean
   facetAliases?: {}
@@ -32,9 +33,15 @@ export const ColumnSelection: React.FunctionComponent<ColumnSelectionProps> = (
     toggleColumnSelection,
     darkTheme,
     facetAliases,
+    show: showFromProps,
+    onChange,
   } = props
 
-  const [show, setShow] = useState(false)
+  let [show, setShow] = useState(false)
+
+  let [usedShow, usedSetShow] =
+    showFromProps !== undefined ? [showFromProps, onChange!] : [show, setShow]
+
   const onDropdownClick = (
     _show: boolean,
     _event: React.SyntheticEvent<Dropdown<'div'>, Event>,
@@ -45,9 +52,9 @@ export const ColumnSelection: React.FunctionComponent<ColumnSelectionProps> = (
     // is defined the event occuring is inside the dropdown which we then want to keep open, otherwise
     // we close it.
     if (metadata.source) {
-      setShow(true)
+      usedSetShow(true)
     } else {
-      setShow(false)
+      usedSetShow(false)
     }
   }
   return (
@@ -56,7 +63,7 @@ export const ColumnSelection: React.FunctionComponent<ColumnSelectionProps> = (
       onToggle={(show: boolean, event: any, metadata: any) =>
         onDropdownClick(show, event, metadata)
       }
-      show={show}
+      show={usedShow}
     >
       <ElementWithTooltip
         idForToolTip={tooltipColumnSelectionId}

--- a/src/lib/containers/table/table-top/ColumnSelection.tsx
+++ b/src/lib/containers/table/table-top/ColumnSelection.tsx
@@ -64,6 +64,7 @@ export const ColumnSelection: React.FunctionComponent<ColumnSelectionProps> = (
         onDropdownClick(show, event, metadata)
       }
       show={usedShow}
+      drop="down"
     >
       <ElementWithTooltip
         idForToolTip={tooltipColumnSelectionId}
@@ -82,7 +83,7 @@ export const ColumnSelection: React.FunctionComponent<ColumnSelectionProps> = (
         className="SRC-primary-color-hover-dropdown"
         alignRight={true}
       >
-        {headers?.map((header, index) => {
+        {headers?.map(header => {
           const { name } = header
           const isCurrentColumnSelected = isColumnSelected.includes(name)
           const iconStyle: React.CSSProperties = {

--- a/src/lib/containers/table/table-top/DownloadOptions.tsx
+++ b/src/lib/containers/table/table-top/DownloadOptions.tsx
@@ -36,6 +36,7 @@ export const DownloadOptions: React.FunctionComponent<DownloadOptionsProps> = pr
     queryResultBundle,
     queryBundleRequest,
     token,
+    darkTheme = true,
   } = props
 
   return (
@@ -46,7 +47,7 @@ export const DownloadOptions: React.FunctionComponent<DownloadOptionsProps> = pr
           tooltipText={'Download Options'}
           image={faDownload}
           size="lg"
-          darkTheme={true}
+          darkTheme={darkTheme}
         ></ElementWithTooltip>
         <Dropdown.Menu
           className="SRC-primary-color-hover-dropdown"

--- a/src/lib/containers/table/table-top/EllipsisDropdown.tsx
+++ b/src/lib/containers/table/table-top/EllipsisDropdown.tsx
@@ -36,7 +36,7 @@ export const EllipsisDropdown: React.FunctionComponent<EllipsisDropdownProps> = 
           tooltipText={'Table Options'}
           image={faEllipsisV}
           size="lg"
-        ></ElementWithTooltip>
+        />
         <Dropdown.Menu
           className="SRC-primary-color-hover-dropdown"
           alignRight={true}
@@ -62,10 +62,7 @@ export const EllipsisDropdown: React.FunctionComponent<EllipsisDropdownProps> = 
             </Dropdown.Item>,
             <Dropdown.Divider key="divider1" />,
           ]}
-          <Dropdown.Item
-            key="Add/Remove Columns"
-            onClick={() => onShowColumns()}
-          >
+          <Dropdown.Item key="ColumnSelection" onClick={() => onShowColumns()}>
             Add/Remove Columns
           </Dropdown.Item>
           <Dropdown.Item key="expand" onClick={() => onFullScreen()}>

--- a/src/lib/containers/table/table-top/EllipsisDropdown.tsx
+++ b/src/lib/containers/table/table-top/EllipsisDropdown.tsx
@@ -62,8 +62,11 @@ export const EllipsisDropdown: React.FunctionComponent<EllipsisDropdownProps> = 
             </Dropdown.Item>,
             <Dropdown.Divider key="divider1" />,
           ]}
-          <Dropdown.Item key="show_columns" onClick={() => onShowColumns()}>
-            Show Columns
+          <Dropdown.Item
+            key="Add/Remove Columns"
+            onClick={() => onShowColumns()}
+          >
+            Add/Remove Columns
           </Dropdown.Item>
           <Dropdown.Item key="expand" onClick={() => onFullScreen()}>
             {isExpanded ? 'Shrink' : 'Full Screen'}

--- a/src/lib/containers/widgets/themes-plot/ThemesPlot.tsx
+++ b/src/lib/containers/widgets/themes-plot/ThemesPlot.tsx
@@ -24,7 +24,7 @@ import BarPlot from './BarPlot'
 
 export type ThemesPlotProps = {
   token?: string
-  onPointClick: ({ facetValue, type }: ClickCallbackParams) => void
+  onPointClick: ({ facetValue, type, event }: ClickCallbackParams) => void
   dotPlot: PlotProps
   topBarPlot: PlotProps
   sideBarPlot: PlotProps
@@ -132,12 +132,16 @@ function fetchData(
 
 function getTotalsByProp<T>(data: GraphItem[], prop: string): T[] {
   const resultObject = data.reduce((res, obj) => {
-    res[obj[prop]] = (obj[prop] in res ? Number(res[obj[prop]]) : 0) + Number(obj.x)
+    res[obj[prop]] =
+      (obj[prop] in res ? Number(res[obj[prop]]) : 0) + Number(obj.x)
     return res
   }, {})
   const result = []
   for (const property in resultObject) {
-    result.push({ [prop]: property, count: resultObject[property] as number } as unknown as T)
+    result.push(({
+      [prop]: property,
+      count: resultObject[property] as number,
+    } as unknown) as T)
   }
   return result
 }
@@ -152,7 +156,7 @@ const getClickTargetData = (e: PlotlyTyped.PlotMouseEvent, swap: boolean) => {
     // @ts-ignore
     ;[facetValue, type] = [type, facetValue]
   }
-  return { facetValue, type }
+  return { facetValue, type, event: e.event }
 }
 
 const renderTopBarLegend = (
@@ -197,7 +201,7 @@ const ThemesPlot: FunctionComponent<ThemesPlotProps> = ({
   sideBarPlot,
   tooltipProps = tooltipVisualProps,
   onPointClick,
-  dotPlotYAxisLabel = 'Research Themes'
+  dotPlotYAxisLabel = 'Research Themes',
 }: ThemesPlotProps) => {
   const [isLoaded, setIsLoaded] = useState(false)
   const [dotPlotQueryData, setDotPlotQueryData] = useState<GraphItem[]>([])
@@ -233,8 +237,13 @@ const ThemesPlot: FunctionComponent<ThemesPlotProps> = ({
       .map(item => item.y)
     xMaxForSideBarPlot = Math.max(...totalsByDotPlotY.map(item => item.count))
     xMaxForDotPlot = Math.max(...dotPlotQueryData.map(item => Number(item.x)))
-    topBarPlotDataSorted = _.orderBy(getTotalsByProp(topBarPlotData, 'y'), ['y'])
-   xLabelsForTopBarPlot = _.orderBy(getTotalsByProp<TotalsGroupByGroup>(topBarPlotData, 'group'), ['group']).map(item => item.group)
+    topBarPlotDataSorted = _.orderBy(getTotalsByProp(topBarPlotData, 'y'), [
+      'y',
+    ])
+    xLabelsForTopBarPlot = _.orderBy(
+      getTotalsByProp<TotalsGroupByGroup>(topBarPlotData, 'group'),
+      ['group'],
+    ).map(item => item.group)
   }
 
   return (
@@ -295,7 +304,7 @@ const ThemesPlot: FunctionComponent<ThemesPlotProps> = ({
               </div>
             </div>
           ))}
-          <div style={{ display: 'flex', position: 'relative'}}>
+          <div style={{ display: 'flex', position: 'relative' }}>
             <div className="ThemesPlot__dotPlotYLabel">{dotPlotYAxisLabel}</div>
             <div className="ThemesPlot__dotPlot">
               {yLabelsForDotPlot.map((label, i) => (

--- a/src/lib/containers/widgets/themes-plot/ThemesPlot.tsx
+++ b/src/lib/containers/widgets/themes-plot/ThemesPlot.tsx
@@ -146,10 +146,13 @@ function getTotalsByProp<T>(data: GraphItem[], prop: string): T[] {
   return result
 }
 
-const getClickTargetData = (e: PlotlyTyped.PlotMouseEvent, swap: boolean) => {
+const getClickTargetData = (
+  e: PlotlyTyped.PlotMouseEvent,
+  swap: boolean,
+): ClickCallbackParams => {
   const pointData = e.points[0].data
 
-  let facetValue = pointData.y[0]
+  let facetValue = pointData.y[0] as string
   let type = pointData.name
 
   if (swap) {

--- a/src/lib/containers/widgets/themes-plot/types.ts
+++ b/src/lib/containers/widgets/themes-plot/types.ts
@@ -31,6 +31,7 @@ export type PlotProps = {
 }
 
 export type ClickCallbackParams = {
+  event: MouseEvent
   facetValue: string | number | Date | PlotlyTyped.Datum[] | null
   type: string | number | Date | PlotlyTyped.Datum[] | null
 }

--- a/src/lib/containers/widgets/themes-plot/types.ts
+++ b/src/lib/containers/widgets/themes-plot/types.ts
@@ -1,4 +1,3 @@
-import * as PlotlyTyped from 'plotly.js'
 export type GraphItem = {
   x: number
   y: string
@@ -32,6 +31,6 @@ export type PlotProps = {
 
 export type ClickCallbackParams = {
   event: MouseEvent
-  facetValue: string | number | Date | PlotlyTyped.Datum[] | null
-  type: string | number | Date | PlotlyTyped.Datum[] | null
+  facetValue: string
+  type: string
 }

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -1099,3 +1099,8 @@ hr ~ .SRC-wrapper {
 .SignInButton {
   padding: 0px;
 }
+
+#addAndRemoveColumns ~ div.dropdown-menu {
+  max-height: 300px;
+  overflow: auto;
+}

--- a/src/lib/style/components/_cards.scss
+++ b/src/lib/style/components/_cards.scss
@@ -294,3 +294,8 @@ img.iconImg.SRC-datasetIcon {
     }
   }
 }
+
+.SRC-viewMore {
+  display: flex;
+  justify-content: flex-end;
+}


### PR DESCRIPTION
Fixed dropdown menu on SynapseTable, was broken functionally. I have an image of the menu for reference -
![image](https://user-images.githubusercontent.com/20282487/88107351-cd986300-cb5b-11ea-93b1-54b43634bce6.png)

- Hoisted state from ColumnSelection state into SynapseTable while still letting it use its own state for when it gets used with the TopLevelControls component
- Added back state variable to track if the export metadata modal is open

Also fixed color of download icon, on the portals its colors are swapped. 
![image](https://user-images.githubusercontent.com/20282487/88107381-d852f800-cb5b-11ea-9e29-da1fcf5879f8.png)

Changed HasAccess to only log backend issues, not the client side error that is thrown. This was cluttering the console output heavily.

Added tests to SynapseTable to validate that the ellipsis dropdown works, the HasAccess column doesn't show when isFileView is false

PORTALS-1482 - Expose event from the ThemesPlot so that ctrl-click can be detected and open link in new tab