### PR TITLE
SWC-5723

### DIFF
--- a/src/lib/containers/CopyToClipboardInput.tsx
+++ b/src/lib/containers/CopyToClipboardInput.tsx
@@ -66,7 +66,7 @@ export const CopyToClipboardInput: React.FunctionComponent<CopyToClipboardInputP
         ></FormControl>
         <Button
           variant="default"
-          className="SRC-copyToClipboardIcon"
+          id="SRC-copyToClipboardButton"
           onClick={copyToClipboard(ref, value)}
         >
           {IconCopy}

--- a/src/lib/containers/CopyToClipboardInput.tsx
+++ b/src/lib/containers/CopyToClipboardInput.tsx
@@ -65,8 +65,7 @@ export const CopyToClipboardInput: React.FunctionComponent<CopyToClipboardInputP
           onClick={copyToClipboard(ref, value)}
         ></FormControl>
         <Button
-          variant="default"
-          id="SRC-copyToClipboardButton"
+          className="SRC-copyToClipboardButton"
           onClick={copyToClipboard(ref, value)}
         >
           {IconCopy}

--- a/src/lib/containers/personal_access_token/AccessTokenCard.tsx
+++ b/src/lib/containers/personal_access_token/AccessTokenCard.tsx
@@ -30,6 +30,12 @@ export const AccessTokenCard: React.FunctionComponent<AccessTokenCardProps> = ({
 
   const isExpired = accessToken.state === 'EXPIRED'
 
+  React.useEffect(() => {
+    // For reasons unknown, the tooltips in this component would not load in Synapse.org without this
+    // see https://github.com/wwayne/react-tooltip/issues/344
+    ReactTooltip.rebuild()
+  }, [])
+
   return (
     <div
       className={
@@ -69,10 +75,10 @@ export const AccessTokenCard: React.FunctionComponent<AccessTokenCardProps> = ({
 
       <div className="SRC-cardContent">
         <p className="SRC-eqHeightRow SRC-userCardName">
+          <ReactTooltip delayShow={100} />
           <span className={'SRC-blackText'}>{accessToken.name}</span>
           {isExpired && (
             <span>
-              <ReactTooltip delayShow={100} />{' '}
               <FontAwesomeIcon
                 data-tip={
                   'This token has expired. It no longer works and can only be deleted.'

--- a/src/lib/containers/personal_access_token/AccessTokenPage.tsx
+++ b/src/lib/containers/personal_access_token/AccessTokenPage.tsx
@@ -6,11 +6,7 @@ import { Error } from '../Error'
 import loadingScreen from '../LoadingScreen'
 import { AccessTokenCard } from './AccessTokenCard'
 import { CreateAccessTokenModal } from './CreateAccessTokenModal'
-import {
-  ErrorBoundary,
-  FallbackProps,
-  useErrorHandler,
-} from 'react-error-boundary'
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary'
 
 const ErrorFallback: React.FunctionComponent<FallbackProps> = ({
   error,
@@ -18,7 +14,6 @@ const ErrorFallback: React.FunctionComponent<FallbackProps> = ({
 }) => {
   return (
     <div role="alert" className="SRC-marginBottomTop">
-      <p>The following error occurred:</p>
       <Error error={error}></Error>
       <Button onClick={resetErrorBoundary}>Reload Access Tokens</Button>
     </div>
@@ -50,7 +45,8 @@ export const AccessTokenPage: React.FunctionComponent<AccessTokenPageProps> = ({
     undefined,
   )
 
-  const handleError = useErrorHandler()
+  const [showErrorMessage, setShowErrorMessage] = React.useState(false)
+  const [errorMessage, setErrorMessage] = React.useState('')
 
   // We rerender the list whenever a token is created or deleted to ensure we are up-to-date
   const rerenderList = () => {
@@ -74,10 +70,11 @@ export const AccessTokenPage: React.FunctionComponent<AccessTokenPageProps> = ({
           }
         })
         .catch(err => {
-          handleError(err)
+          setIsLoading(false)
+          setErrorMessage(err)
+          setShowErrorMessage(true)
         })
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadNextPage, token, nextPageToken])
 
   return (
@@ -123,7 +120,7 @@ export const AccessTokenPage: React.FunctionComponent<AccessTokenPageProps> = ({
               )
             })}
             {isLoading && loadingScreen}
-            {!isLoading && nextPageToken && (
+            {!isLoading && nextPageToken && !showErrorMessage && (
               <div className="SRC-loadMoreButtonContainer">
                 <Button
                   className="SRC-loadMoreAccessTokensButton"
@@ -135,6 +132,7 @@ export const AccessTokenPage: React.FunctionComponent<AccessTokenPageProps> = ({
               </div>
             )}
           </div>
+          {showErrorMessage && <Error error={errorMessage}></Error>}
         </div>
       </ErrorBoundary>
     </>

--- a/src/lib/style/components/_copy-to-clipboard.scss
+++ b/src/lib/style/components/_copy-to-clipboard.scss
@@ -1,23 +1,23 @@
+$copy-to-clipboard-input-height: 35px;
+
 .SRC-copyToClipboardInputContainer {
   display: flex;
   justify-content: center;
   .SRC-copyToClipboardInput {
-    height: 35px;
+    height: $copy-to-clipboard-input-height;
     border-top-right-radius: 0px;
     border-bottom-right-radius: 0px;
     border-right: none;
     align-self: center;
   }
-  #SRC-copyToClipboardButton {
+
+  button.SRC-copyToClipboardButton {
     padding: 5px 10px;
-    height: 35px;
+    height: $copy-to-clipboard-input-height;
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
     align-self: center;
     background-color: #fff;
     border-color: #ccc;
-  }
-  .SRC-copyToClipboardIcon:hover {
-    background-color: #00000010;
   }
 }

--- a/src/lib/style/components/_copy-to-clipboard.scss
+++ b/src/lib/style/components/_copy-to-clipboard.scss
@@ -8,12 +8,14 @@
     border-right: none;
     align-self: center;
   }
-  .SRC-copyToClipboardIcon {
+  #SRC-copyToClipboardButton {
     padding: 5px 10px;
     height: 35px;
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
     align-self: center;
+    background-color: #fff;
+    border-color: #ccc;
   }
   .SRC-copyToClipboardIcon:hover {
     background-color: #00000010;

--- a/src/lib/style/components/_personal-access-tokens.scss
+++ b/src/lib/style/components/_personal-access-tokens.scss
@@ -41,6 +41,7 @@
   .SRC-accessTokenPageCreateButtonContainer {
     align-items: flex-end;
     align-self: center;
+    margin-left: 15px;
   }
 }
 


### PR DESCRIPTION
* Fixes an issue with `ReactTooltip`s not rendering in synapse.org
* Adds very specific styling to CopyToClipboardInput button (synapse.org overrides #body > .btn)
* Use custom error handling at the top level of the page component, because the added error boundary fails and the entire page fails to render (unsure why, I suspect it has to do with differences between a JS `Error` and a `SynapseClientError`) when the user tries to load the component when not signed in.