### PR TITLE
SWC-5318: zoom has weird behavior on safari; use transform

### DIFF
--- a/src/lib/style/components/_carousel.scss
+++ b/src/lib/style/components/_carousel.scss
@@ -9,15 +9,13 @@
 
   &__SelectedCard {
     opacity: 1;
-    zoom: 1;
-    -moz-transform: scale(1); // zoom is not supported in FF
+    transform: scale(1);
     transition-duration: 0.75s;
   }
 
   &__UnselectedCard {
     opacity: 0.5;
-    zoom: 0.65;
-    -moz-transform: scale(0.65); // zoom is not supported in FF
+    transform: scale(0.65);
     transition-duration: 0.75s;
   }
 


### PR DESCRIPTION
In Safari, zoom causes the flex container height to change, and the zoom-ed element 'pops' and seems to re-render children after the animation ends. Fixes with transform, which is fine across all browsers