### PR TITLE
limit modal height, fix too many divs

### DIFF
--- a/src/lib/containers/access_requirement_list/AcceptedRequirements.tsx
+++ b/src/lib/containers/access_requirement_list/AcceptedRequirements.tsx
@@ -145,13 +145,14 @@ export default function AcceptedRequirements({
   const RenderAcceptedRequirements = () => {
     if (isApproved) {
       // show link to Synapse AR page if Managed ACT AR
-      const isManagedActAr = accessRequirement.concreteType ===
+      const isManagedActAr =
+        accessRequirement.concreteType ===
         SUPPORTED_ACCESS_REQUIREMENTS.ManagedACTAccessRequirement
       return (
         <div>
           <p>
             You have accepted the terms of use.
-            { isManagedActAr &&
+            {isManagedActAr && (
               <button
                 className="update-request-button bold-text"
                 onClick={() => {
@@ -160,7 +161,7 @@ export default function AcceptedRequirements({
               >
                 Update Request
               </button>
-            }
+            )}
             <button
               className="view-terms-button bold-text"
               onClick={() => {
@@ -180,29 +181,34 @@ export default function AcceptedRequirements({
   }
 
   return (
-    <div>
+    <>
       <div className="requirement-container">
         <AccessApprovalCheckMark isCompleted={isApproved} />
         <div className="terms-of-use-content">
           <RenderAcceptedRequirements />
         </div>
       </div>
-      {token ? (showButton ?? (
-        <div className={`button-container ${isApproved ? `hide` : `default`}`}>
-          <div className="accept-button-container">
-            <button className="accept-button" onClick={onAcceptClicked}>
-              {acceptButtonText}
-            </button>
-          </div>
+      {token ? (
+        showButton ?? (
+          <div
+            className={`button-container ${isApproved ? `hide` : `default`}`}
+          >
+            <div className="accept-button-container">
+              <button className="accept-button" onClick={onAcceptClicked}>
+                {acceptButtonText}
+              </button>
+            </div>
 
-          <div className="not-accept-button-container">
-            <button className="not-accpet-button" onClick={() => onHide?.()}>
-              I do not accept
-            </button>
+            <div className="not-accept-button-container">
+              <button className="not-accpet-button" onClick={() => onHide?.()}>
+                I do not accept
+              </button>
+            </div>
           </div>
-        </div>
-        )) : <></>
-      }
-    </div>
+        )
+      ) : (
+        <></>
+      )}
+    </>
   )
 }

--- a/src/lib/containers/access_requirement_list/AccessRequirementList.tsx
+++ b/src/lib/containers/access_requirement_list/AccessRequirementList.tsx
@@ -242,59 +242,62 @@ export default function AccessRequirementList({
   }
 
   const content = (
-    <div>
+    <>
       <ReactBootstrap.Modal.Header closeButton={true}>
         <ReactBootstrap.Modal.Title className="AccessRequirementList__title">
           Data Access Request
         </ReactBootstrap.Modal.Title>
       </ReactBootstrap.Modal.Header>
-      <ReactBootstrap.Modal.Body></ReactBootstrap.Modal.Body>
-      <h4 className="AccessRequirementList__instruction AccessRequirementList__access">
-        Access For:
-      </h4>
-      <a
-        className="AccessRequirementList__register-text-link"
-        href={`https://www.synapse.org/#!Synapse:${entityId}`}
-      >
-        <FontAwesomeIcon
-          size="lg"
-          icon="file"
-          className="AccessRequirementList__file"
-        />{' '}
-        &nbsp;{entityInformation[0]?.name}
-      </a>
-      <h4 className="AccessRequirementList__instruction">
-        What do I need to do?
-      </h4>
-      <div className="requirement-container">
-        <AccessApprovalCheckMark isCompleted={isSignedIn} />
+      <ReactBootstrap.Modal.Body>
         <div>
-          {!isSignedIn && (
-            <p className="AccessRequirementList__signin">
-              <button
-                className={`${SynapseConstants.SRC_SIGN_IN_CLASS} SRC-primary-text-color SRC-boldText `}
-              >
-                Sign in
-              </button>
-              with a Sage Platform (Synapse) user account.
-            </p>
-          )}
-          <SignedIn />
-        </div>
-      </div>
-      {accessRequirements?.map(
-        ({ accessRequirement, accessRequirementStatus }) => {
-          return (
-            <React.Fragment key={accessRequirement.id}>
-              {renderAccessRequirement(
-                accessRequirement,
-                accessRequirementStatus,
+          <h4 className="AccessRequirementList__instruction AccessRequirementList__access">
+            Access For:
+          </h4>
+          <a
+            className="AccessRequirementList__register-text-link"
+            href={`https://www.synapse.org/#!Synapse:${entityId}`}
+          >
+            <FontAwesomeIcon
+              size="lg"
+              icon="file"
+              className="AccessRequirementList__file"
+            />
+            &nbsp;{entityInformation[0]?.name}
+          </a>
+          <h4 className="AccessRequirementList__instruction">
+            What do I need to do?
+          </h4>
+          <div className="requirement-container">
+            <AccessApprovalCheckMark isCompleted={isSignedIn} />
+            <div>
+              {!isSignedIn && (
+                <p className="AccessRequirementList__signin">
+                  <button
+                    className={`${SynapseConstants.SRC_SIGN_IN_CLASS} SRC-primary-text-color SRC-boldText `}
+                  >
+                    Sign in
+                  </button>
+                  with a Sage Platform (Synapse) user account.
+                </p>
               )}
-            </React.Fragment>
-          )
-        },
-      )}
-    </div>
+              <SignedIn />
+            </div>
+          </div>
+          {accessRequirements?.map(
+            ({ accessRequirement, accessRequirementStatus }) => {
+              return (
+                <React.Fragment key={accessRequirement.id}>
+                  {renderAccessRequirement(
+                    accessRequirement,
+                    accessRequirementStatus,
+                  )}
+                </React.Fragment>
+              )
+            },
+          )}
+        </div>
+      </ReactBootstrap.Modal.Body>
+    </>
   )
 
   if (renderAsModal) {
@@ -304,6 +307,8 @@ export default function AccessRequirementList({
         onHide={() => onHide?.()}
         show={true}
         animation={false}
+        centered={true}
+        scrollable={true}
       >
         {content}
       </ReactBootstrap.Modal>

--- a/src/lib/containers/access_requirement_list/SelfSignAccessRequirement.tsx
+++ b/src/lib/containers/access_requirement_list/SelfSignAccessRequirement.tsx
@@ -58,7 +58,7 @@ export default function SelfSignAccessRequirementComponent({
   }, [accessRequirement, token, user])
 
   return (
-    <div>
+    <>
       {accessRequirement.isCertifiedUserRequired && (
         <div className="requirement-container">
           <AccessApprovalCheckMark isCompleted={userBundle?.isCertified} />
@@ -118,6 +118,6 @@ export default function SelfSignAccessRequirementComponent({
         onHide={onHide}
         entityId={entityId}
       />
-    </div>
+    </>
   )
 }

--- a/src/lib/containers/access_requirement_list/TermsOfUseAccessRequirement.tsx
+++ b/src/lib/containers/access_requirement_list/TermsOfUseAccessRequirement.tsx
@@ -40,7 +40,7 @@ export default function TermsOfUseAccessRequirementComponent({
   }, [token, accessRequirement])
 
   return (
-    <div>
+    <>
       {isLoading && <span className="spinner" />}
       <AcceptedRequirements
         user={user}
@@ -51,6 +51,6 @@ export default function TermsOfUseAccessRequirementComponent({
         onHide={onHide}
         entityId={entityId}
       />
-    </div>
+    </>
   )
 }

--- a/src/lib/containers/download_list/DownloadListTable.tsx
+++ b/src/lib/containers/download_list/DownloadListTable.tsx
@@ -331,7 +331,7 @@ export default function DownloadListTable(props: DownloadListTableProps) {
       <div style={{ display: arPropsFromHasAccess ? 'none' : '' }}>
         <div className="SRC-split download-list-table-top SRC-primary-background-color SRC-border-bottom-only">
           <span className="create-package-text">
-            Download List &nbsp;&nbsp;{' '}
+            Download List &nbsp;&nbsp;
             {isLoading && <span className="spinner" />}
           </span>
           <button

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -1104,3 +1104,29 @@ hr ~ .SRC-wrapper {
   max-height: 300px;
   overflow: auto;
 }
+
+// https://github.com/twbs/bootstrap/blob/c140347bd26851c79e76766ae381e91c159b3f48/scss/_modal.scss
+.modal-dialog-scrollable {
+  height: 100%;
+
+  .modal-content {
+    height: 90%;
+    overflow: hidden;
+  }
+
+  .modal-body {
+    height: 90%;
+    overflow-y: auto;
+    padding: 15px;
+    h4 {
+      margin: 0px;
+    }
+  }
+}
+
+.modal-dialog-centered {
+  margin-top: 0px;
+  display: flex;
+  align-items: center;
+  min-height: 90%;
+}


### PR DESCRIPTION
Tweaks to modal:
- limit modal height
- bootstrap modal.body was empty, moved content inside of it..
- removed unnecessary wrapping div

![image](https://user-images.githubusercontent.com/20282487/88593833-fd8cae00-d014-11ea-8d7b-386dfc8aafaf.png)

also fixed way too many divs in access requirement list component 😨 

before:
![image](https://user-images.githubusercontent.com/20282487/88593986-417fb300-d015-11ea-8964-af8464c539ba.png)

after:
![image](https://user-images.githubusercontent.com/20282487/88594068-6aa04380-d015-11ea-9715-914e4a89d84d.png)

