### PR TITLE
Missed some changes from node-sass to Dart Sass

### DIFF
--- a/src/lib/style/components/synapse_form_wrapper/_steps-side-nav.scss
+++ b/src/lib/style/components/synapse_form_wrapper/_steps-side-nav.scss
@@ -136,7 +136,7 @@
 
         div.item {
           $b: 1.7rem;
-          @include calc(padding-left, #{$left-offset} + #{$b});
+          @include calc(padding-left, '#{$left-offset} + #{$b}');
         }
       }
     }

--- a/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
+++ b/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
@@ -154,7 +154,7 @@
   $b: 35rem;
 
   .wrap {
-    @include calc(height, #{$a} - #{$b});
+    @include calc(height, '#{$a} - #{$b}');
     overflow: hidden;
     width: 100%;
     clear: both;
@@ -481,7 +481,7 @@
     .scroll-area {
       height: 100%;
       &.table-body {
-        @include calc(height, #{$c} - #{$d});
+        @include calc(height, '#{$c} - #{$d}');
       }
     }
     .summary-table-header {


### PR DESCRIPTION
Sass changed its interpolation behavior between LibSass/node-sass and Dart Sass. We previously caught a few cases where this broke Sass compilation. Here are a few places where sass successfully compiled, but produced invalid CSS