### PR TITLE
PORTALS-1678: option to wrap the matching value with parens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.15.26",
+  "version": "1.15.27",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
+++ b/src/demo/containers/playground/QueryWrapperPlotNavDemo.tsx
@@ -41,6 +41,15 @@ class QueryWrapperPlotNavDemo extends React.Component<
       propsWithTable: {
         tableConfiguration: {
           showAccessColumn: true,
+          columnLinks: [
+            {
+              matchColumnName: 'study',
+              isMarkdown: false,
+              baseURL: 'Explore/Studies/DetailsPage',
+              URLColumnName: 'Study_Name',
+              wrapValueWithParens: true,
+            },
+          ],
         },
         searchConfiguration: {
           searchable: [
@@ -189,7 +198,7 @@ class QueryWrapperPlotNavDemo extends React.Component<
           style={{ color: 'white', padding: 10 }}
           onClick={() => this.setState({ showCards: !showCards })}
         >
-          Switch to cards
+          Switch to table/cards
         </button>
         <QueryWrapperPlotNav token={this.props.token} {...propsForPlotNav} />
         <hr></hr>

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -20,6 +20,9 @@ export interface CardLink {
   // the column name who's value will be used
   matchColumnName: string
   isMarkdown: false
+  // the value that will go into the url link should be surrounded with parenthesis, making the search
+  // param study=(ROSMAP) instead of study=ROSMAP
+  wrapValueWithParens?: boolean
 }
 
 export type MarkdownLink = {

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -180,8 +180,9 @@ export const renderLabel = (args: {
     className = 'SRC-primary-text-color'
   }
   return split.map((el, index) => {
-    const { baseURL, URLColumnName } = labelLink
-    const href = `/${baseURL}?${URLColumnName}=${el}`
+    const { baseURL, URLColumnName, wrapValueWithParens } = labelLink
+    const value = wrapValueWithParens ? `(${el})` : el
+    const href = `/${baseURL}?${URLColumnName}=${value}`
     return (
       <React.Fragment key={el}>
         <a href={href} key={el} className={className} style={style}>


### PR DESCRIPTION
This is to help with the AMP-AD study name match. Ideally these would be synapse IDs