### PR TITLE
PORTALS-1786: Limit the image height in ProjectViewCard

### DIFF
--- a/src/lib/style/components/_project-view-card.scss
+++ b/src/lib/style/components/_project-view-card.scss
@@ -10,7 +10,15 @@
   text-align: left;
 
   img {
+    display: block;
     max-width: 100%;
+    max-height: 30%;
+    width: auto;
+    height: auto;
+
+    // Center the image
+    margin-left: auto;
+    margin-right: auto;
   }
 
   &__ImagePlaceholder {

--- a/src/lib/style/components/_project-view-card.scss
+++ b/src/lib/style/components/_project-view-card.scss
@@ -13,8 +13,6 @@
     display: block;
     max-width: 100%;
     max-height: 30%;
-    width: auto;
-    height: auto;
 
     // Center the image
     margin-left: auto;


### PR DESCRIPTION
Before, a taller-than-expected image would push contents off of the card:

![image](https://user-images.githubusercontent.com/17580037/102138364-372a4e00-3e2a-11eb-9107-1ce5984bff28.png)


After:

![image](https://user-images.githubusercontent.com/17580037/102138327-2a0d5f00-3e2a-11eb-963a-47f9321a5bed.png)
