### PR TITLE
PORTALS-1907

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,6 +53,7 @@ export default {
     'react-transition-group',
     'sql-parser',
     'universal-cookie',
+    'json-schema-ref-parser', // bundling this results in a non-functional build (without error). see PORTALS-1907
   ],
   onwarn: function (args) {
     // Skip certain warnings
@@ -72,10 +73,10 @@ export default {
   },
   // NOTE - the order matters for the extensions below
   plugins: [
-    resolve({ extensions, browser: true, preferBuiltins: true }),
+    resolve({ extensions, browser: true, preferBuiltins: false }),
     babel({
       extensions,
-      exclude: 'node_modules/*.*',
+      exclude: 'node_modules/**',
     }),
     // Common js is used to handle the import of older javascript modules not using es6
     commonjs(),

--- a/src/__tests__/lib/containers/widgets/facet-nav/FacetNav.test.tsx
+++ b/src/__tests__/lib/containers/widgets/facet-nav/FacetNav.test.tsx
@@ -2,7 +2,7 @@ import FacetNav, {
   FacetNavProps,
 } from '../../../../../lib/containers/widgets/facet-nav/FacetNav'
 import * as React from 'react'
-import * as _ from 'lodash'
+import * as _ from 'lodash-es'
 import { render, fireEvent } from '@testing-library/react'
 import {
   QueryResultBundle,

--- a/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
+++ b/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
@@ -10,7 +10,6 @@ import { unCamelCase } from '../../../utils/functions/unCamelCase'
 import { faTimes } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ElementWithTooltip } from '../ElementWithTooltip'
-import _ from 'lodash'
 import { SynapseConstants } from '../../../utils'
 
 export type FacetWithSelection = {
@@ -38,7 +37,7 @@ const SelectionCriteriaPill: FunctionComponent<SelectionCriteriaPillProps> = ({
 }) => {
   let innerText,
     tooltipText: string | null = ''
-  if (facetWithSelection) {    
+  if (facetWithSelection) {
     if (facetWithSelection.facet.facetType === 'enumeration') {
       innerText =
         facetWithSelection.displayValue === SynapseConstants.VALUE_NOT_SET
@@ -57,7 +56,7 @@ const SelectionCriteriaPill: FunctionComponent<SelectionCriteriaPillProps> = ({
     let filterValue = filter?.value
     if (filterValue?.startsWith('%') && filterValue?.endsWith('%')) {
       // strip '%' wildcard character when using a LIKE condition
-      filterValue = filterValue.substring(1, filterValue.length-1)
+      filterValue = filterValue.substring(1, filterValue.length - 1)
     }
     innerText = `"${filterValue}" in ${unCamelCase(filter?.columnName)}`
     tooltipText = `${unCamelCase(filter?.columnName)}: ${filterValue}`
@@ -66,7 +65,7 @@ const SelectionCriteriaPill: FunctionComponent<SelectionCriteriaPillProps> = ({
     <ElementWithTooltip
       idForToolTip={`selectionCriteria_${+index}`}
       tooltipText={tooltipText}
-      callbackFn={() => _.noop}
+      callbackFn={() => {}}
     >
       <label
         className="SelectionCriteriaPill"


### PR DESCRIPTION
* Omit json-schema-ref-parser because it breaks the UMD build without error when accidentally bundled. See [JIRA](https://sagebionetworks.jira.com/browse/PORTALS-1907).
* Remove uses of `lodash`. We use `lodash-es`, which works better with Rollup's tree shaking and reduces the build size, if it happens to be included.