### PR TITLE
PORTALS-1767 (PR 2): Use @use, @forward, namespacing

### DIFF
--- a/src/demo/style/DemoStyle.scss
+++ b/src/demo/style/DemoStyle.scss
@@ -1,4 +1,6 @@
-$primary-action-color: rgb(64, 123, 160);
-$primary-bgcolor-rgba: rgba(64, 123, 160, 0.03);
-@import '../../lib/template_style/Index.scss';
-@import '../../lib/style/main.scss';
+@use '../../lib/style/main.scss' with (
+    $primary-action-color: rgb(64, 123, 160),
+    $primary-bgcolor-rgba: rgba(64, 123, 160, 0.03),
+);
+
+@use '../../lib/template_style/Index.scss';

--- a/src/lib/style/base/_base.scss
+++ b/src/lib/style/base/_base.scss
@@ -1,6 +1,7 @@
 // -----------------------------------------------------------------------------
 // This file contains very basic styles.
 // -----------------------------------------------------------------------------
+@use '../abstracts/variables' as SRC;
 
 /**
  * Set up a decent box model on the root element
@@ -29,7 +30,7 @@ html {
 }
 
 body {
-  color: $gray-regular;
+  color: SRC.$gray-regular;
   font-family: 'Lato';
 }
 

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -2,6 +2,7 @@
 // Synapse React Client (SRC) Core scss                     //
 //////////////////////////////////////////////////////////////
 // from // from SWC.scss and core.scss
+@use '../abstracts/variables' as SRC;
 
 // Fix scrollbar not showing for some people when css set to scroll: auto
 // Ref: https://stackoverflow.com/questions/7492062/css-overflow-scroll-always-show-vertical-scroll-bar
@@ -12,8 +13,8 @@
 
 ::-webkit-scrollbar-thumb {
   border-radius: 4px;
-  background-color: rgba(0, 0, 0, .5);
-  box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+  background-color: rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
 }
 a:hover {
   cursor: pointer;
@@ -33,8 +34,8 @@ svg.SRC-hoverBox {
 }
 
 .SRCBorderedPanel {
-  background: $gray-light;
-  border: 1px solid $border-color-gray;
+  background: SRC.$gray-light;
+  border: 1px solid SRC.$border-color-gray;
   padding: 10px;
 
   &--padded2x {
@@ -94,8 +95,9 @@ svg.SRC-hoverBox {
       width: 18px;
       height: 18px;
     }
-    svg, path {
-      fill: $primary-action-color;
+    svg,
+    path {
+      fill: SRC.$primary-action-color;
     }
   }
   .SRC-selected-table-icon {
@@ -103,7 +105,8 @@ svg.SRC-hoverBox {
       width: 18px;
       height: 18px;
     }
-    svg, path {
+    svg,
+    path {
       fill: #fff;
     }
   }
@@ -120,7 +123,8 @@ svg.SRC-hoverBox {
     display: flex;
   }
   .SRC-primary-background-color-hover:hover {
-    svg, path {
+    svg,
+    path {
       fill: #fff;
     }
   }
@@ -367,24 +371,24 @@ button.SRC-roundBorder {
 }
 
 .SRC-border-bottom-only {
-  border-bottom: 1px solid $border-color-gray;
+  border-bottom: 1px solid SRC.$border-color-gray;
 }
 
 .SRC-border-top-only {
-  border-top: 1px solid $border-color-gray;
+  border-top: 1px solid SRC.$border-color-gray;
 }
 
 .SRC-bar-border-bottom {
   padding: 7px; /*create more room around texts */
-  border-bottom: 1px solid $border-color-gray;
-  border-left: 1px solid $border-color-gray;
-  border-right: 1px solid $border-color-gray;
+  border-bottom: 1px solid SRC.$border-color-gray;
+  border-left: 1px solid SRC.$border-color-gray;
+  border-right: 1px solid SRC.$border-color-gray;
 }
 
 .SRC-bar-border-top {
-  border-top: 1px solid $border-color-gray;
-  border-left: 1px solid $border-color-gray;
-  border-right: 1px solid $border-color-gray;
+  border-top: 1px solid SRC.$border-color-gray;
+  border-left: 1px solid SRC.$border-color-gray;
+  border-right: 1px solid SRC.$border-color-gray;
 }
 
 #root {
