### PR TITLE
use flex on outer goals div to align explore button link

### DIFF
--- a/src/lib/style/components/_goals.scss
+++ b/src/lib/style/components/_goals.scss
@@ -24,6 +24,8 @@
   }
   &__Card {
     flex: 1;
+    display: flex;
+    flex-direction: column;
     box-shadow: 0px 3px 10px rgba(93, 105, 171, 0.1);
     background: #ffffff;
     margin: 10px;
@@ -35,9 +37,9 @@
     }
     margin: 10px;
     &__header {
+      min-height: 75px;
       @extend %side-padding;
       background: $primary-action-color;
-      height: 75px;
       display: flex;
       justify-content: center;
       p {
@@ -60,10 +62,10 @@
       }
     }
     &__summary {
+      flex: 1;
       @extend %side-padding;
       padding-top: 20px;
       padding-bottom: 20px;
-      min-height: 150px;
       @extend %space-between;
       flex-direction: column;
       &__link {
@@ -71,6 +73,7 @@
         width: 120px;
         height: 33px;
         padding: 20px;
+        margin-top: 20px;
         background: $primary-action-color;
         border-radius: 24px;
         color: white !important;


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/20282487/90833399-c8fed000-e2fc-11ea-9981-c970d80308bb.png)


- added flex to container of cards, this allowed the summary div to expand to full height
after:

![image](https://user-images.githubusercontent.com/20282487/90833228-71606480-e2fc-11ea-9bcb-249eaf50292a.png)
