### PR TITLE
Fix inline MD buttons + convert another button to BS4

### DIFF
--- a/src/__tests__/lib/containers/MarkdownSynapse.test.tsx
+++ b/src/__tests__/lib/containers/MarkdownSynapse.test.tsx
@@ -265,7 +265,7 @@ describe('it performs all functionality', () => {
       const { wrapper } = await createShallowComponent({
         markdown: '# header [text](https://synapse.org)',
       })
-      const expectedValue = `<div class="markdown bootstrap-4-backport"><span><h1 id="SRC-header-1" toc="true"> header  <a href="https://synapse.org" target="_blank"> text </a></h1> 
+      const expectedValue = `<div class="markdown"><span><h1 id="SRC-header-1" toc="true"> header  <a href="https://synapse.org" target="_blank"> text </a></h1> 
  </span></div>`
       expect(wrapper.html()).toEqual(expectedValue)
     })
@@ -273,7 +273,7 @@ describe('it performs all functionality', () => {
       const { wrapper } = await createShallowComponent({
         markdown: 'some more free \n# header\nloose text',
       })
-      const expectedValue = `<div class="markdown bootstrap-4-backport"><span><p> some more free </p> \n <h1 id="SRC-header-1" toc="true"> header </h1> \n <p> loose text </p> \n </span></div>`
+      const expectedValue = `<div class="markdown"><span><p> some more free </p> \n <h1 id="SRC-header-1" toc="true"> header </h1> \n <p> loose text </p> \n </span></div>`
       expect(wrapper.html()).toEqual(expectedValue)
     })
     it('works with two inline widgets', async () => {
@@ -281,7 +281,7 @@ describe('it performs all functionality', () => {
         markdown:
           '${buttonlink?text=sometext&url=#/Help/How%20It%20Works&highlight=true}${buttonlink?text=APPLY&url=#/Apply&highlight=true} ',
       })
-      const expectedValue = `<div class="markdown bootstrap-4-backport"><span><p><a href="#/Help/How It Works" class="pill-xl  btn btn-primary">sometext</a><a href="#/Apply" class="pill-xl  btn btn-primary">APPLY</a></p> \n </span></div>`
+      const expectedValue = `<div class="markdown"><span><p><span class="bootstrap-4-backport"><a href="#/Help/How It Works" class="pill-xl  btn btn-primary">sometext</a></span><span class="bootstrap-4-backport"><a href="#/Apply" class="pill-xl  btn btn-primary">APPLY</a></p></span> \n </span></div>`
       expect(wrapper.html()).toEqual(expectedValue)
     })
   })

--- a/src/__tests__/lib/containers/MarkdownSynapse.test.tsx
+++ b/src/__tests__/lib/containers/MarkdownSynapse.test.tsx
@@ -265,7 +265,7 @@ describe('it performs all functionality', () => {
       const { wrapper } = await createShallowComponent({
         markdown: '# header [text](https://synapse.org)',
       })
-      const expectedValue = `<div class="markdown"><span><h1 id="SRC-header-1" toc="true"> header  <a href="https://synapse.org" target="_blank"> text </a></h1> 
+      const expectedValue = `<div class="markdown bootstrap-4-backport"><span><h1 id="SRC-header-1" toc="true"> header  <a href="https://synapse.org" target="_blank"> text </a></h1> 
  </span></div>`
       expect(wrapper.html()).toEqual(expectedValue)
     })
@@ -273,7 +273,7 @@ describe('it performs all functionality', () => {
       const { wrapper } = await createShallowComponent({
         markdown: 'some more free \n# header\nloose text',
       })
-      const expectedValue = `<div class="markdown"><span><p> some more free </p> \n <h1 id="SRC-header-1" toc="true"> header </h1> \n <p> loose text </p> \n </span></div>`
+      const expectedValue = `<div class="markdown bootstrap-4-backport"><span><p> some more free </p> \n <h1 id="SRC-header-1" toc="true"> header </h1> \n <p> loose text </p> \n </span></div>`
       expect(wrapper.html()).toEqual(expectedValue)
     })
     it('works with two inline widgets', async () => {
@@ -281,7 +281,7 @@ describe('it performs all functionality', () => {
         markdown:
           '${buttonlink?text=sometext&url=#/Help/How%20It%20Works&highlight=true}${buttonlink?text=APPLY&url=#/Apply&highlight=true} ',
       })
-      const expectedValue = `<div class="markdown"><span><p><div class="bootstrap-4-backport"><a href="#/Help/How It Works" class="pill-xl  btn btn-primary">sometext</a></div><div class="bootstrap-4-backport"><a href="#/Apply" class="pill-xl  btn btn-primary">APPLY</a></div></p> \n </span></div>`
+      const expectedValue = `<div class="markdown bootstrap-4-backport"><span><p><a href="#/Help/How It Works" class="pill-xl  btn btn-primary">sometext</a><a href="#/Apply" class="pill-xl  btn btn-primary">APPLY</a></p> \n </span></div>`
       expect(wrapper.html()).toEqual(expectedValue)
     })
   })

