### PR TITLE
SWC-5286 : do not throw away other error response json data (used to only hold onto "reason").

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.15.15",
+  "version": "1.15.16",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -144,20 +144,21 @@ const fetchWithExponentialTimeout = <T>(
           if (resp.ok) {
             // possible empty response
             return Promise.resolve({
-              reason: error,
+              ...error,
               status: resp.status,
             })
           }
           if (error.reason && resp.status) {
-            // successfull return from server but invalid call
+            // successful return from server but invalid call
             return Promise.reject({
-              reason: error.reason,
+              ...error,
               status: resp.status,
             })
           }
           // This occurs if the response is not ok and does not have json or is empty
+          // retain any other fields the original error has
           return Promise.reject({
-            reason: error,
+            ...error,
             status: resp.status,
           })
         })

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -156,9 +156,8 @@ const fetchWithExponentialTimeout = <T>(
             })
           }
           // This occurs if the response is not ok and does not have json or is empty
-          // retain any other fields the original error has
           return Promise.reject({
-            ...error,
+            reason: error,
             status: resp.status,
           })
         })

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -144,7 +144,7 @@ const fetchWithExponentialTimeout = <T>(
           if (resp.ok) {
             // possible empty response
             return Promise.resolve({
-              ...error,
+              reason: error,
               status: resp.status,
             })
           }

--- a/src/lib/utils/synapseTypes/OIDCAuthorizationRequest.ts
+++ b/src/lib/utils/synapseTypes/OIDCAuthorizationRequest.ts
@@ -19,7 +19,7 @@ export type OIDCAuthorizationRequest = {
       }
     }
   }
-  responseType: 'code'
+  responseType: string
   redirectUri: string
   nonce?: string
   userId?: string


### PR DESCRIPTION
Also fix type definition for OIDCAuthorizationRequest (not hard-coding responseType)