@@ -873,7 +877,7 @@ div.SRC-userImg {
   padding-right: 15px;
 }
 .srcRssFeedItem {
-  border: 1px solid $border-color-gray;
+  border: 1px solid SRC.$border-color-gray;
   margin-bottom: 30px;
 }
 .srcRssFeedItemTitle {
@@ -1132,13 +1136,14 @@ hr ~ .SRC-wrapper {
       margin: 0;
       border-radius: 0;
       &.icon-vertical-dots {
-        width: 24px
+        width: 24px;
       }
 
       svg {
         color: #fff;
       }
-      svg, path {
+      svg,
+      path {
         fill: #fff;
       }
     }
@@ -1170,12 +1175,15 @@ hr ~ .SRC-wrapper {
 .homepage-button-link {
   border-radius: 24px;
   padding: 10px 24px;
-  background-color: $primary-action-color;
+  background-color: SRC.$primary-action-color;
   color: #fff;
   font-size: 16px;
   display: inline-block;
 
-  &:link, &:visited, &:hover, &:active {
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
     color: #fff;
   }
 }

--- a/src/lib/style/base/_icons.scss
+++ b/src/lib/style/base/_icons.scss
@@ -1,6 +1,8 @@
+@use '../abstracts/variables' as SRC;
+
 .SRC-arrow-icon {
   path {
-    fill: $primary-action-color;
+    fill: SRC.$primary-action-color;
   }
 }
 
@@ -8,10 +10,10 @@
 .SRC-r-icon,
 .SRC-python-icon {
   path {
-    fill: $primary-action-color-500;
+    fill: SRC.$primary-action-color-500;
   }
 }
 
 .SRC-terminal-icon > rect.outer {
-  fill: $primary-action-color-500;
+  fill: SRC.$primary-action-color-500;
 }

--- a/src/lib/style/bootstrap4_backports/_base-import.scss
+++ b/src/lib/style/bootstrap4_backports/_base-import.scss
@@ -1,22 +1,24 @@
+@use '../abstracts/variables' as SRC;
+
 .bootstrap-4-backport {
   //initial bootstrap config based on Synapse design
-  $primary: $primary-action-color;
-  $secondary: $secondary-action-color;
+  $primary: SRC.$primary-action-color;
+  $secondary: SRC.$secondary-action-color;
   $border-radius: 0.2rem;
 
   @import 'node_modules/bootstrap/scss/bootstrap';
 
   .btn-primary-900 {
     @include button-variant(
-      $primary-action-color-900,
-      $primary-action-color-900
+      SRC.$primary-action-color-900,
+      SRC.$primary-action-color-900
     );
   }
 
   .btn-primary-500 {
     @include button-variant(
-      $primary-action-color-500,
-      $primary-action-color-500
+      SRC.$primary-action-color-500,
+      SRC.$primary-action-color-500
     );
   }
 }

--- a/src/lib/style/bootstrap4_backports/_overrides.scss
+++ b/src/lib/style/bootstrap4_backports/_overrides.scss
@@ -57,7 +57,7 @@
   }
 
   // Buttons need more vertical padding when in mobile view.
-  @media (max-width: map-get($breakpoints, 'medium')) {
+  @media (max-width: map-get(SRC.$breakpoints, 'medium')) {
     .btn {
       padding-top: 0.75rem;
       padding-bottom: 0.75rem;

--- a/src/lib/style/bootstrap4_backports/_overrides.scss
+++ b/src/lib/style/bootstrap4_backports/_overrides.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 //overrides to bootstrap 4 that are directly applied to Bootstrap 4 class names
 .bootstrap-4-backport {
   //overrides
@@ -13,7 +15,7 @@
   }
 
   label {
-    color: $gray-deemphasized;
+    color: SRC.$gray-deemphasized;
     font-weight: normal;
   }
 
@@ -26,7 +28,7 @@
 
   // change styling of dropdowns
   %dropdown-active-state {
-    background: $primary-action-color;
+    background: SRC.$primary-action-color;
     color: white;
   }
   .show button.dropdown-toggle {
@@ -37,12 +39,12 @@
   }
   .dropdown-menu {
     a.dropdown-item:hover:not(.disabled) {
-      background: $primary-action-color;
+      background: SRC.$primary-action-color;
       color: white !important;
       text-decoration: none;
     }
     a.dropdown-item:hover:not(.disabled) * {
-      background: $primary-action-color;
+      background: SRC.$primary-action-color;
       color: white !important;
       text-decoration: none;
     }

--- a/src/lib/style/components/_access-requirement-list.scss
+++ b/src/lib/style/components/_access-requirement-list.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 .AccessRequirementList {
   color: #515359;
 
@@ -31,7 +33,7 @@
 
   &__register-text-link {
     display: block;
-    color: $primary-action-color;
+    color: SRC.$primary-action-color;
     margin-top: 20px;
     margin-bottom: 20px;
     padding-left: 25px;
@@ -53,11 +55,11 @@
   }
 
   .view-terms-button {
-    color: $primary-action-color;
+    color: SRC.$primary-action-color;
   }
 
   .update-request-button {
-    color: $primary-action-color;
+    color: SRC.$primary-action-color;
   }
 
   .accept-button-container {
@@ -68,7 +70,7 @@
   }
 
   .accept-button {
-    background-color: $primary-action-color;
+    background-color: SRC.$primary-action-color;
     padding: 10px 70px 10px 70px;
     color: white;
   }
@@ -79,12 +81,12 @@
     align-content: center;
     justify-content: center;
     text-align: center;
-    color: $primary-action-color;
+    color: SRC.$primary-action-color;
   }
 
   .get-access-requirement-button {
     margin-left: 10px;
-    background-color: $primary-action-color;
+    background-color: SRC.$primary-action-color;
     color: white;
   }
   .check-mark-container {

--- a/src/lib/style/components/_cards-rotate.scss
+++ b/src/lib/style/components/_cards-rotate.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 $card-rotate-margin: 21px;
 
 .UserCardListRotate {
@@ -33,7 +35,7 @@ $card-rotate-margin: 21px;
     }
 
     .cardContainer {
-      box-shadow: $box-shadow-soft;
+      box-shadow: SRC.$box-shadow-soft;
     }
 
   }
@@ -44,7 +46,7 @@ $card-rotate-margin: 21px;
     .UserCardListRotate__summary__link {
       border-radius: 24px;
       padding: 10px 24px;
-      background-color: $primary-action-color;
+      background-color: SRC.$primary-action-color;
       color: #fff;
       font-size: 16px;
       display: inline-block;

--- a/src/lib/style/components/_cards.scss
+++ b/src/lib/style/components/_cards.scss
@@ -1,3 +1,4 @@
+@use '../abstracts/variables' as SRC;
 
 //Variables
 $baseline-grid: 21px;
@@ -185,7 +186,7 @@ $text-color-lighter: #898989;
       margin: $baseline-grid 0 $baseline-grid $baseline-grid * 2;
       a {
         display: inline-flex;
-        background: $primary-action-color;
+        background: SRC.$primary-action-color;
         padding: 5px 20px;
         justify-content: center;
         align-items: center;

--- a/src/lib/style/components/_carousel.scss
+++ b/src/lib/style/components/_carousel.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 .SRC-Carousel {
   padding-top: 10px;
   padding-bottom: 10px;
@@ -35,14 +37,14 @@
       width: 16px;
       height: 16px;
       background: none;
-      border: 1px solid $primary-action-color-500;
+      border: 1px solid SRC.$primary-action-color-500;
     }
 
     .BrainhubCarousel__dot--selected::before {
       width: 16px;
       height: 16px;
-      background-color: $primary-action-color-500;
-      border: 1px solid $primary-action-color-500;
+      background-color: SRC.$primary-action-color-500;
+      border: 1px solid SRC.$primary-action-color-500;
     }
   }
 }

--- a/src/lib/style/components/_column-selection.scss
+++ b/src/lib/style/components/_column-selection.scss
@@ -1,9 +1,11 @@
+@use '../abstracts/variables' as SRC;
+
 %column-theme-dark {
   .SRC-primary-fill-color {
     fill: white;
   }
   .SRC-primary-stroke-color {
-    fill: $primary-action-color !important;
+    fill: SRC.$primary-action-color !important;
     stroke: white !important;
   }
 }
@@ -13,7 +15,7 @@ button {
     @extend %column-theme-dark;
     .SRC-column-light-theme {
       .SRC-light-column {
-        fill: $primary-action-color !important;
+        fill: SRC.$primary-action-color !important;
         stroke: white !important;
       }
     }

--- a/src/lib/style/components/_download-link.scss
+++ b/src/lib/style/components/_download-link.scss
@@ -1,8 +1,10 @@
+@use '../abstracts/variables' as SRC;
+
 .Download-Link {
   position: relative;
   display: inline-block;
   .icon-container {
-    background-color: $primary-action-color;
+    background-color: SRC.$primary-action-color;
     border-radius: 50%;
     width: 30px;
     height: 30px;

--- a/src/lib/style/components/_element-with-tooltip.scss
+++ b/src/lib/style/components/_element-with-tooltip.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 .ElementWithTooltip {
   display: inline-flex;
   align-items: center;
@@ -7,18 +9,19 @@
 
   &.dark-theme {
     svg {
-      fill: $primary-action-color;
-      color: $primary-action-color !important;
+      fill: SRC.$primary-action-color;
+      color: SRC.$primary-action-color !important;
       width: 18px;
       height: 18px;
 
       path {
-        fill: $primary-action-color;
+        fill: SRC.$primary-action-color;
       }
     }
 
     &:hover {
-      svg, path {
+      svg,
+      path {
         fill: #fff;
       }
     }
@@ -28,7 +31,7 @@
   .ElementWithTooltip {
     &.dark-theme {
       svg {
-        fill: $primary-action-color;
+        fill: SRC.$primary-action-color;
         color: white !important;
 
         path {
@@ -40,7 +43,8 @@
 }
 
 button.ElementWithTooltip {
-  &:active:focus, &:focus {
+  &:active:focus,
+  &:focus {
     outline: none;
   }
 }

--- a/src/lib/style/components/_facet-plots-card.scss
+++ b/src/lib/style/components/_facet-plots-card.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 .FacetPlotsCard {  
   background-color: white;
   overflow: hidden;
@@ -40,7 +42,7 @@
   &__loading {
     min-height: 400px;
   }
-  @media (max-width: map-get($breakpoints, 'medium')) {
+  @media (max-width: map-get(SRC.$breakpoints, 'medium')) {
     margin: 15px 0px;
   }
 }

--- a/src/lib/style/components/_featured-data-plots.scss
+++ b/src/lib/style/components/_featured-data-plots.scss
@@ -1,4 +1,6 @@
-@media (max-width: map-get($breakpoints, 'medium')) {
+@use '../abstracts/variables' as SRC;
+
+@media (max-width: map-get(SRC.$breakpoints, 'medium')) {
   .FeaturedDataPlots {
     &__queryPerCard, &__singleQuery {
       display: block;
@@ -8,7 +10,7 @@
     }    
   }
 }
-@media (min-width: map-get($breakpoints, 'medium')) {
+@media (min-width: map-get(SRC.$breakpoints, 'medium')) {
   .FeaturedDataPlots {
     &__queryPerCard, &__singleQuery .SRC-wrapper {
       display: flex;

--- a/src/lib/style/components/_feed-cards.scss
+++ b/src/lib/style/components/_feed-cards.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 .FeedWhatsNew {
   font-weight: bold;
 }
@@ -28,7 +30,7 @@
       cursor: pointer;
       border: 1px solid transparent;
       border-radius: 24px;
-      background-color: $primary-action-color;
+      background-color: SRC.$primary-action-color;
       color: white;
     }
   }
@@ -66,13 +68,13 @@
         justify-content: flex-start;
         flex-wrap: wrap;
         .FeedItemCategory {
-          border: 1px solid $primary-action-color;
+          border: 1px solid SRC.$primary-action-color;
           display: inline-flex;
           align-content: flex-start;
           border-radius: 100px;
           padding: 5px 20px;
           text-transform: uppercase;
-          color: $primary-action-color;
+          color: SRC.$primary-action-color;
           margin-right: 5px;
           margin-bottom: 5px;
           font-size: 12px;

--- a/src/lib/style/components/_goals.scss
+++ b/src/lib/style/components/_goals.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 // have space between items
 %space-between {
   display: flex;
@@ -26,7 +28,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    box-shadow: $box-shadow-soft;
+    box-shadow: SRC.$box-shadow-soft;
     background: #ffffff;
     margin: 10px;
     &:first-child {
@@ -39,7 +41,7 @@
     &__header {
       min-height: 75px;
       @extend %side-padding;
-      background: $primary-action-color;
+      background: SRC.$primary-action-color;
       background-size: cover !important;
       background-repeat: no-repeat !important;
       display: flex;
@@ -76,7 +78,7 @@
         height: 33px;
         padding: 20px;
         margin-top: 20px;
-        background: $primary-action-color;
+        background: SRC.$primary-action-color;
         border-radius: 24px;
         color: white !important;
       }
@@ -88,8 +90,8 @@
       @extend %hv-center;
       &__Count {
         @extend %hv-center;
-        border: 1px solid $primary-action-color;
-        color: $primary-action-color;
+        border: 1px solid SRC.$primary-action-color;
+        color: SRC.$primary-action-color;
         border-radius: 50%;
         min-height: 50px;
         min-width: 50px;
@@ -110,7 +112,7 @@
         height: 33px;
         padding: 20px;
         margin-top: 20px;
-        background: $primary-action-color;
+        background: SRC.$primary-action-color;
         border-radius: 24px;
         color: white !important;
       }

--- a/src/lib/style/components/_programs.scss
+++ b/src/lib/style/components/_programs.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 // horizontally and vertically center
 %hv-center {
   display: flex;
@@ -21,13 +23,13 @@
     display: flex;
     min-height: 300px;
     flex-direction: column;
-    box-shadow: $box-shadow-soft;
+    box-shadow: SRC.$box-shadow-soft;
     background: #ffffff;
     margin: 5px;
     &__header {
       min-height: 75px;
       @extend %side-padding;
-      background: $primary-action-color;
+      background: SRC.$primary-action-color;
       display: flex;
       align-items: center;
       .iconImg {

--- a/src/lib/style/components/_project-view-card.scss
+++ b/src/lib/style/components/_project-view-card.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 .ProjectViewCard {
   word-wrap: break-word;
   width: 410px;
@@ -22,7 +24,7 @@
   &__ImagePlaceholder {
     width: 100%;
     height: 25%;
-    background: $primary-action-color-300;
+    background: SRC.$primary-action-color-300;
   }
 
   &__ProjectName {

--- a/src/lib/style/components/_query-filter.scss
+++ b/src/lib/style/components/_query-filter.scss
@@ -1,6 +1,8 @@
+@use '../abstracts/variables' as SRC;
+
 .QueryFilter {
   margin: 0rem 1rem 1rem 0;
-  border: 1px solid $border-color-gray;
+  border: 1px solid SRC.$border-color-gray;
   padding: 1rem;
 
   &__facet {
@@ -10,6 +12,3 @@
     }
   }
 }
-
-
-

--- a/src/lib/style/components/_range-slider.scss
+++ b/src/lib/style/components/_range-slider.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 $textLight: #b7b7b7;
 
 .RangeSlider {
@@ -53,14 +55,14 @@ $textLight: #b7b7b7;
     cursor: pointer;
     border-radius: 50%;
     box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.2);
-    background-color: $primary-action-color;
+    background-color: SRC.$primary-action-color;
   }
 
   &__track {
     position: absolute;
     height: $rail-height;
     z-index: 1;
-    background-color: $primary-action-color;
+    background-color: SRC.$primary-action-color;
     border-radius: $rail-height/2;
     cursor: pointer;
   }

--- a/src/lib/style/components/_resources.scss
+++ b/src/lib/style/components/_resources.scss
@@ -1,8 +1,11 @@
+@use '../abstracts/variables' as SRC;
+@use 'sass:color';
+
 // TODO: These colors to be configurable for the other portals.
 .Resources {
   background-color: rgba(64, 123, 160, 0.05);
   a {
-    color: $primary-action-color;
+    color: SRC.$primary-action-color;
   }
   .control-container {
     background: white;
@@ -23,10 +26,12 @@
         padding: 10px;
         &.isSelected,
         &:not(.gap-fill):hover {
-          color: $primary-action-color;
-          // Hex value can also set opacity, using two extra values at the end
-          background-color: #{$primary-action-color}0a;
-          border-right: 2px solid $primary-action-color;
+          color: SRC.$primary-action-color;
+          background-color: color.adjust(
+            SRC.$primary-action-color,
+            $alpha: 0.04
+          );
+          border-right: 2px solid SRC.$primary-action-color;
         }
         border-right: 2px solid #dcdcdc;
         font-weight: bold;

--- a/src/lib/style/components/_searchv2.scss
+++ b/src/lib/style/components/_searchv2.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 .SearchV2 {
   &__searchbar {
     height: 50px;
@@ -6,7 +8,7 @@
     display: flex;
     align-items: center;
     &:focus-within {
-      outline-color: $primary-action-color;
+      outline-color: SRC.$primary-action-color;
       outline-style: auto;
       outline-width: 5px;
     }
@@ -54,7 +56,7 @@
 
   // Search bar height animation
   &__animate_height {
-    max-height: 0;            
+    max-height: 0;
     overflow-y: hidden;
     -webkit-transition: max-height 0.3s ease-in-out;
     -moz-transition: max-height 0.3s ease-in-out;
@@ -63,7 +65,7 @@
   }
 
   &__animate_bar-enter-done {
-    max-height: 50px;  // fixed height required for css height animation
+    max-height: 50px; // fixed height required for css height animation
   }
 
   &__animate_bar-exit-done {
@@ -71,7 +73,7 @@
   }
 
   &__animate_dropdown-enter-done {
-    max-height: 300px;  // fixed height required for css height animation
+    max-height: 300px; // fixed height required for css height animation
   }
 
   &__animate_dropdown-exit-done {
@@ -82,25 +84,23 @@
     position: relative;
     width: 100%;
   }
-  
+
   &__column-select.SearchV2__animate_height {
     overflow: scroll;
   }
-  
+
   &__animate_dropdown-exit-active,
   &__animate_dropdown-enter-done {
     padding-left: 30px;
     padding-top: 15px;
     padding-bottom: 5px;
   }
-  
+
   &__animate_dropdown-exit-done {
-    padding: 0
+    padding: 0;
   }
 
   .radio {
-    padding: 4px 0;  
+    padding: 4px 0;
   }
-
 }
-

--- a/src/lib/style/components/_synapse-homepage.scss
+++ b/src/lib/style/components/_synapse-homepage.scss
@@ -1,3 +1,5 @@
+@use '../abstracts/variables' as SRC;
+
 .SynapseHomepage {
   color: #515359;
   &__Section {
@@ -49,7 +51,7 @@
     flex-shrink: 1;
   }
 
-  @media (max-width: map-get($breakpoints, 'medium')) {
+  @media (max-width: map-get(SRC.$breakpoints, 'medium')) {
     &__Section {
       padding: 30px 40px;
     }
@@ -98,7 +100,7 @@
     }
   }
 
-  @media (min-width: map-get($breakpoints, 'medium') + 1) {
+  @media (min-width: map-get(SRC.$breakpoints, 'medium') + 1) {
     &__Section {
       padding: 50px 60px;
     }

--- a/src/lib/style/components/_total-query-results.scss
+++ b/src/lib/style/components/_total-query-results.scss
@@ -1,5 +1,7 @@
+@use '../abstracts/variables' as SRC;
+
 .TotalQueryResults {
-  background: $gray-light;
+  background: SRC.$gray-light;
   /* Divider */
 
   margin-top: -1px;
@@ -38,7 +40,7 @@
   font-size: 1.2rem;
   line-height: 100%;
   cursor: pointer;
-  background-color: $primary-action-color !important;
+  background-color: SRC.$primary-action-color !important;
   color: #fff;
   font-weight: normal;
   margin: 10px;

--- a/src/lib/style/components/_user-card-list-groups.scss
+++ b/src/lib/style/components/_user-card-list-groups.scss
@@ -1,14 +1,17 @@
+@use '../abstracts/variables' as SRC;
+@use 'sass:color';
+
 .UserCardListGroups {
   a {
-    color: $primary-action-color;
+    color: SRC.$primary-action-color;
   }
   &__Desktop {
     .control-container {
       background: white;
       border: 1px solid #dcdcdc;
-      display: flex;    
+      display: flex;
       padding: 15px;
-      height: 500px;  
+      height: 500px;
       .button-container {
         flex: 1;
         display: flex;
@@ -23,10 +26,14 @@
           padding: 10px;
           &.isSelected,
           &:not(.gap-fill):hover {
-            color: $primary-action-color;
-            // Hex value can also set opacity, using two extra values at the end
-            background-color: #{$primary-action-color}0a;
-            border-right: 2px solid $primary-action-color;
+            color: SRC.$primary-action-color;
+            // Hex value can also set opacity, using two extra values at the
+            background-color: color.adjust(
+              SRC.$primary-action-color,
+              $alpha: 0.04
+            );
+            // background-color: #{SRC.$primary-action-color}0a;
+            border-right: 2px solid SRC.$primary-action-color;
           }
           border-right: 2px solid #dcdcdc;
           font-weight: bold;

--- a/src/lib/style/components/evaluation_queue/_evaluation-card.scss
+++ b/src/lib/style/components/evaluation_queue/_evaluation-card.scss
@@ -1,3 +1,5 @@
+@use '../../abstracts/variables' as SRC;
+
 .evaluation-card {
   .submit-button {
     margin-top: 1rem;
@@ -13,7 +15,7 @@
 
   .status-open {
     //we want to make the sync icon be centered with the text
-    color: $green-affrimative;
+    color: SRC.$green-affrimative;
     .status {
       align-items: center;
     }
@@ -24,7 +26,7 @@
   .status-completed {
     //we want the clipboard icon to be bottom-aligned with the text
     svg {
-      color: $green-affrimative;
+      color: SRC.$green-affrimative;
     }
     .status {
       align-items: baseline;

--- a/src/lib/style/components/evaluation_queue/_evaluation-round-editor.scss
+++ b/src/lib/style/components/evaluation_queue/_evaluation-round-editor.scss
@@ -1,3 +1,5 @@
+@use '../../abstracts/variables' as SRC;
+
 .evaluation-round-editor {
   .card-body {
     // even though all sides have the same padding,
@@ -20,18 +22,18 @@
 
   .round-status {
     .status-in-progress {
-      color: $green-affrimative;
+      color: SRC.$green-affrimative;
     }
     .status-completed {
       svg {
-        color: $green-affrimative;
+        color: SRC.$green-affrimative;
       }
       span {
-        color: $gray-deemphasized;
+        color: SRC.$gray-deemphasized;
       }
     }
     .status-not-yet-started {
-      color: $gray-deemphasized;
+      color: SRC.$gray-deemphasized;
     }
   }
 
@@ -76,13 +78,13 @@
     .remove-button {
       grid-column-start: remove-button;
       svg {
-        fill: $primary-action-color;
+        fill: SRC.$primary-action-color;
       }
     }
     .add-button {
       grid-column-start: add-button;
       svg {
-        fill: $primary-action-color;
+        fill: SRC.$primary-action-color;
       }
     }
   }

--- a/src/lib/style/components/facet_nav/_facet-nav-panel.scss
+++ b/src/lib/style/components/facet_nav/_facet-nav-panel.scss
@@ -1,3 +1,5 @@
+@use '../../abstracts/variables' as SRC;
+
 $facetNavPanel-btn-padding: 3px;
 $facetNavPanel-btn-margin: 0 1px;
 
@@ -16,7 +18,7 @@ $facetNavPanel-btn-margin: 0 1px;
       font-weight: 700;
     }
     padding-bottom: 10px;
-    border-bottom: 1px solid $gray-dark;
+    border-bottom: 1px solid SRC.$gray-dark;
     display: flex;
     &__tools {
       font-size: 16px;

--- a/src/lib/style/components/facet_nav/_facet-nav.scss
+++ b/src/lib/style/components/facet_nav/_facet-nav.scss
@@ -1,7 +1,9 @@
+@use '../../abstracts/variables' as SRC;
+
 .FacetNav {
   padding-top: 5px;
   padding-bottom: 5px;
-  border: 1px solid $gray-dark;
+  border: 1px solid SRC.$gray-dark;
 
   &__row {
     background-color: #fff;
@@ -23,7 +25,7 @@
 
     .FacetNav__showMore:focus {
       // somehow &__showMore:focus doesn't work
-      outline-color: $primary-action-color;
+      outline-color: SRC.$primary-action-color;
     }
   }
 }

--- a/src/lib/style/components/query_filter/_enum-facet-filter.scss
+++ b/src/lib/style/components/query_filter/_enum-facet-filter.scss
@@ -1,3 +1,5 @@
+@use '../../abstracts/variables' as SRC;
+
 .EnumFacetFilter {
   $input-icon-margin: 5px;
 
@@ -17,7 +19,7 @@
     }
 
     &--forAll {
-      border-bottom: dotted 1px $border-color-gray;
+      border-bottom: dotted 1px SRC.$border-color-gray;
       padding: 0;
     }
   }
@@ -42,10 +44,10 @@
       border: 1px solid #dcdcdc;
       padding: 6px 30px;
       &::placeholder {
-        color: $gray-deemphasized;
+        color: SRC.$gray-deemphasized;
       }
       &:focus {
-        outline-color: $primary-action-color;
+        outline-color: SRC.$primary-action-color;
       }
     }
     button {
@@ -74,7 +76,7 @@
 
       > span {
         margin-left: 2px;
-        color: $gray-regular;
+        color: SRC.$gray-regular;
       }
     }
     input ~ span {
@@ -94,10 +96,10 @@
     width: 100%;
     margin: 10px 0 0 0;
     padding: 0;
-    color: $primary-action-color !important;
+    color: SRC.$primary-action-color !important;
 
     &:hover {
-      color: $primary-action-color !important;
+      color: SRC.$primary-action-color !important;
       text-decoration: underline;
     }
   }
@@ -109,7 +111,7 @@
   &__count {
     margin-left: 10px;
     align-self: center;
-    color: $gray-deemphasized;
+    color: SRC.$gray-deemphasized;
   }
 
   &__noMatch {
@@ -117,6 +119,6 @@
   }
 
   button {
-    color: $primary-action-color;
+    color: SRC.$primary-action-color;
   }
 }

--- a/src/lib/style/components/synapse_form_wrapper/_steps-side-nav.scss
+++ b/src/lib/style/components/synapse_form_wrapper/_steps-side-nav.scss
@@ -1,3 +1,6 @@
+@use '../../abstracts/variables' as SrcVars;
+@use '../../abstracts/mixins' as SrcMixins;
+
 /* --- Steps Left Nav ---*/
 .json-forms-menu {
   // top level menu
@@ -8,7 +11,7 @@
     list-style-type: none;
     padding: 0px;
     margin: 0px;
-    background-color: $gray-light;
+    background-color: SrcVars.$gray-light;
 
     li {
       min-height: $item-height;
@@ -28,12 +31,12 @@
       height: $item-height;
       line-height: $item-height;
       text-align: left;
-      @include themify($themes) {
+      @include SrcMixins.themify(SrcVars.$themes) {
         color: themed('action-color');
       }
 
-      background-color: $gray-dark;
-      border-left-color: $gray-dark;
+      background-color: SrcVars.$gray-dark;
+      border-left-color: SrcVars.$gray-dark;
 
       .btn-link {
         color: white;
@@ -61,7 +64,7 @@
     }
 
     .btn-link {
-      @include themify($themes) {
+      @include SrcMixins.themify(SrcVars.$themes) {
         color: themed('action-color');
       }
       font-weight: bold;
@@ -77,27 +80,27 @@
     }
 
     .fa-check-circle {
-      @include themify($themes) {
+      @include SrcMixins.themify(SrcVars.$themes) {
         color: themed('action-color');
       }
     }
 
     .fa-circle {
       border-radius: 50%;
-      border: 1px solid $gray-dark;
-      color: $gray-light;
+      border: 1px solid SrcVars.$gray-dark;
+      color: SrcVars.$gray-light;
     }
 
     .static .fa-circle {
-      border: 1px solid $secondary-action-color;
-      @include themify($themes) {
+      border: 1px solid SrcVars.$secondary-action-color;
+      @include SrcMixins.themify(SrcVars.$themes) {
         color: themed('action-color');
       }
     }
 
     .fa-exclamation-circle {
-      color: $red-error;
-      background-color: $gray-light;
+      color: SrcVars.$red-error;
+      background-color: SrcVars.$gray-light;
       border-radius: 50%;
     }
 
@@ -136,7 +139,7 @@
 
         div.item {
           $b: 1.7rem;
-          @include calc(padding-left, '#{$left-offset} + #{$b}');
+          @include SrcMixins.calc(padding-left, '#{$left-offset} + #{$b}');
         }
       }
     }

--- a/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
+++ b/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
@@ -1,3 +1,6 @@
+@use '../../abstracts/variables' as SrcVariables;
+@use '../../abstracts/mixins' as SrcMixins;
+
 /* MODAL OVERWRITE! */
 .modal-backdrop {
   opacity: 0.7;
@@ -11,11 +14,11 @@
     h2 {
       font-size: 2.1rem;
       font-weight: 700;
-      color: $gray-formtext;
+      color: SrcVariables.$gray-formtext;
     }
     &.submitted {
       div {
-        @include themify($themes) {
+        @include SrcMixins.themify(SrcVariables.$themes) {
           color: themed('action-color');
         }
         font-weight: bold;
@@ -27,7 +30,7 @@
     }
   }
   hr {
-    margin: $space-unit 0 $space-unit 0;
+    margin: SrcVariables.$space-unit 0 SrcVariables.$space-unit 0;
   }
   .fade {
     opacity: inherit;
@@ -36,7 +39,7 @@
   .nav-link,
   a.nav-link,
   .nav-link > a {
-    @include themify($themes) {
+    @include SrcMixins.themify(SrcVariables.$themes) {
       color: themed('action-color');
     }
     font-weight: bold;
@@ -47,17 +50,17 @@
   }
 
   .btn-action {
-    @include themify($themes) {
+    @include SrcMixins.themify(SrcVariables.$themes) {
       background-color: themed('action-color');
     }
     color: #fff;
   }
   .btn-action:hover,
   .btn-action:focus {
-    @include themify($themes) {
+    @include SrcMixins.themify(SrcVariables.$themes) {
       background-color: themed('action-color');
     }
-    @include box-shadow(3px, 3px, 5px, rgba(0, 0, 0, 0.5));
+    @include SrcMixins.box-shadow(3px, 3px, 5px, rgba(0, 0, 0, 0.5));
     color: #fff;
   }
 
@@ -87,12 +90,15 @@
       padding-left: 0.8rem;
     }
     .panel {
-      background-color: $gray-light;
+      background-color: SrcVariables.$gray-light;
     }
     .file-table {
-      @include calc(margin-bottom, '#{$space-unit} * #{3}');
+      @include SrcMixins.calc(
+        margin-bottom,
+        '#{SrcVariables.$space-unit} * #{3}'
+      );
       button.btn {
-        @include themify($themes) {
+        @include SrcMixins.themify(SrcVariables.$themes) {
           color: themed('action-color');
         }
       }
@@ -124,7 +130,7 @@
           vertical-align: middle;
         }
         a {
-          @include themify($themes) {
+          @include SrcMixins.themify(SrcVariables.$themes) {
             color: themed('action-color');
           }
         }
@@ -133,7 +139,7 @@
 
     .btn-large {
       color: #fff;
-      @include themify($themes) {
+      @include SrcMixins.themify(SrcVariables.$themes) {
         background-color: themed('action-color');
       }
 
@@ -154,13 +160,13 @@
   $b: 35rem;
 
   .wrap {
-    @include calc(height, '#{$a} - #{$b}');
+    @include SrcMixins.calc(height, '#{$a} - #{$b}');
     overflow: hidden;
     width: 100%;
     clear: both;
-    padding: $space-unit 0 1rem $space-unit;
+    padding: SrcVariables.$space-unit 0 1rem SrcVariables.$space-unit;
 
-    background-color: $gray-light;
+    background-color: SrcVariables.$gray-light;
 
     h4 {
       margin-top: 0;
@@ -174,11 +180,11 @@
   }
 
   .notification-area {
-    @include themify($themes) {
+    @include SrcMixins.themify(SrcVariables.$themes) {
       color: themed('action-color');
     }
     font-style: italic;
-    margin-bottom: $space-unit;
+    margin-bottom: SrcVariables.$space-unit;
   }
 
   .inner-wrap {
@@ -221,17 +227,17 @@
   ul.error-detail li {
     list-style: none;
     font-style: italic;
-    color: $red-error2;
+    color: SrcVariables.$red-error2;
   }
 
   .step-exclude-directions {
     font-style: italic;
 
     vertical-align: middle;
-    @include calc(line-height, '#{$space-unit} * 2');
-    @include calc(height, '#{$space-unit} * 2');
+    @include SrcMixins.calc(line-height, '#{SrcVariables.$space-unit} * 2');
+    @include SrcMixins.calc(height, '#{SrcVariables.$space-unit} * 2');
     button.btn-link {
-      @include themify($themes) {
+      @include SrcMixins.themify(SrcVariables.$themes) {
         color: themed('action-color');
       }
       font-weight: 700;
@@ -255,18 +261,18 @@
   .has-error.checkbox-inline label,
   .has-error.radio label,
   .has-error.radio-inline label {
-    color: $red-error2;
+    color: SrcVariables.$red-error2;
   }
 
   input[type='checkbox']:checked + label::before,
   input[type='checkbox']:checked + span::before {
-    @include themify($themes) {
+    @include SrcMixins.themify(SrcVariables.$themes) {
       color: themed('action-color');
     }
   }
 
   .has-error .form-control {
-    border-color: $red-error2;
+    border-color: SrcVariables.$red-error2;
   }
 
   /*--- form ---*/
@@ -292,7 +298,7 @@
       legend {
         font-size: 1.4rem;
         font-weight: normal;
-        color: $gray-formtext;
+        color: SrcVariables.$gray-formtext;
         display: block;
         margin-bottom: 0;
       }
@@ -315,7 +321,7 @@
   .data-range legend {
     font-size: 1.4rem;
     font-weight: normal;
-    color: $gray-formtext;
+    color: SrcVariables.$gray-formtext;
   }
 
   .form-group {
@@ -333,11 +339,13 @@
     height: 1.5rem;
   }
 
-  .radio input[type='radio'] + label, .radio input[type='radio'] + span {
+  .radio input[type='radio'] + label,
+  .radio input[type='radio'] + span {
     padding-left: 24px;
   }
 
-  .radio input[type='radio']:checked + label, .radio input[type='radio']:checked + span {
+  .radio input[type='radio']:checked + label,
+  .radio input[type='radio']:checked + span {
     padding-left: 23px;
   }
 
@@ -345,7 +353,7 @@
   .radio input[type='radio']:checked + span::before,
   .radio-inline input[type='radio']:checked + label::before,
   .radio-inline input[type='radio']:checked + span::before {
-    @include themify($themes) {
+    @include SrcMixins.themify(SrcVariables.$themes) {
       background: themed('action-color');
     }
     vertical-align: middle;
@@ -357,7 +365,7 @@
     margin-right: 1rem;
   }
   .array-item {
-    border: 1px solid $gray-dark;
+    border: 1px solid SrcVariables.$gray-dark;
     padding: 2rem 1rem;
     overflow: auto;
     margin: 0 1.6rem 2rem 1.6rem;
@@ -395,7 +403,7 @@
     button,
     button:hover {
       background-color: transparent;
-      @include themify($themes) {
+      @include SrcMixins.themify(SrcVariables.$themes) {
         color: themed('action-color');
       }
       border: none;
@@ -406,7 +414,7 @@
     }
 
     i.glyphicon {
-      @include themify($themes) {
+      @include SrcMixins.themify(SrcVariables.$themes) {
         background: themed('action-color');
       }
       color: white;
@@ -428,10 +436,10 @@
     width: 100%;
     button.btn-info.btn-add {
       background-color: transparent;
-      @include themify($themes) {
+      @include SrcMixins.themify(SrcVariables.$themes) {
         color: themed('action-color');
       }
-      border: 1px solid $gray-dark;
+      border: 1px solid SrcVariables.$gray-dark;
       padding: 2rem 3.3rem;
       text-align: right;
       /*box-shadow: none;*/
@@ -442,7 +450,7 @@
     }
 
     i.glyphicon {
-      @include themify($themes) {
+      @include SrcMixins.themify(SrcVariables.$themes) {
         background-color: themed('action-color');
       }
       color: white;
@@ -457,7 +465,7 @@
   }
   .toggle-help-label {
     line-height: 3em;
-    border: 1px solid $gray-light;
+    border: 1px solid SrcVariables.$gray-light;
 
     padding: 0 1em;
     margin: 0 1em;
@@ -468,7 +476,7 @@
     vertical-align: middle;
     margin: 0 5px;
     .react-switch-bg {
-      @include themify($themes) {
+      @include SrcMixins.themify(SrcVariables.$themes) {
         background-color: themed('action-color') !important;
       }
     }
@@ -481,7 +489,7 @@
     .scroll-area {
       height: 100%;
       &.table-body {
-        @include calc(height, '#{$c} - #{$d}');
+        @include SrcMixins.calc(height, '#{$c} - #{$d}');
       }
     }
     .summary-table-header {
@@ -517,7 +525,7 @@
 .btn-success,
 .btn-success:active,
 .btn-success:focus {
-  @include themify($themes) {
+  @include SrcMixins.themify(SrcVariables.$themes) {
     background-color: themed('action-color');
     border-color: themed('action-color');
   }
@@ -548,4 +556,3 @@
     }
   }
 }
-

--- a/src/lib/style/main.scss
+++ b/src/lib/style/main.scss
@@ -1,21 +1,29 @@
 @charset "UTF-8";
 
 // 0. Configuration and helpers
-@import 'abstracts/variables', 'abstracts/functions', 'abstracts/mixins';
+@forward 'abstracts/variables';
+@use 'abstracts/variables';
+@use 'abstracts/functions';
+@use 'abstracts/mixins';
+
 
 // 1. Bootstrap 4 backports.
 // We currently use Bootstrap 3 CSS but accidentally ended up using react-bootstrap 1.x.x, which was designed for Bootstrap 4
 // In an effort to facilitate eventual migration towards Bootstrap 4, we backport certain styling that are new or changed in Bootstrap 4
-@import 'bootstrap4_backports/all';
+@use 'bootstrap4_backports/all';
 
 // 2. Vendors
-@import 'vendors/normalize';
+@use 'vendors/normalize';
 
 // 3. Base stuff
-@import 'base/base', 'base/fonts', 'base/helpers', 'base/core', 'base/icons';
+@use 'base/base';
+@use 'base/fonts';
+@use 'base/helpers';
+@use 'base/core';
+@use 'base/icons';
 
 // 4. Components
-@import 'components/all';
+@use 'components/all' as all2;
 
 // 5. Themes
 // at least for now we are handing themes as a different import

--- a/src/lib/template_style/Index.scss
+++ b/src/lib/template_style/Index.scss
@@ -1,2 +1,2 @@
-@import './theme.scss';
-@import './form.scss';
+@use './theme.scss';
+@use './form.scss';

--- a/src/lib/template_style/_form.scss
+++ b/src/lib/template_style/_form.scss
@@ -1,3 +1,4 @@
+@use '../style/abstracts/variables' as SRC;
 //////////////////////////////////////////////////////////////
 // params: $primary-action-color                            //
 //////////////////////////////////////////////////////////////
@@ -31,7 +32,7 @@ input[type='radio'] {
 .indeterminate-checkbox input[type='checkbox'] + label::before,
 .indeterminate-checkbox input[type='checkbox'] + span::before {
   content: '–';
-  color: $primary-action-color;
+  color: SRC.$primary-action-color;
   font-size: 14px;
   margin-left: -17px;
   top: 1px;
@@ -42,7 +43,7 @@ input[type='radio'] {
 input[type='checkbox']:checked + label::before,
 input[type='checkbox']:checked + span::before {
   content: '✓';
-  color: $primary-action-color;
+  color: SRC.$primary-action-color;
   font-size: 14px;
   margin-left: -19px;
   top: 1px;
@@ -62,7 +63,7 @@ input[type='checkbox']:checked + span::before {
   border-radius: 50%;
   margin-left: -18px;
   margin-right: 8px;
-  background: $primary-action-color;
+  background: SRC.$primary-action-color;
 }
 .radio input[type='radio'] + label,
 .radio input[type='radio'] + span,

--- a/src/lib/template_style/_theme.scss
+++ b/src/lib/template_style/_theme.scss
@@ -2,27 +2,28 @@
 // Synapse React Client (SRC) Custom scss                   //
 // params: $primary-action-color                            //
 //////////////////////////////////////////////////////////////
+@use '../style/abstracts/variables' as SRC;
 
 .SRC-primary-text-color {
-  color: $primary-action-color !important;
+  color: SRC.$primary-action-color !important;
 }
 .SRC-primary-fill-color {
-  fill: $primary-action-color;
+  fill: SRC.$primary-action-color;
 }
 .SRC-primary-stroke-color {
-  stroke: $primary-action-color;
+  stroke: SRC.$primary-action-color;
 }
 .SRC-primary-color-hover:hover * {
-  color: $primary-action-color !important;
-  fill: $primary-action-color !important;
+  color: SRC.$primary-action-color !important;
+  fill: SRC.$primary-action-color !important;
 }
 
 .SRC-primary-background-color {
-  background-color: $primary-action-color !important;
+  background-color: SRC.$primary-action-color !important;
 }
 
 .SRC-primary-background-color-border-left {
-  border-left-color: $primary-action-color !important;
+  border-left-color: SRC.$primary-action-color !important;
 }
 
 %hoverFade {
@@ -34,17 +35,17 @@
 }
 
 .SRC-primary-background-color-hover:hover {
-  background-color: $primary-action-color !important;
+  background-color: SRC.$primary-action-color !important;
   color: white !important;
   fill: white !important;
   * {
-    background-color: $primary-action-color !important;
+    background-color: SRC.$primary-action-color !important;
     color: white !important;
   }
 }
 
 .grip-handle:hover {
-  background-color: $primary-action-color !important;
+  background-color: SRC.$primary-action-color !important;
   width: 3px;
 }
 
@@ -60,13 +61,13 @@
   border: none;
   background: white;
   &:focus {
-    outline: $primary-action-color;
+    outline: SRC.$primary-action-color;
   }
 }
 
 .SRC-button-focus-primary-color {
   &:focus {
-    outline-color: $primary-action-color;
+    outline-color: SRC.$primary-action-color;
     outline-style: auto;
     outline-width: 5px;
   }
@@ -74,7 +75,7 @@
 
 .SRC-primary-button,
 .SRC-primary-button.btn.btn-primary {
-  background: $primary-action-color;
+  background: SRC.$primary-action-color;
   border: none;
   color: white !important;
   &:hover {
@@ -92,7 +93,7 @@
     @extend %hoverFade;
     @extend %defaultBoxShadow;
     text-decoration: none;
-    background: $primary-action-color;
+    background: SRC.$primary-action-color;
     color: white;
   }
 }
@@ -104,7 +105,7 @@
     bottom: 7px;
     right: 7px;
     border-radius: 24px;
-    background-color: $primary-action-color;
+    background-color: SRC.$primary-action-color;
     color: white !important;
     height: 44px;
     width: 257px;
@@ -124,7 +125,7 @@
 .SRC-basicButton {
   border: none;
   background: none;
-  color: $primary-action-color;
+  color: SRC.$primary-action-color;
 }
 
 .SRC-mailchimpSubscribeContainer {
@@ -144,26 +145,26 @@
     cursor: pointer;
     border: 1px solid transparent;
     border-radius: 24px;
-    background-color: $primary-action-color;
+    background-color: SRC.$primary-action-color;
     color: white;
   }
 }
 
 :focus {
-  outline-color: $primary-action-color;
+  outline-color: SRC.$primary-action-color;
 }
 
 .SRC-portalCard {
   .SRC-cardAction {
     button {
-      background-color: $primary-action-color;
+      background-color: SRC.$primary-action-color;
     }
   }
   a {
-    color: $primary-action-color;
+    color: SRC.$primary-action-color;
   }
   .SRC-downloadData {
-    background-color: $primary-action-color;
+    background-color: SRC.$primary-action-color;
   }
 }
 
@@ -175,14 +176,14 @@
     border: none;
     button.close {
       font-size: 25px;
-      color: $primary-action-color;
+      color: SRC.$primary-action-color;
       opacity: 1;
     }
   }
 }
 
 %dropdown-active-state {
-  background: $primary-action-color;
+  background: SRC.$primary-action-color;
   border-radius: 0;
   color: white;
 }
@@ -196,19 +197,19 @@ button.dropdown-toggle:hover {
 
 .dropdown-menu.SRC-primary-color-hover-dropdown {
   a.dropdown-item:hover:not(.disabled) {
-    background: $primary-action-color;
+    background: SRC.$primary-action-color;
     color: white !important;
     text-decoration: none;
   }
   a.dropdown-item:hover:not(.disabled) * {
-    background: $primary-action-color;
+    background: SRC.$primary-action-color;
     color: white !important;
     text-decoration: none;
   }
 }
 
 .SRC-icon-fill {
-  fill: $primary-action-color;
+  fill: SRC.$primary-action-color;
 }
 
 .SRC-portalCardHeader {
@@ -224,10 +225,10 @@ a:link,
 a:visited,
 a:hover,
 a:active {
-  color: $primary-action-color;
+  color: SRC.$primary-action-color;
 }
 
 .homepage-color-background {
-  background-color: $primary-bgcolor-rgba;
+  background-color: SRC.$primary-bgcolor-rgba;
   padding: 40px 0;
 }


### PR DESCRIPTION
Depends on #822, https://github.com/Sage-Bionetworks/portals/pull/534.

First, see #822, which aims to replace node-sass with Dart Sass in our toolchain.

`@use` and `@forward` are replacements for `@import` that are supported in Dart Sass (and will never be supported by node-sass because it is deprecated).

This PR uses these where possible. Notably, we can use a namespace for our variables, eliminating the risk of a variable name collision. No styles or behavior should be changed.