### PR TITLE
PORTALS-1575

### DIFF
--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -64,7 +64,7 @@ export const CARD_LONG_DESCRIPTION_CSS = 'SRC-long-description'
 // note - had to add an escape character for the second slash in the regex above
 export const DOI_REGEX = /^10.\d{4,9}\/[-._;()/:a-z0-9]+$/i
 // check for 'syn' followed and ended by a digit of unlimited length, must also begin the line
-export const SYNAPSE_REGX = /^syn\d+$/
+export const SYNAPSE_REGX = /^syn\d+\.?\d+$/
 
 // This function isn't in the class only for ease of testing with renderShortDescription
 export const getCutoff = (summary: string) => {
@@ -91,6 +91,12 @@ export const renderValueOrMultiValue = ({
   selectColumns?: SelectColumn[]
   columnModels?: ColumnModel[]
 }): ValueOrMultiValue => {
+  if (!value) {
+    return {
+      str: '',
+      strList: undefined,
+    }
+  }
   const selectedColumnOrUndefined =
     selectColumns?.find(el => el.name === columnName) ||
     columnModels?.find(el => el.name === columnName)

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -2,6 +2,14 @@
 // https://stackoverflow.com/questions/39084438/how-to-import-plotly-js-into-typescript
 declare module 'plotly.js-basic-dist'
 declare module 'sql-parser'
+declare module 'sql-parser' {
+  var lexer: {
+    tokenize: (input: string) => string[][]
+  }
+  var parser: {
+    parse: (input: string[][]) => string
+  }
+}
 declare module 'react-native-rss-parser'
 declare module '*.svg'
 declare module 'column-resizer'


### PR DESCRIPTION
To support [PORTALS-1575](https://sagebionetworks.jira.com/browse/PORTALS-1575) the sql parser needs to work with versioned entities which it currently does not. Modified the parser to recognize a versioned entity and fix the tokens accordingly.

Miscellaneous:
- Added a return type to `formatSQLFromParser`
- Added types for the sql-parser library inside of SRC
- fixed bug in renderValueOrMultiValue by checking null params
- changed synapse regex to recognize a versioned table
- Changed switch statement to use `default` to be more generic

