### PR TITLE
PORTALS-1751 Use DemoStyle.css in Styleguidist

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "build-gh": "yarn run build:docs",
     "deploy": "gh-pages -d styleguide && gh-pages -d styleguide -o upstream",
     "deploy:origin": "yarn install && yarn run predeploy && gh-pages -d styleguide && gh-pages -d styleguide -o origin",
-    "build-css": "node-sass src/lib/style -o src/lib/style",
+    "build-css": "node-sass src/lib/style -o src/lib/style && node-sass src/demo/style -o src/demo/style",
     "watch-css": "yarn run build-css && node-sass src/ -o src/ --watch --recursive",
     "start-js": "react-scripts start",
     "start": "npm-run-all -p watch-css serve:docs",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -38,7 +38,7 @@ module.exports = {
     require: [
         path.join(__dirname, 'styleguide.setup.js'),
         path.join(__dirname, 'styleguide.setup.css'),
-        path.join(__dirname, 'src/lib/style/main.css'),
+        path.join(__dirname, 'src/demo/style/DemoStyle.css'),
     ],
     theme: {
         maxWidth: 1300,


### PR DESCRIPTION
I've been using the styleguide to verify changes to buttons and found this defect. Just using main.css breaks some styles because we are missing Index.scss. This is fixed by using DemoStyle.css (which was used in the react-scripts demo), which pulls in both main.scss and Index.scss.

As an example, see QueryWrapperPlotNav. We lose the .SRC-light-button class.

without Index.scss:
![image](https://user-images.githubusercontent.com/17580037/101952565-db13bf80-3bc6-11eb-9e5a-7158eb2631c9.png)

with Index.scss:
![image](https://user-images.githubusercontent.com/17580037/101952707-131b0280-3bc7-11eb-8f08-d0cf82fc4e43.png)

