### PR TITLE
fix home page user grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.15.88",
+  "version": "1.15.89",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/style/components/_cards-rotate.scss
+++ b/src/lib/style/components/_cards-rotate.scss
@@ -14,6 +14,7 @@ $card-rotate-margin: 21px;
       height: auto;
       margin-left: $card-rotate-margin;
       margin-right: $card-rotate-margin;
+      overflow: hidden;
     }
 
     & > .SRC-grid-item:first-child {


### PR DESCRIPTION
It's this problem:
https://twitter.com/wesbos/status/1256229763225657348/photo/1

Need to set the overflow of the grid items to hidden for it to respect the grid layout (note the text overflow of the paragraphs is already set properly, so it renders ellipsis when long values are truncated).