--- a/src/__tests__/lib/containers/MarkdownSynapse.test.tsx
+++ b/src/__tests__/lib/containers/MarkdownSynapse.test.tsx
@@ -281,7 +281,7 @@ describe('it performs all functionality', () => {
         markdown:
           '${buttonlink?text=sometext&url=#/Help/How%20It%20Works&highlight=true}${buttonlink?text=APPLY&url=#/Apply&highlight=true} ',
       })
-      const expectedValue = `<div class="markdown"><span><p><span class="bootstrap-4-backport"><a href="#/Help/How It Works" class="pill-xl  btn btn-primary">sometext</a></span><span class="bootstrap-4-backport"><a href="#/Apply" class="pill-xl  btn btn-primary">APPLY</a></p></span> \n </span></div>`
+      const expectedValue = `<div class="markdown"><span><p><span class="bootstrap-4-backport"><a href="#/Help/How It Works" class="pill-xl  btn btn-primary">sometext</a></span><span class="bootstrap-4-backport"><a href="#/Apply" class="pill-xl  btn btn-primary">APPLY</a></span></p> \n </span></div>`
       expect(wrapper.html()).toEqual(expectedValue)
     })
   })

--- a/src/lib/containers/MarkdownSynapse.tsx
+++ b/src/lib/containers/MarkdownSynapse.tsx
@@ -580,7 +580,11 @@ export default class MarkdownSynapse extends React.Component<
       highlight === 'true' ? 'primary' : 'light-primary-base'
     if (alignLowerCase === 'center') {
       return (
-        <div key={widgetparamsMapped.reactKey} style={{ textAlign: 'center' }}>
+        <div
+          key={widgetparamsMapped.reactKey}
+          className="bootstrap-4-backport"
+          style={{ textAlign: 'center' }}
+        >
           <Button
             href={widgetparamsMapped.url}
             className={buttonClasses}
@@ -592,13 +596,15 @@ export default class MarkdownSynapse extends React.Component<
       )
     }
     return (
-      <Button
-        href={widgetparamsMapped.url}
-        className={buttonClasses}
-        variant={buttonVariant}
-      >
-        {widgetparamsMapped.text}
-      </Button>
+      <span className="bootstrap-4-backport">
+        <Button
+          href={widgetparamsMapped.url}
+          className={buttonClasses}
+          variant={buttonVariant}
+        >
+          {widgetparamsMapped.text}
+        </Button>
+      </span>
     )
   }
   public renderSynapsePlot(widgetparamsMapped: any) {
@@ -728,16 +734,13 @@ export default class MarkdownSynapse extends React.Component<
     )
     if (renderInline) {
       return (
-        <span
-          className="markdown markdown-inline bootstrap-4-backport"
-          ref={this.markupRef}
-        >
+        <span className="markdown markdown-inline" ref={this.markupRef}>
           {content}
         </span>
       )
     }
     return (
-      <div className="markdown bootstrap-4-backport" ref={this.markupRef}>
+      <div className="markdown" ref={this.markupRef}>
         {content}
       </div>
     )

