### PR TITLE
SWC-5356: CreateAccessTokenModal -- 'enter' keypress should trigger submit

### DIFF
--- a/src/__tests__/lib/containers/personal_access_token/CreateAccessTokenModal.test.tsx
+++ b/src/__tests__/lib/containers/personal_access_token/CreateAccessTokenModal.test.tsx
@@ -4,7 +4,7 @@ import { ErrorBanner } from 'lib/containers/ErrorBanner'
 import { CreateAccessTokenModal } from 'lib/containers/personal_access_token/CreateAccessTokenModal'
 import { Checkbox } from 'lib/containers/widgets/Checkbox'
 import * as React from 'react'
-import { Button } from 'react-bootstrap'
+import { Button, Modal } from 'react-bootstrap'
 import { act } from 'react-dom/test-utils'
 
 const EXAMPLE_PAT = 'abcdefghiklmnop'
@@ -12,6 +12,10 @@ const SynapseClient = require('../../../../lib/utils/SynapseClient')
 
 const mockOnClose = jest.fn(() => null)
 const mockOnCreate = jest.fn(() => null)
+
+const clickEvent: any = {
+  preventDefault: () => {},
+}
 
 SynapseClient.createPersonalAccessToken = jest.fn().mockResolvedValue({
   token: EXAMPLE_PAT,
@@ -34,17 +38,15 @@ describe('basic functionality', () => {
 
     // Fill out the form
     await act(async () => {
-      await wrapper
-        .find('FormControl')
-        .simulate('change', {
-          target: {
-            value: tokenName,
-          },
-        })
+      wrapper.find('FormControl').simulate('change', {
+        target: {
+          value: tokenName,
+        },
+      })
       await wrapper.find(Checkbox).at(0).prop('onChange')()
       await wrapper.find(Checkbox).at(1).prop('onChange')()
       await wrapper.find(Checkbox).at(2).prop('onChange')()
-      await wrapper.find(Button).at(1).simulate('click')
+      wrapper.find(Button).at(1).prop('onClick')!(clickEvent)
     })
 
     expect(mockOnCreate).toHaveBeenCalled()
@@ -56,7 +58,7 @@ describe('basic functionality', () => {
 
     // Close the modal using the 'Close' button
     expect(wrapper.find(Button).text().includes('Close')).toBe(true)
-    wrapper.find(Button).prop('onClick')()
+    wrapper.find(Button).prop('onClick')!(clickEvent)
 
     expect(mockOnClose).toHaveBeenCalled()
   })
@@ -70,7 +72,7 @@ describe('basic functionality', () => {
       expect(wrapper.find(Button).at(1).text().includes('Create Token')).toBe(
         true,
       )
-      await wrapper.find(Button).at(1).simulate('click')
+      wrapper.find(Button).at(1).prop('onClick')!(clickEvent)
     })
     expect(mockOnCreate).not.toHaveBeenCalled()
     expect(SynapseClient.createPersonalAccessToken).not.toHaveBeenCalled()
@@ -78,17 +80,15 @@ describe('basic functionality', () => {
 
     // Add a name
     await act(async () => {
-      await wrapper
-        .find('FormControl')
-        .simulate('change', {
-          target: {
-            value: 'some name',
-          },
-        })
+      wrapper.find('FormControl').simulate('change', {
+        target: {
+          value: 'some name',
+        },
+      })
       expect(wrapper.find(Button).at(1).text().includes('Create Token')).toBe(
         true,
       )
-      await wrapper.find(Button).at(1).simulate('click')
+      wrapper.find(Button).at(1).prop('onClick')!(clickEvent)
     })
 
     expect(mockOnCreate).not.toHaveBeenCalled()
@@ -97,18 +97,16 @@ describe('basic functionality', () => {
 
     // Remove name, add a permission
     await act(async () => {
-      await wrapper
-        .find('FormControl')
-        .simulate('change', {
-          target: {
-            value: '',
-          },
-        })
+      wrapper.find('FormControl').simulate('change', {
+        target: {
+          value: '',
+        },
+      })
       await wrapper.find(Checkbox).at(0).prop('onChange')()
       expect(wrapper.find(Button).at(1).text().includes('Create Token')).toBe(
         true,
       )
-      await wrapper.find(Button).at(1).simulate('click')
+      wrapper.find(Button).at(1).prop('onClick')!(clickEvent)
     })
 
     expect(mockOnCreate).not.toHaveBeenCalled()
@@ -127,18 +125,16 @@ describe('basic functionality', () => {
 
     // Fill out the form and send the request
     await act(async () => {
-      await wrapper
-        .find('FormControl')
-        .simulate('change', {
-          target: {
-            value: 'token name',
-          },
-        })
+      wrapper.find('FormControl').simulate('change', {
+        target: {
+          value: 'token name',
+        },
+      })
       await wrapper.find(Checkbox).at(0).prop('onChange')()
       expect(wrapper.find(Button).at(1).text().includes('Create Token')).toBe(
         true,
       )
-      await wrapper.find(Button).at(1).simulate('click')
+      wrapper.find(Button).at(1).prop('onClick')!(clickEvent)
     })
 
     expect(wrapper.find(ErrorBanner).length).toBe(1)
@@ -149,7 +145,7 @@ describe('basic functionality', () => {
     const wrapper = shallow(<CreateAccessTokenModal {...props} />)
 
     // Close the modal using the prop
-    wrapper.find('Modal').prop('onHide')()
+    wrapper.find(Modal).prop('onHide')!()
 
     expect(mockOnClose).toHaveBeenCalled()
 
@@ -162,7 +158,7 @@ describe('basic functionality', () => {
 
     // Close the modal using the prop
     expect(wrapper.find(Button).at(0).text().includes('Cancel')).toBe(true)
-    await wrapper.find(Button).at(0).prop('onClick')()
+    wrapper.find(Button).at(0).prop('onClick')!(clickEvent)
 
     expect(mockOnClose).toHaveBeenCalled()
 

--- a/src/lib/containers/personal_access_token/CreateAccessTokenModal.tsx
+++ b/src/lib/containers/personal_access_token/CreateAccessTokenModal.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react'
-import { Button, FormControl, Modal, ModalBody } from 'react-bootstrap'
+import {
+  Button,
+  Form,
+  FormControl,
+  FormLabel,
+  Modal,
+  ModalBody,
+} from 'react-bootstrap'
 import { SynapseClient } from '../../utils'
 import { AccessTokenGenerationRequest } from '../../utils/synapseTypes/AccessToken/AccessTokenGenerationRequest'
 import { scopeDescriptions } from '../../utils/synapseTypes/AccessToken/ScopeDescriptions'
@@ -43,7 +50,10 @@ export const CreateAccessTokenModal: React.FunctionComponent<CreateAccessTokenMo
     return !!tokenName && access.some(x => x)
   }
 
-  const onSubmit = async (): Promise<void> => {
+  const onSubmit = async (
+    clickEvent: React.MouseEvent<HTMLElement, MouseEvent>,
+  ): Promise<void> => {
+    clickEvent.preventDefault()
     if (validateInput(tokenName, [viewAccess, downloadAccess, modifyAccess])) {
       try {
         const request: AccessTokenGenerationRequest = {
@@ -78,86 +88,94 @@ export const CreateAccessTokenModal: React.FunctionComponent<CreateAccessTokenMo
 
   return (
     <Modal animation={false} show={true} onHide={onClose}>
-      <Modal.Header>
-        <Modal.Title>Create New Personal Access Token</Modal.Title>
-      </Modal.Header>
-      <ModalBody>
-        {isLoading ? (
-          loadingScreen
-        ) : showCreatedToken ? (
-          <>
-            <span className="SRC-boldText">
-              This token will not be able to be retrieved again.
-            </span>{' '}
-            <span>
-              If needed, generate a new personal access token, and delete this
-              one.
-            </span>
-            <div className="SRC-createdTokenCopyToClipboardContainer">
-              <CopyToClipboardInput value={createdToken} inputWidth={'350px'} />
+      <Form>
+        <Modal.Header>
+          <Modal.Title>Create New Personal Access Token</Modal.Title>
+        </Modal.Header>
+        <ModalBody>
+          {isLoading ? (
+            loadingScreen
+          ) : showCreatedToken ? (
+            <>
+              <span className="SRC-boldText">
+                This token will not be able to be retrieved again.
+              </span>{' '}
+              <span>
+                If needed, generate a new personal access token, and delete this
+                one.
+              </span>
+              <div className="SRC-createdTokenCopyToClipboardContainer">
+                <CopyToClipboardInput
+                  value={createdToken}
+                  inputWidth={'350px'}
+                />
+              </div>
+              <p>
+                This token grants access to your account functions and should be
+                treated like a password.
+              </p>
+            </>
+          ) : (
+            <div className="SRC-marginFive">
+              <div className="SRC-marginBottomTen">
+                <FormLabel className="SRC-boldText">Token Name</FormLabel>
+                <FormControl
+                  autoFocus
+                  className="SRC-personalAccessTokenNameInput"
+                  value={tokenName}
+                  onChange={handleTokenNameChange}
+                  type="text"
+                  placeholder="e.g. Synapse command line access on my laptop"
+                ></FormControl>
+              </div>
+              <div className="SRC-marginBottomTop">
+                <FormLabel className="SRC-boldText">
+                  Token Permissions
+                </FormLabel>
+                <Checkbox
+                  label={`${scopeDescriptions.view.displayName} (${scopeDescriptions.view.description})`}
+                  id="view"
+                  checked={viewAccess}
+                  onChange={() => setViewAccess(!viewAccess)}
+                ></Checkbox>
+                <Checkbox
+                  label={`${scopeDescriptions.download.displayName} (${scopeDescriptions.download.description})`}
+                  id="download"
+                  checked={downloadAccess}
+                  onChange={() => setDownloadAccess(!downloadAccess)}
+                ></Checkbox>
+                <Checkbox
+                  label={`${scopeDescriptions.modify.displayName} (${scopeDescriptions.modify.description})`}
+                  id="modify"
+                  checked={modifyAccess}
+                  onChange={() => setModifyAccess(!modifyAccess)}
+                ></Checkbox>
+              </div>
+              <div className="SRC-center-text">
+                {showErrorMessage && (
+                  <ErrorBanner error={errorMessage}></ErrorBanner>
+                )}
+              </div>
             </div>
-            <p>
-              This token grants access to your account functions and should be
-              treated like a password.
-            </p>
-          </>
-        ) : (
-          <div className="SRC-marginFive">
-            <div className="SRC-marginBottomTen">
-              <label className="SRC-boldText">Token Name</label>
-              <FormControl
-                className="SRC-personalAccessTokenNameInput"
-                value={tokenName}
-                onChange={handleTokenNameChange}
-                type="text"
-                placeholder="e.g. Synapse command line access on my laptop"
-              ></FormControl>
-            </div>
-            <div className="SRC-marginBottomTop">
-              <p className="SRC-boldText">Token Permissions</p>
-              <Checkbox
-                label={`${scopeDescriptions.view.displayName} (${scopeDescriptions.view.description})`}
-                id="view"
-                checked={viewAccess}
-                onChange={() => setViewAccess(!viewAccess)}
-              ></Checkbox>
-              <Checkbox
-                label={`${scopeDescriptions.download.displayName} (${scopeDescriptions.download.description})`}
-                id="download"
-                checked={downloadAccess}
-                onChange={() => setDownloadAccess(!downloadAccess)}
-              ></Checkbox>
-              <Checkbox
-                label={`${scopeDescriptions.modify.displayName} (${scopeDescriptions.modify.description})`}
-                id="modify"
-                checked={modifyAccess}
-                onChange={() => setModifyAccess(!modifyAccess)}
-              ></Checkbox>
-            </div>
-            <div className="SRC-center-text">
-              {showErrorMessage && (
-                <ErrorBanner error={errorMessage}></ErrorBanner>
-              )}
-            </div>
-          </div>
-        )}
-      </ModalBody>
-      <Modal.Footer>
-        {showCreatedToken ? (
-          <Button variant="default" onClick={onClose}>
-            Close
-          </Button>
-        ) : (
-          <>
+          )}
+        </ModalBody>
+        <Modal.Footer>
+          {showCreatedToken ? (
             <Button variant="default" onClick={onClose}>
-              Cancel
+              Close
             </Button>
-            <Button variant="primary" onClick={onSubmit}>
-              Create Token
-            </Button>
-          </>
-        )}
-      </Modal.Footer>
+          ) : (
+            <>
+              <Button variant="default" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="submit" variant="primary" onClick={onSubmit}>
+                Create Token
+              </Button>
+            </>
+          )}
+        </Modal.Footer>
+      </Form>
     </Modal>
   )
 }


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/SWC-5356

* Embedding the modal content inside a `Form` tag and adding the `submit` type to the submit button triggers a submission when pressing 'enter'
* In some situations, the page would reload on the keypress, which is avoided by calling `preventDefault`
* Tab does not currently cycle through checkboxes, but this is an issue with all checkboxes and radio buttons on Synapse. Tracking this issue in [SWC-5372](https://sagebionetworks.jira.com/browse/SWC-5372)