### PR TITLE
fix overflow of icons on firefox

### DIFF
--- a/src/lib/style/components/_query-wrapper-plot-nav.scss
+++ b/src/lib/style/components/_query-wrapper-plot-nav.scss
@@ -13,9 +13,7 @@
     .QueryWrapperPlotNav__actions {
       display: inline-flex;
       align-items: center;
-      .ElementWithTooltip,
-      .dropdown {
-        flex: 1;
+      .ElementWithTooltip {
         width: 35px;
       }
     }


### PR DESCRIPTION
before: icons on the right side overflow the container, they stretch beyond the width of the gray line
![image](https://user-images.githubusercontent.com/20282487/88567027-c35ae680-cfeb-11ea-986f-19397a522c94.png)


after: icons don't overflow
![image](https://user-images.githubusercontent.com/20282487/88567056-cfdf3f00-cfeb-11ea-8631-8e69493b43d6.png)