--- a/src/lib/containers/MarkdownSynapse.tsx
+++ b/src/lib/containers/MarkdownSynapse.tsx
@@ -580,11 +580,7 @@ export default class MarkdownSynapse extends React.Component<
       highlight === 'true' ? 'primary' : 'light-primary-base'
     if (alignLowerCase === 'center') {
       return (
-        <div
-          className="bootstrap-4-backport"
-          key={widgetparamsMapped.reactKey}
-          style={{ textAlign: 'center' }}
-        >
+        <div key={widgetparamsMapped.reactKey} style={{ textAlign: 'center' }}>
           <Button
             href={widgetparamsMapped.url}
             className={buttonClasses}
@@ -596,15 +592,13 @@ export default class MarkdownSynapse extends React.Component<
       )
     }
     return (
-      <div className="bootstrap-4-backport">
-        <Button
-          href={widgetparamsMapped.url}
-          className={buttonClasses}
-          variant={buttonVariant}
-        >
-          {widgetparamsMapped.text}
-        </Button>
-      </div>
+      <Button
+        href={widgetparamsMapped.url}
+        className={buttonClasses}
+        variant={buttonVariant}
+      >
+        {widgetparamsMapped.text}
+      </Button>
     )
   }
   public renderSynapsePlot(widgetparamsMapped: any) {
@@ -734,13 +728,16 @@ export default class MarkdownSynapse extends React.Component<
     )
     if (renderInline) {
       return (
-        <span className="markdown markdown-inline" ref={this.markupRef}>
+        <span
+          className="markdown markdown-inline bootstrap-4-backport"
+          ref={this.markupRef}
+        >
           {content}
         </span>
       )
     }
     return (
-      <div className="markdown" ref={this.markupRef}>
+      <div className="markdown bootstrap-4-backport" ref={this.markupRef}>
         {content}
       </div>
     )

--- a/src/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid.tsx
+++ b/src/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid.tsx
@@ -452,13 +452,14 @@ export default class SynapseFormSubmissionGrid extends React.Component<
                   this.props.formGroupId,
                 )}
 
-                <div className="text-center">
-                  <a
-                    className="btn btn-large"
+                <div className="text-center bootstrap-4-backport">
+                  <Button
+                    className="pill-xl btn-large" // .btn-large is a custom class, don't use size="lg"
+                    variant="primary"
                     href={`${this.props.pathpart}?formGroupId=${this.props.formGroupId}`}
                   >
                     Add new {this.props.itemNoun}
-                  </a>
+                  </Button>
                 </div>
               </div>
             </div>

