### PR TITLE
Upgrade react-intersection-observer to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-datetime": "^3.0.4",
     "react-dom": "16.13.1",
     "react-error-boundary": "^3.0.2",
-    "react-intersection-observer": "3.0.2",
+    "react-intersection-observer": "^8.31.0",
     "react-jsonschema-form": "^1.7.0",
     "react-mailchimp-subscribe": "^2.1.0",
     "react-measure": "^2.1.2",

--- a/src/lib/containers/VisibilityObserver.tsx
+++ b/src/lib/containers/VisibilityObserver.tsx
@@ -81,11 +81,12 @@ export default class VisibilityObserver extends React.Component<VisibilityObserv
 
     return (
       <Observer
-        tag={tag || 'div'}
+        as={tag as any || 'div'}
         rootMargin={rootMargin}
         onChange={this.onVisibilityChange}
-        render={this.getObserverChildren}
-      />
+      >
+        {this.getObserverChildren}
+      </Observer>
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12631,10 +12631,10 @@ react-icons@^3.8.0:
   dependencies:
     camelcase "^5.0.0"
 
-react-intersection-observer@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-3.0.2.tgz#942476b2019f17ba9358d5c65bb5554262d9890b"
-  integrity sha512-ryMe7DKmm21D25MmmaQdNDg+ONs/yWwFpn4vD6xeMigOZfV1ovHYDWpgnF4vwoV+MdNxkiqmTVOHbPyNpH3WZQ==
+react-intersection-observer@^8.31.0:
+  version "8.31.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.31.0.tgz#0ed21aaf93c4c0475b22b0ccaba6169076d01605"
+  integrity sha512-XraIC/tkrD9JtrmVA7ypEN1QIpKc52mXBH1u/bz/aicRLo8QQEJQAMUTb8mz4B6dqpPwyzgjrr7Ljv/2ACDtqw==
 
 react-is@^16.13.1, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"


### PR DESCRIPTION
Planning to use the `useInView` hook in the Entity Finder.

See docs: https://github.com/thebuilder/react-intersection-observer#hooks-