### PR TITLE
PORTALS-1854

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.15.74",
+  "version": "1.15.75",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -37,8 +37,9 @@ export type CTAButtonCardLink = {
   linkConfig: CardLink
 }
 
-export type MarkdownValue = {
-  isMarkdown: true
+export type DescriptionConfig = {
+  isMarkdown?: boolean
+  showFullDescriptionByDefault?: boolean
 }
 
 // Specify the indices in the values [] that should be rendered specially
@@ -58,7 +59,7 @@ export type CommonCardProps = {
   titleLinkConfig?: CardLink
   ctaButtonLinkConfig?: CTAButtonCardLink
   labelLinkConfig?: LabelLinkConfig
-  descriptionLinkConfig?: MarkdownValue
+  descriptionConfig?: DescriptionConfig
   rgbIndex?: number
   columnIconOptions?: ColumnIconConfigs
 }

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -5,7 +5,7 @@ import {
   CardLink,
   CommonCardProps,
   MarkdownLink,
-  MarkdownValue,
+  DescriptionConfig,
 } from './CardContainerLogic'
 import { unCamelCase } from '../utils/functions/unCamelCase'
 import MarkdownSynapse from './MarkdownSynapse'
@@ -30,9 +30,10 @@ export type GenericCardSchema = {
   type: string
   title: string
   subTitle?: string
-  description?: string
+  description?: string  
   icon?: string
-  imageFileHandleColumnName?:string
+  imageFileHandleColumnName?: string
+  thumbnailRequiresPadding?: boolean
   secondaryLabels?: any[]
   link?: string
   dataTypeIconNames?: string
@@ -348,7 +349,7 @@ export default class GenericCard extends React.Component<
       ctaButtonLinkConfig,
       labelLinkConfig,
       facetAliases = {},
-      descriptionLinkConfig,
+      descriptionConfig,
       rgbIndex,
       tableId,
       tableEntityConcreteType,
@@ -421,9 +422,9 @@ export default class GenericCard extends React.Component<
       marginTop: isHeader ? '0px' : undefined,
       marginBottom: isHeader ? '0px' : undefined,
       paddingBottom: showFooter || imageFileHandleIdValue ? undefined : '15px',
-    }
+    }    
     const icon:JSX.Element = <>