--- a/src/lib/style/components/_markdown.scss
+++ b/src/lib/style/components/_markdown.scss
@@ -1,162 +1,166 @@
 .markdowntable {
-    border: 1px solid #dddddd;
-    border-collapse: separate;
-    *border-collapse: collapsed;
-    border-left: 0;
-    margin: 10px 0 10px 0;
-  }
-  .markdowntable td {
-    border-left: 1px solid #dddddd;
-    border-top: 1px solid #dddddd;
-    padding: 2px 4px;
-  }
-  .markdowntable th {
-    border-left: 1px solid #dddddd;
-    border-top: 1px solid #dddddd;
-    padding: 2px 4px;
-    font-weight: 500;
-    font-size: 1.1em;
-  }
-  .markdowntable .userBadgeTable {
-    top: 0px;
-  }
-  .markdowntable caption + thead tr:first-child th,
-  .markdowntable caption + tbody tr:first-child th,
-  .markdowntable caption + tbody tr:first-child td,
-  .markdowntable colgroup + thead tr:first-child th,
-  .markdowntable colgroup + tbody tr:first-child th,
-  .markdowntable colgroup + tbody tr:first-child td,
-  .markdowntable thead:first-child tr:first-child th,
-  .markdowntable tbody:first-child tr:first-child th,
-  .markdowntable tbody:first-child tr:first-child td {
-    border-top: 0;
-  }
-  .markdowntable thead:first-child tr:first-child th:first-child,
-  .markdowntable tbody:first-child tr:first-child td:first-child {
-    -webkit-border-top-left-radius: 4px;
-    border-top-left-radius: 4px;
-    -moz-border-radius-topleft: 4px;
-  }
-  .markdowntable thead:first-child tr:first-child th:last-child,
-  .markdowntable tbody:first-child tr:first-child td:last-child {
-    -webkit-border-top-right-radius: 4px;
-    border-top-right-radius: 4px;
-    -moz-border-radius-topright: 4px;
-  }
-  .markdowntable thead:last-child tr:last-child th:first-child,
-  .markdowntable tbody:last-child tr:last-child td:first-child {
-    -webkit-border-bottom-left-radius: 4px;
-    border-bottom-left-radius: 4px;
-    -moz-border-radius-bottomleft: 4px;
-  }
-  .markdowntable thead:last-child tr:last-child th:last-child,
-  .markdowntable tbody:last-child tr:last-child td:last-child {
-    -webkit-border-bottom-right-radius: 4px;
-    border-bottom-right-radius: 4px;
-    -moz-border-radius-bottomright: 4px;
-  }
-  
-  .markdown {
-    word-wrap: break-word;
-    overflow-x: auto;
-    overflow-y: hidden;
-    line-height: 1.8em;
-    color: #515359;
-    &.markdown-inline {
-      line-height: unset;
-    }
-  }
-  .markdown ol {
-    list-style-type: decimal;
-    padding-left: 15px;
-  }
-  .markdown ol li {
-    padding-top: 5px;
-  }
-  .markdown ul {
-    list-style-type: square;
-    padding-left: 17px;
-  }
-  .markdown ul li {
-    padding-top: 5px;
-  }
-  .markdown strong {
-    font-weight: bold;
-  }
-  .markdown del {
-    text-decoration: line-through;
-  }
-  .markdown em {
-    font-style: italic;
-  }
-  .markdown blockquote {
-    margin: 1em 3em;
-    padding: 0.5em 1em;
-    background-color: #fcf8f2;
-    border-left: 3px solid #f0ad4e;
-    font-size: 13px;
-  }
-  .markdown blockquote h4,
-  .markdown blockquote h3,
-  .markdown blockquote h2,
-  .markdown blockquote h1 {
-    color: #f0ad4e;
-  }
-  .markdown code {
-    font-family: 'Courier New', Courier, monospace !important;
-    background-clip: padding-box;
-    border-radius: 3px 3px 3px 3px;
-    padding: 0 5px 2px;
-    overflow: auto;
-    white-space: pre;
-    word-wrap: normal;
-  }
-  .markdown img {
-    max-width: 100%;
-  }
-  .markdown p {
-    margin: 0px;
-    padding-bottom: 12px;
-  }
-  .markdown h1 {
-    padding: 35px 0 12px 0;
-  }
-  .markdown h2 {
-    padding: 29px 0 10px 0;
-  }
-  .markdown h3 {
-    padding: 23px 0 8px 0;
-  }
-  .markdown h4 {
-    padding: 17px 0 6px 0;
-  }
-  .markdown h5 {
-    padding: 11px 0 4px 0;
-  }
-  .markdown h6 {
-    padding: 5px 0 2px 0;
-  }
+  border: 1px solid #dddddd;
+  border-collapse: separate;
+  *border-collapse: collapsed;
+  border-left: 0;
+  margin: 10px 0 10px 0;
+}
+.markdowntable td {
+  border-left: 1px solid #dddddd;
+  border-top: 1px solid #dddddd;
+  padding: 2px 4px;
+}
+.markdowntable th {
+  border-left: 1px solid #dddddd;
+  border-top: 1px solid #dddddd;
+  padding: 2px 4px;
+  font-weight: 500;
+  font-size: 1.1em;
+}
+.markdowntable .userBadgeTable {
+  top: 0px;
+}
+.markdowntable caption + thead tr:first-child th,
+.markdowntable caption + tbody tr:first-child th,
+.markdowntable caption + tbody tr:first-child td,
+.markdowntable colgroup + thead tr:first-child th,
+.markdowntable colgroup + tbody tr:first-child th,
+.markdowntable colgroup + tbody tr:first-child td,
+.markdowntable thead:first-child tr:first-child th,
+.markdowntable tbody:first-child tr:first-child th,
+.markdowntable tbody:first-child tr:first-child td {
+  border-top: 0;
+}
+.markdowntable thead:first-child tr:first-child th:first-child,
+.markdowntable tbody:first-child tr:first-child td:first-child {
+  -webkit-border-top-left-radius: 4px;
+  border-top-left-radius: 4px;
+  -moz-border-radius-topleft: 4px;
+}
+.markdowntable thead:first-child tr:first-child th:last-child,
+.markdowntable tbody:first-child tr:first-child td:last-child {
+  -webkit-border-top-right-radius: 4px;
+  border-top-right-radius: 4px;
+  -moz-border-radius-topright: 4px;
+}
+.markdowntable thead:last-child tr:last-child th:first-child,
+.markdowntable tbody:last-child tr:last-child td:first-child {
+  -webkit-border-bottom-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+  -moz-border-radius-bottomleft: 4px;
+}
+.markdowntable thead:last-child tr:last-child th:last-child,
+.markdowntable tbody:last-child tr:last-child td:last-child {
+  -webkit-border-bottom-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  -moz-border-radius-bottomright: 4px;
+}
 
