### PR TITLE
PORTALS-1808: Reformat Graphs Based On Screen Size

### DIFF
--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -185,7 +185,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
       colorIndex: index,
     }
   })
-  const showMoreState = getShowMoreState()
+  const showMoreButtonState = getShowMoreState()
 
   if (error) {
     return <></>
@@ -200,7 +200,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   } else {
     return (
       <>
-        <div className={`FacetNav ${showFacetVisualization ? '' : 'hidden'}${showMoreState === 'LESS' ? 'less' : ''}`}>
+        <div className={`FacetNav ${showFacetVisualization ? '' : 'hidden'} ${showMoreButtonState === 'LESS' ? 'less' : ''}`}>
           <div className="FacetNav__expanded">
             {expandedFacets.map((facet, index) => (
               <div key={facet.columnName}>
@@ -279,13 +279,13 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
             ))}
           </div>
           <div className="FacetNav__showMoreContainer">
-            {showMoreState !== 'NONE' && (
+            {showMoreButtonState !== 'NONE' && (
               <button
                 className="btn btn-default FacetNav__showMore"
-                onClick={() => onShowMoreClick(showMoreState === 'MORE')}
+                onClick={() => onShowMoreClick(showMoreButtonState === 'MORE')}
                 style={{ zIndex: 500 }}
               >
-                {showMoreState === 'LESS'
+                {showMoreButtonState === 'LESS'
                   ? 'Hide Optional Graphs'
                   : 'Show All Graphs'}
               </button>

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -200,7 +200,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   } else {
     return (
       <>
-        <div className={`FacetNav ${showFacetVisualization ? '' : 'hidden'}`}>
+        <div className={`FacetNav ${showFacetVisualization ? '' : 'hidden'}${showMoreState === 'LESS' ? 'less' : ''}`}>
           <div className="FacetNav__expanded">
             {expandedFacets.map((facet, index) => (
               <div key={facet.columnName}>
@@ -283,6 +283,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
               <button
                 className="btn btn-default FacetNav__showMore"
                 onClick={() => onShowMoreClick(showMoreState === 'MORE')}
+                style={{ zIndex: 500 }}
               >
                 {showMoreState === 'LESS'
                   ? 'Hide Optional Graphs'

--- a/src/lib/style/components/facet_nav/_facet-nav.scss
+++ b/src/lib/style/components/facet_nav/_facet-nav.scss
@@ -30,7 +30,7 @@
   }
 }
 
-.container-full-width {
+.container-full-width .FacetNav.less{
   .FacetNav {
     &__row {
       display: flex;


### PR DESCRIPTION
This fix is for Jira issue: https://sagebionetworks.jira.com/browse/PORTALS-1808.

Allows the size of the graph containers to shrink as the screen width gets smaller. This solves the problem of having three graphs that are stacked together, with two on top and one on the bottom. Some images of the fix can be seen below:

When the window size is normal:
![Screen Shot 2021-01-26 at 12 01 13 PM](https://user-images.githubusercontent.com/31671708/105900549-0f093f80-5fd1-11eb-9075-2837317377d7.png)

When the window size decreases:
![Screen Shot 2021-01-26 at 12 03 37 PM](https://user-images.githubusercontent.com/31671708/105900574-17fa1100-5fd1-11eb-9c54-08ea08729841.png)

When the "Show All Graphs" button is pressed:
![Screen Shot 2021-01-26 at 12 10 18 PM](https://user-images.githubusercontent.com/31671708/105900652-32cc8580-5fd1-11eb-8e5c-7525a1697390.png)
