### PR TITLE
SWC-5375

### DIFF
--- a/src/lib/containers/ErrorBanner.tsx
+++ b/src/lib/containers/ErrorBanner.tsx
@@ -63,7 +63,7 @@ export const ErrorBanner = (props: ErrorProps) => {
     stringError = error
   }
   return (
-    <div className="Error">
+    <div className="ErrorBanner">
       <Alert
         dismissible={false}
         show={true}

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -1173,3 +1173,7 @@ hr ~ .SRC-wrapper {
     width: 0%;
   }
 }
+
+.alert-danger {
+  color: rgb(102, 102, 102);
+}

--- a/src/lib/style/components/_all.scss
+++ b/src/lib/style/components/_all.scss
@@ -5,10 +5,11 @@
   './download-link', './total-query-results', './facet_nav/all',
   './query-wrapper-plot-nav', './searchv2', './element-with-tooltip',
   './_column-selection.scss', './programmatic-options',
-  './query_filter/enum-facet-filter', './error', './goals', './feed-cards',
-  './upset-plot', './resources', 'cards-rotate', './expandable_content',
-  './bar-loader', './facet-plots-card', './featured-data-plots',
-  './featured-data-tabs', './programs', './user-card-list-groups',
-  './evaluation_queue/all', './personal-access-tokens', './copy-to-clipboard',
-  './account-level-badge', './terms-and-conditions', './page-progress',
-  './project-view-card', './carousel', './synapse-homepage', './login';
+  './query_filter/enum-facet-filter', './error-banner', './goals',
+  './feed-cards', './upset-plot', './resources', 'cards-rotate',
+  './expandable_content', './bar-loader', './facet-plots-card',
+  './featured-data-plots', './featured-data-tabs', './programs',
+  './user-card-list-groups', './evaluation_queue/all',
+  './personal-access-tokens', './copy-to-clipboard', './account-level-badge',
+  './terms-and-conditions', './page-progress', './project-view-card',
+  './carousel', './synapse-homepage', './login';

--- a/src/lib/style/components/_error-banner.scss
+++ b/src/lib/style/components/_error-banner.scss
@@ -1,0 +1,5 @@
+.ErrorBanner {
+  div {
+    text-align: center;
+  }
+}

--- a/src/lib/style/components/_error.scss
+++ b/src/lib/style/components/_error.scss
@@ -1,8 +1,0 @@
-.Error {
-  div {
-    text-align: center;
-  }
-  p {
-    color: rgb(102, 102, 102);
-  }
-}


### PR DESCRIPTION
SWC overrides the alert style, but can't override the text color because the selector is too specific. We'll just change all alerts in SRC to use the ErrorBanner style.

SWC will need to be updated to apply `!important` or a [more specific selector](https://github.com/Sage-Bionetworks/SynapseWebClient/pull/4496/files), since SRC CSS is applied after the custom bootstrap theme.

Error message currently looks like this:
![image](https://user-images.githubusercontent.com/17580037/104761116-69341600-5730-11eb-89dc-87eaff23354e.png)



My main concern with this approach is that it is very brittle. A preferred approach would be importing the SCSS into SWC and overriding the variables. However, this complicates the build process.