### PR TITLE
bump version to prep for release of 1.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/containers/UpsetPlot.tsx
+++ b/src/lib/containers/UpsetPlot.tsx
@@ -136,6 +136,7 @@ const UpsetPlot: React.FunctionComponent<UpsetPlotProps> = ({
                 combinationName={combinationName}
                 fontFamily='Lato sans-serif'
                 fontSizes={updateFontSizes}
+                exportButtons={false}
               />
             </div>            
           )}


### PR DESCRIPTION
and hide Upset.js plot export buttons for now (styling is lost on redirect to share embed site)