### PR TITLE
Match node version for portals Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10.15.3"
+  - 14
 script:
   - yarn test:coverage
   - yarn build


### PR DESCRIPTION
Fixing portals Travis build here: https://github.com/Sage-Bionetworks/portals/pull/533

Would be good to target the same version of node for both projects.