### PR TITLE
new StyleGuidist component wrapper

### DIFF
--- a/src/lib/containers/StyleGuidistComponentWrapper.tsx
+++ b/src/lib/containers/StyleGuidistComponentWrapper.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { MemoryRouter } from 'react-router';
+import RenderIfInView from './RenderIfInView';
+
+export default class StyleGuidistComponentWrapper extends React.Component {
+  public render() {
+    return <MemoryRouter><RenderIfInView>{this.props.children}</RenderIfInView></MemoryRouter>
+  }
+}

--- a/src/lib/containers/synapse_form_wrapper/SynapseFormWrapper.md
+++ b/src/lib/containers/synapse_form_wrapper/SynapseFormWrapper.md
@@ -1,0 +1,13 @@
+Contribution Form
+```jsx
+<SynapseFormWrapper
+formSchemaEntityId="syn20692910"
+fileNamePath="study.submission_name"
+formUiSchemaEntityId="syn20692911"
+formNavSchemaEntityId="syn20968007"
+isWizardMode={true}
+token={sessionToken}
+formTitle="Your Contribution Request"
+formClass="contribution-request"
+/>
+```

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -9,7 +9,7 @@ module.exports = {
     pagePerSection: true,
     skipComponentsWithoutExample: true,
     styleguideComponents: {
-        Wrapper: path.resolve(__dirname, 'src/lib/containers/RenderIfInView'),
+        Wrapper: path.resolve(__dirname, 'src/lib/containers/StyleGuidistComponentWrapper'),
     },
     sections: [
         {


### PR DESCRIPTION
introduce a memoryrouter for components that rely on the router environment (like Prompt, Switch, Link, and others)