### PR TITLE
SWC-5440: change scope of btn success override for forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.15.78",
+  "version": "1.15.79",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
+++ b/src/lib/style/components/synapse_form_wrapper/_synapse-form-wrapper.scss
@@ -60,6 +60,13 @@
     margin-right: 1rem;
   }
 
+  .btn-success,
+  .btn-success:active,
+  .btn-success:focus {
+    background-color: SrcVariables.$primary-action-color;
+    border-color: SrcVariables.$primary-action-color;  
+  }
+
   /* padding */
   .padding-full {
     padding: 2rem;
@@ -485,13 +492,6 @@
     font-size: 1.4rem;
     font-style: italic;
   }
-}
-
-.btn-success,
-.btn-success:active,
-.btn-success:focus {
-  background-color: SrcVariables.$primary-action-color;
-  border-color: SrcVariables.$primary-action-color;  
 }
 
 @media print {


### PR DESCRIPTION
only apply to elements under SRC-ReactJsonForm