### PR TITLE
remove SRC-adjust-for-bootstrap-margin

### DIFF
--- a/src/lib/containers/UserCardList.tsx
+++ b/src/lib/containers/UserCardList.tsx
@@ -107,7 +107,7 @@ export default class UserCardList extends React.Component<
     const fauxUserProfilesList = data && this.manuallyExtractData(data)
     let fauxUserProfileIndex = 0
     return (
-      <div className="SRC-card-grid-row SRC-adjust-for-bootstrap-margin">
+      <div className="SRC-card-grid-row">
         {// we loop through the list from the props because thats the 'active set of data' whereas the data stored in state could be stale
         list.map(ownerId => {
           const userProfile = userProfileMap[ownerId]

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -722,11 +722,6 @@ div.SRC-userImg {
   box-sizing: border-box;
 }
 
-.SRC-adjust-for-bootstrap-margin {
-  margin-left: -15px;
-  margin-right: -15px;
-}
-
 .row.no-gutter > [class*='col-'] {
   padding-right: 0;
   padding-left: 0;


### PR DESCRIPTION
I think this must have been a misunderstanding.  If items are in a bootstrap responsive grid, then the row already has a -15px margin (left and right) to correct for the columns which have a 15px padding (left and right).