-  .toc-indent1 {
-    margin-left: 35px;
+.markdown {
+  word-wrap: break-word;
+  overflow-x: auto;
+  overflow-y: hidden;
+  line-height: 1.8em;
+  color: #515359;
+  &.markdown-inline {
+    line-height: unset;
   }
-  
-  .toc-indent2 {
-    margin-left: 65px;
-  }
-  
-  .toc-indent3 {
-    margin-left: 95px;
-  }
-  
-  .toc-indent4 {
-    margin-left: 125px;
-  }
-  
-  .toc-indent5 {
-    margin-left: 155px;
-  }
-  
-  .toc-indent6 {
-    margin-left: 185px;
-  }
+}
+.markdown ol {
+  list-style-type: decimal;
+  padding-left: 15px;
+}
+.markdown ol li {
+  padding-top: 5px;
+}
+.markdown ul {
+  list-style-type: square;
+  padding-left: 17px;
+}
+.markdown ul li {
+  padding-top: 5px;
+}
+.markdown strong {
+  font-weight: bold;
+}
+.markdown del {
+  text-decoration: line-through;
+}
+.markdown em {
+  font-style: italic;
+}
+.markdown blockquote {
+  margin: 1em 3em;
+  padding: 0.5em 1em;
+  background-color: #fcf8f2;
+  border-left: 3px solid #f0ad4e;
+  font-size: 13px;
+}
+.markdown blockquote h4,
+.markdown blockquote h3,
+.markdown blockquote h2,
+.markdown blockquote h1 {
+  color: #f0ad4e;
+}
+.markdown code {
+  font-family: 'Courier New', Courier, monospace !important;
+  background-clip: padding-box;
+  border-radius: 3px 3px 3px 3px;
+  padding: 0 5px 2px;
+  overflow: auto;
+  white-space: pre;
+  word-wrap: normal;
+}
+.markdown img {
+  max-width: 100%;
+}
+.markdown p {
+  margin: 0px;
+  padding-bottom: 12px;
+}
+.markdown h1 {
+  padding: 35px 0 12px 0;
+}
+.markdown h2 {
+  padding: 29px 0 10px 0;
+}
+.markdown h3 {
+  padding: 23px 0 8px 0;
+}
+.markdown h4 {
+  padding: 17px 0 6px 0;
+}
+.markdown h5 {
+  padding: 11px 0 4px 0;
+}
+.markdown h6 {
+  padding: 5px 0 2px 0;
+}
+
+.toc-indent1 {
+  margin-left: 35px;
+}
+
+.toc-indent2 {
+  margin-left: 65px;
+}
+
+.toc-indent3 {
+  margin-left: 95px;
+}
+
+.toc-indent4 {
+  margin-left: 125px;
+}
+
+.toc-indent5 {
+  margin-left: 155px;
+}
+
+.toc-indent6 {
+  margin-left: 185px;
+}
+
+.markdown span.bootstrap-4-backport a {
+  margin: 20px 20px 20px 0px;
+}

--- a/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
+++ b/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
@@ -143,9 +143,7 @@
         background-color: themed('action-color');
       }
 
-      font-size: 1.25rem;
       text-transform: uppercase;
-      border-radius: 15px;
       padding: 0.75rem 1.5rem;
     }
   }


### PR DESCRIPTION
Use a span instead of a div for non-centered buttons

v1.15.56 (before regression):
![image](https://user-images.githubusercontent.com/17580037/105365529-5c01a600-5bcc-11eb-983f-9ef617954cb9.png)


Current:
![image](https://user-images.githubusercontent.com/17580037/105364205-e3e6b080-5bca-11eb-9f7f-02ad4477c9bd.png)


After: 
![image](https://user-images.githubusercontent.com/17580037/105366439-58225380-5bcd-11eb-9cb3-6c02f5037b2a.png)


Also, convert a form button to BS4 so it gets the theme color reliably.