### PR TITLE
PORTALS-1627: Apply softer box shadow

### DIFF
--- a/src/lib/containers/UserCardMedium.tsx
+++ b/src/lib/containers/UserCardMedium.tsx
@@ -300,8 +300,7 @@ export default class UserCardMedium extends React.Component<
     // when the component is large we have to set the click handler to wrap both the top and bottom portion
     return (
       <div
-        style={{ boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.25)' }}
-        className={isContextMenuOpen ? 'SRC-hand-cursor' : ''}
+        className={isContextMenuOpen ? 'SRC-hand-cursor cardContainer' : 'cardContainer'}
         onClick={isContextMenuOpen ? this.toggleContextMenu : undefined}
       >
         <div

--- a/src/lib/style/abstracts/_variables.scss
+++ b/src/lib/style/abstracts/_variables.scss
@@ -19,6 +19,8 @@ $red-error: #b2242a !default;
 $red-error2: #c94281!default;
 $space-unit: 2.1rem;
 
+$box-shadow-soft: 0 3px 10px rgba(93,105,171,.1);
+
 $themes: (
   drug-upload-tool: (
     action-color: #5960a5,

--- a/src/lib/style/components/_cards-rotate.scss
+++ b/src/lib/style/components/_cards-rotate.scss
@@ -31,6 +31,11 @@ $card-rotate-margin: 21px;
       word-wrap: break-word;
       word-break: break-word;
     }
+
+    .cardContainer {
+      box-shadow: $box-shadow-soft;
+    }
+
   }
 
   .UserCardListRotate__summary {

--- a/src/lib/style/components/_cards.scss
+++ b/src/lib/style/components/_cards.scss
@@ -309,3 +309,7 @@ img.iconImg.SRC-datasetIcon {
   display: flex;
   justify-content: flex-end;
 }
+
+.cardContainer {
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+}

--- a/src/lib/style/components/_goals.scss
+++ b/src/lib/style/components/_goals.scss
@@ -26,7 +26,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    box-shadow: 0px 3px 10px rgba(93, 105, 171, 0.1);
+    box-shadow: $box-shadow-soft;
     background: #ffffff;
     margin: 10px;
     &:first-child {


### PR DESCRIPTION
- Fix box shadow styling to match Goal cards. 
- Move inline CSS to stylesheet.

<img width="1488" alt="Screen Shot 2020-09-08 at 1 47 55 PM" src="https://user-images.githubusercontent.com/434792/92526237-fe029200-f1d9-11ea-89f3-22e8db66d9c2.png">
