### PR TITLE
PORTALS-1699

### DIFF
--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -1205,7 +1205,5 @@ hr ~ .SRC-wrapper {
 
 .modal-dialog-centered {
   margin-top: 0px;
-  display: flex;
-  align-items: center;
   min-height: 90%;
 }

--- a/src/lib/style/components/_download-link.scss
+++ b/src/lib/style/components/_download-link.scss
@@ -36,8 +36,6 @@
 }
 
 .download-list-modal-container {
-  width: 70%;
-  position: relative;
   .DownloadListTable {
     padding: 20px;
     max-height: 700px;


### PR DESCRIPTION
Bootstrap modal dialogs are already centered, and have better responsive behavior than results from the current css overrides.  Delete.