### PR TITLE
Bump markdown-it-synapse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.15.65",
+  "version": "1.15.66",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
@@ -55,7 +55,7 @@
     "markdown-it-strikethrough-alt": "^1.0.0",
     "markdown-it-sub-alt": "^1.0.0",
     "markdown-it-sup-alt": "^1.0.2",
-    "markdown-it-synapse": "^1.1.7",
+    "markdown-it-synapse": "^1.1.8",
     "markdown-it-synapse-heading": "^1.0.1",
     "markdown-it-synapse-math": "^3.0.4",
     "markdown-it-synapse-table": "^1.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9690,12 +9690,10 @@ markdown-it-synapse-table@^1.0.6:
   resolved "https://registry.yarnpkg.com/markdown-it-synapse-table/-/markdown-it-synapse-table-1.0.6.tgz#5e14383257a6f6495d6c097388911548fe2155fb"
   integrity sha1-XhQ4Mlem9kldbAlziJEVSP4hVfs=
 
-markdown-it-synapse@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/markdown-it-synapse/-/markdown-it-synapse-1.1.7.tgz#b91324a4b366769ef3623fe4869fc6582a9f9a80"
-  integrity sha512-xCxlY5T75nbI2hWJKpBveoN2mDgpKD+dj2zepWS8n5z8GzvWy1IPmcm8MgDH2qDGd8hKHv5zspaN4XZp1znd2g==
-  dependencies:
-    node "^10.3.0"
+markdown-it-synapse@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/markdown-it-synapse/-/markdown-it-synapse-1.1.8.tgz#887395e1f628a1a3c997b60965a2ece0b72a6dd0"
+  integrity sha512-KoRODZ3pIYEtFlMbLS8/xWhCxBeADoFp5j8cKFyo7j/TjUROXTpUIUA5RR/stYjr+64If0lWF4DgAmj/7d7tHw==
 
 markdown-it@^11.0.0:
   version "11.0.1"
@@ -10233,11 +10231,6 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-bin-setup@^1.0.0:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/node-bin-setup/-/node-bin-setup-1.0.6.tgz#4b5c9bb937ece702d7069b36ca78af4684677528"
-  integrity sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q==
-
 node-dir@^0.1.10:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
@@ -10371,13 +10364,6 @@ node-sass@4:
     sass-graph "2.2.5"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
-
-node@^10.3.0:
-  version "10.23.0"
-  resolved "https://registry.yarnpkg.com/node/-/node-10.23.0.tgz#848049b565361d5b2f8ad1ba0117d12d0575c047"
-  integrity sha512-iC4soH/Ej+F/ncc5s1vs5w1rp/iIKym2p8CM05VsfLHkj0FFMUoYbsTSXtICFmFeou9FCGNs0XrPImhP3xlAPA==
-  dependencies:
-    node-bin-setup "^1.0.0"
 
 "nopt@2 || 3":
   version "3.0.6"


### PR DESCRIPTION
Removes a dependency on `node`