-        {imageFileHandleIdValue && <div className="SRC-imageThumbnail">
+        {imageFileHandleIdValue && <div className="SRC-imageThumbnail" style={{padding: genericCardSchemaDefined.thumbnailRequiresPadding ? '21px' : undefined}}>
           <ImageFileHandle 
             token={token}
             fileHandleId={imageFileHandleIdValue}
@@ -438,7 +439,7 @@ export default class GenericCard extends React.Component<
     if (isHeader) {
       return (
         <HeaderCard
-          descriptionLinkConfig={descriptionLinkConfig}
+          descriptionConfig={descriptionConfig}
           title={title}
           subTitle={subTitle}
           backgroundColor={backgroundColor}
@@ -531,14 +532,14 @@ export default class GenericCard extends React.Component<
                 description,
                 hasClickedShowMore,
                 descriptionSubTitle,
-                descriptionLinkConfig,
+                descriptionConfig,
               )}
             {description &&
               this.renderLongDescription(
                 description,
                 hasClickedShowMore,
                 descriptionSubTitle,
-                descriptionLinkConfig,
+                descriptionConfig,
                 this.props.token,
               )}
             {ctaButtonLinkConfig &&
@@ -573,14 +574,14 @@ export default class GenericCard extends React.Component<
     description: string,
     hasClickedShowMore: boolean,
     descriptionSubTitle: any,
-    descriptionLinkConfig?: MarkdownValue,
+    descriptionConfig?: DescriptionConfig,
     token?: string,
   ): React.ReactNode {
     let content: JSX.Element | string = description
-    if (descriptionLinkConfig?.isMarkdown) {
+    if (descriptionConfig?.isMarkdown) {
       content = <MarkdownSynapse token={token} markdown={content} />
     }
-    const show = hasClickedShowMore || descriptionLinkConfig
+    const show = hasClickedShowMore || descriptionConfig?.showFullDescriptionByDefault
     return (
       <div className={show ? '' : 'SRC-hidden'}>
         <span
@@ -597,9 +598,9 @@ export default class GenericCard extends React.Component<
     description: string,
     hasClickedShowMore: boolean,
     descriptionSubTitle: any,
-    descriptionLinkConfig?: MarkdownValue,
+    descriptionConfig?: DescriptionConfig,
   ): React.ReactNode {
-    if (descriptionLinkConfig) {
+    if (descriptionConfig?.showFullDescriptionByDefault) {
       return <></>
     }
     return (

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -424,7 +424,7 @@ export default class GenericCard extends React.Component<
       paddingBottom: showFooter || imageFileHandleIdValue ? undefined : '15px',
     }    
     const icon:JSX.Element = <>
-        {imageFileHandleIdValue && <div className="SRC-imageThumbnail" style={{padding: genericCardSchemaDefined.thumbnailRequiresPadding ? '21px' : '0px'}}>
+        {imageFileHandleIdValue && <div className="SRC-imageThumbnail" style={{padding: genericCardSchemaDefined.thumbnailRequiresPadding ? '21px' : 'inherit'}}>
           <ImageFileHandle 
             token={token}
             fileHandleId={imageFileHandleIdValue}

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -424,7 +424,7 @@ export default class GenericCard extends React.Component<
       paddingBottom: showFooter || imageFileHandleIdValue ? undefined : '15px',
     }    
     const icon:JSX.Element = <>
-        {imageFileHandleIdValue && <div className="SRC-imageThumbnail" style={{padding: genericCardSchemaDefined.thumbnailRequiresPadding ? '21px' : undefined}}>
+        {imageFileHandleIdValue && <div className="SRC-imageThumbnail" style={{padding: genericCardSchemaDefined.thumbnailRequiresPadding ? '21px' : '0px'}}>
           <ImageFileHandle 
             token={token}
             fileHandleId={imageFileHandleIdValue}

--- a/src/lib/containers/HeaderCard.tsx
+++ b/src/lib/containers/HeaderCard.tsx
@@ -1,5 +1,5 @@
 import { CardFooter } from './row_renderers/utils'
-import { MarkdownValue } from './CardContainerLogic'
+import { DescriptionConfig } from './CardContainerLogic'
 import MarkdownSynapse from './MarkdownSynapse'
 import React, { useState, useEffect } from 'react'
 import getColorPalette from './ColorGradient'
@@ -17,7 +17,7 @@ export type HeaderCardProps = {
   secondaryLabelLimit?: number
   values?: string[][]
   isAlignToLeftNav?: boolean
-  descriptionLinkConfig?: MarkdownValue
+  descriptionConfig?: DescriptionConfig
   href?: string
   target?: string
   icon: JSX.Element
@@ -32,7 +32,7 @@ const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
   values,
   secondaryLabelLimit,
   isAlignToLeftNav,
-  descriptionLinkConfig,
+  descriptionConfig,
   href,
   target,
   rgbIndex,
@@ -100,7 +100,7 @@ const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
           {subTitle && <div className="SRC-author"> {subTitle} </div>}
           {description && (
             <span className="SRC-font-size-base">
-              {descriptionLinkConfig ? (
+              {descriptionConfig?.isMarkdown ? (
                 <MarkdownSynapse markdown={description} />
               ) : (
                 description


### PR DESCRIPTION
Expand descriptionLinkConfig to define if the description should be expanded by default (shown in full), in addition to whether it should be processed as Markdown.
Also add "thumbnailRequiresPadding", which will pad the icon or image by 21px (matches padding-top of card type UI element).