### PR TITLE
PORTALS-1478: update to the latest plotly.js-basic-dist version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "markdown-it-synapse-table": "^1.0.6",
     "moment": "^2.24.0",
     "node-sass": "4.12.0",
-    "plotly.js-basic-dist": "^1.47.3",
+    "plotly.js-basic-dist": "^1.54.7",
     "raf": "^3.4.1",
     "react": "16.13.1",
     "react-app-polyfill": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10426,10 +10426,10 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-plotly.js-basic-dist@^1.47.3:
-  version "1.53.0"
-  resolved "https://registry.yarnpkg.com/plotly.js-basic-dist/-/plotly.js-basic-dist-1.53.0.tgz#dadc4cbd1fcdeec803deb55462439b5bcbcd2b40"
-  integrity sha512-906O6cwy+D8rygaYiP/ujl6PaLrEXkgwnuiNjjYnkCUfpkfd2QQEQaoRp4W9WAFFDJofbnWPOVIso7P5y1Xwtw==
+plotly.js-basic-dist@^1.54.7:
+  version "1.54.7"
+  resolved "https://registry.yarnpkg.com/plotly.js-basic-dist/-/plotly.js-basic-dist-1.54.7.tgz#df9d635d182f7feafe66cc114f82adb089df93c4"
+  integrity sha512-89L14wW/WzzbaSdek3SjljKyXs4O36sl7S/0NIlqyDZKnf0pi+H4nOxJIPYXjyY/kw1oZVSmsNJkMUb4HYxkFQ==
 
 pn@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
from 1.53.0 to 1.54.7