### PR TITLE
SWC-5538 

### DIFF
--- a/src/__tests__/lib/containers/UserCardTests.test.tsx
+++ b/src/__tests__/lib/containers/UserCardTests.test.tsx
@@ -162,8 +162,7 @@ describe('it creates the correct UI for the small card', () => {
         .onClick({ stopPropagation: () => {} } as any)
     })
     await resolveAllPending(wrapper)
-    expect(wrapper.find(UserCard)).toHaveLength(2)
-    expect(wrapper.find(UserCard).at(1).prop('size')).toBe(MEDIUM_USER_CARD)
+    expect(wrapper.find(UserCardMedium)).toHaveLength(1)
   })
 
   it('creates an anchor link when showCardOnHover is false', () => {

--- a/src/lib/containers/Avatar.tsx
+++ b/src/lib/containers/Avatar.tsx
@@ -1,34 +1,90 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { getColor } from '../utils/functions/getUserData'
 import { UserProfile } from '../utils/synapseTypes'
+import UserCardMedium from './UserCardMedium'
+import { useOverlay } from '../utils/hooks/useOverlay'
 
-export type AvatarSize = 'SMALL' | 'LARGE'
+const TIMER_DELAY_SHOW = 250 // milliseconds
+const TIMER_DELAY_HIDE = 500
+
+export type AvatarSize = 'SMALL' | 'MEDIUM' | 'LARGE'
 
 export type AvatarProps = {
   userProfile: UserProfile
   avatarSize?: AvatarSize
   imageURL?: string
+  showCardOnHover?: boolean
 }
 
 export const Avatar: React.FunctionComponent<AvatarProps> = ({
   userProfile,
   avatarSize = 'LARGE',
   imageURL,
+  showCardOnHover = false,
 }) => {
-  const sizeClass = avatarSize === 'SMALL' ? 'SRC-userImgSmall' : 'SRC-userImg'
+  const target = useRef(null)
 
-  return imageURL ? (
-    <div
-      style={{ backgroundImage: `url(${imageURL})` }}
-      className={sizeClass}
-    />
-  ) : (
-    <div
-      style={{ background: getColor(userProfile.userName) }}
-      className={`${sizeClass} SRC-centerContentInline`}
-    >
-      {userProfile.firstName &&
-        (userProfile.firstName[0] || userProfile.userName[0])}
-    </div>
+  const mediumUserCard = (
+    <UserCardMedium userProfile={userProfile} imageURL={imageURL} />
+  )
+  const {
+    OverlayComponent,
+    isShowing: isShowingOverlay,
+    toggleShow,
+    toggleHide,
+  } = useOverlay(mediumUserCard, target, TIMER_DELAY_SHOW, TIMER_DELAY_HIDE)
+
+  let sizeClass
+  switch (avatarSize) {
+    case 'SMALL':
+      sizeClass = 'SRC-userImgSmall'
+      break
+    case 'MEDIUM':
+      sizeClass = 'SRC-userImgMedium'
+      break
+    case 'LARGE':
+      sizeClass = 'SRC-userImg'
+      break
+    default:
+      break
+  }
+
+  const cursorStyle = showCardOnHover ? 'pointer' : 'unset'
+
+  return (
+    <>
+      {showCardOnHover && OverlayComponent}
+      {imageURL ? (
+        <div
+          ref={target}
+          onMouseEnter={() => toggleShow()}
+          onMouseLeave={() => toggleHide()}
+          onClick={event => {
+            event.stopPropagation()
+            isShowingOverlay ? toggleHide(false) : toggleShow(false)
+          }}
+          style={{ backgroundImage: `url(${imageURL})`, cursor: cursorStyle }}
+          className={sizeClass}
+        />
+      ) : (
+        <div
+          ref={target}
+          onMouseEnter={() => toggleShow()}
+          onMouseLeave={() => toggleHide()}
+          onClick={event => {
+            event.stopPropagation()
+            isShowingOverlay ? toggleHide(false) : toggleShow(false)
+          }}
+          style={{
+            background: getColor(userProfile.userName),
+            cursor: cursorStyle,
+          }}
+          className={`${sizeClass} SRC-centerContentInline`}
+        >
+          {userProfile.firstName &&
+            (userProfile.firstName[0] || userProfile.userName[0])}
+        </div>
+      )}
+    </>
   )
 }

--- a/src/lib/containers/UserCard.tsx
+++ b/src/lib/containers/UserCard.tsx
@@ -7,7 +7,7 @@ import { SynapseConstants } from '../utils/'
 import { UserCardSmall, UserCardSmallProps } from './UserCardSmall'
 import UserCardMedium, { UserCardMediumProps } from './UserCardMedium'
 import usePreFetchResource from '../utils/hooks/usePreFetchImage'
-import { Avatar, AvatarSize } from './Avatar'
+import { Avatar, AvatarProps, AvatarSize } from './Avatar'
 
 export type UserCardSize =
   | 'AVATAR'
@@ -28,7 +28,7 @@ export type UserCardProps = {
   ownerId?: string
   /** Specifies the card size */
   size: UserCardSize
-  /** For the small user card, shows the medium user card on mouseover */
+  /** For the small user card or avatar, shows the medium user card on mouseover */
   showCardOnHover?: boolean
   /** For the small user card, hides the tooltip observed when hovering over the profile image. */
   hideTooltip?: boolean
@@ -43,7 +43,10 @@ export type UserCardProps = {
   disableLink?: boolean
   isCertified?: boolean
   isValidated?: boolean
+  /** Determines the size of the avatar when size === 'AVATAR' or (size === 'SMALL' and withAvatar is true) */
   avatarSize?: AvatarSize
+  /** Whether to show the avatar with the name for the small user card */
+  withAvatar?: boolean
 }
 
 export const UserCard: React.FunctionComponent<UserCardProps> = (
@@ -94,7 +97,7 @@ export const UserCard: React.FunctionComponent<UserCardProps> = (
 
   function getCard(
     cardSize: UserCardSize,
-    propsForChild: UserCardSmallProps | UserCardMediumProps,
+    propsForChild: AvatarProps | UserCardSmallProps | UserCardMediumProps,
   ) {
     switch (cardSize) {
       case SynapseConstants.AVATAR:

--- a/src/lib/containers/UserCardSmall.tsx
+++ b/src/lib/containers/UserCardSmall.tsx
@@ -1,8 +1,8 @@
-import React, { useRef, useState } from 'react'
-import { Overlay } from 'react-bootstrap'
-import { MEDIUM_USER_CARD } from '../utils/SynapseConstants'
+import React, { useRef } from 'react'
 import { UserProfile } from '../utils/synapseTypes/'
-import UserCard from './UserCard'
+import { Avatar, AvatarSize } from './Avatar'
+import UserCardMedium from './UserCardMedium'
+import { useOverlay } from '../utils/hooks/useOverlay'
 
 export type UserCardSmallProps = {
   userProfile: UserProfile
@@ -10,16 +10,13 @@ export type UserCardSmallProps = {
   disableLink?: boolean
   link?: string
   openLinkInNewTab?: boolean
+  withAvatar?: boolean
+  avatarSize?: AvatarSize
+  imageURL?: string
 }
 
 const TIMER_DELAY_SHOW = 250 // milliseconds
 const TIMER_DELAY_HIDE = 500
-
-function resetTimer(timer: React.MutableRefObject<NodeJS.Timeout | null>) {
-  if (timer.current) {
-    clearTimeout(timer.current)
-  }
-}
 
 export const UserCardSmall: React.FunctionComponent<UserCardSmallProps> = ({
   userProfile,
@@ -27,83 +24,79 @@ export const UserCardSmall: React.FunctionComponent<UserCardSmallProps> = ({
   disableLink,
   link,
   openLinkInNewTab,
+  withAvatar = false,
+  avatarSize = 'SMALL',
+  imageURL,
   ...rest
 }) => {
-  const timer = useRef<NodeJS.Timeout | null>(null)
-  const [show, setShow] = useState(false)
-
   const target = useRef(null)
 
-  const OverlayComponent = (
-    <Overlay target={target.current} show={show} placement="top-start">
-      {({ placement, arrowProps, show: _show, popper, ...props }) => {
-        return (
-          <div
-            className="bootstrap-4-backport"
-            onMouseEnter={() => {
-              resetTimer(timer)
-              setShow(true)
-            }}
-            onMouseLeave={() => {
-              // Assume the user is done with the card regardless of click state
-              resetTimer(timer)
-              timer.current = setTimeout(() => {
-                setShow(false)
-              }, TIMER_DELAY_HIDE)
-            }}
-            {...props}
-            style={{ ...props.style, width: 'max-content', minWidth: '300px' }}
-          >
-            <UserCard
-              size={MEDIUM_USER_CARD}
-              userProfile={userProfile}
-              link={link}
-              disableLink={disableLink}
-              openLinkInNewTab={openLinkInNewTab}
-              {...rest}
-            />
-          </div>
-        )
-      }}
-    </Overlay>
+  const mediumUserCard = (
+    <UserCardMedium userProfile={userProfile} imageURL={imageURL} />
+  )
+
+  const {
+    OverlayComponent,
+    isShowing: isShowingOverlay,
+    toggleShow,
+    toggleHide,
+  } = useOverlay(mediumUserCard, target, TIMER_DELAY_SHOW, TIMER_DELAY_HIDE)
+
+  const avatar = withAvatar ? (
+    <span className="SRC-inline-avatar">
+      <Avatar
+        userProfile={userProfile}
+        avatarSize={avatarSize}
+        imageURL={imageURL}
+      />
+    </span>
+  ) : (
+    <></>
   )
 
   return showCardOnHover ? (
     <>
       {OverlayComponent}
+
       <span
         ref={target}
-        onMouseEnter={() => {
-          resetTimer(timer)
-          timer.current = setTimeout(() => setShow(true), TIMER_DELAY_SHOW)
-        }}
-        onMouseLeave={() => {
-          resetTimer(timer)
-          timer.current = setTimeout(() => setShow(false), TIMER_DELAY_HIDE)
-        }}
+        onMouseEnter={() => toggleShow()}
+        onMouseLeave={() => toggleHide()}
         onClick={event => {
           event.stopPropagation()
-          resetTimer(timer)
-          setShow(!show)
+          isShowingOverlay ? toggleHide(false) : toggleShow(false)
         }}
         className="SRC-userCard UserCardSmall SRC-underline-on-hover"
         style={{ whiteSpace: 'nowrap' }}
-      >{`@${userProfile.userName}`}</span>
+      >
+        {avatar}
+        {`@${userProfile.userName}`}
+      </span>
     </>
   ) : disableLink ? (
     <span
       className="SRC-userCard UserCardSmall SRC-boldText"
       style={{ cursor: 'unset' }}
-    >{`@${userProfile.userName}`}</span>
+    >
+      {avatar}
+      {`@${userProfile.userName}`}
+    </span>
   ) : (
-    // eslint-disable-next-line react/jsx-no-target-blank
-    <a
-      className="SRC-userCard UserCardSmall"
-      target={openLinkInNewTab ? '_blank' : ''}
-      rel={openLinkInNewTab ? 'noreferrer' : ''}
-      href={
-        link ? link : `https://www.synapse.org/#!Profile:${userProfile.ownerId}`
-      }
-    >{`@${userProfile.userName}`}</a>
+    <span>
+      {avatar}
+      {/* eslint-disable-next-line react/jsx-no-target-blank*/}
+      <a
+        className="SRC-userCard UserCardSmall"
+        target={openLinkInNewTab ? '_blank' : ''}
+        rel={openLinkInNewTab ? 'noreferrer' : ''}
+        href={
+          link
+            ? link
+            : `https://www.synapse.org/#!Profile:${userProfile.ownerId}`
+        }
+      >
+        {`@${userProfile.userName}`}
+      </a>
+    </span>
   )
 }

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -583,6 +583,19 @@ div.SRC-logo-cursor * {
 }
 
 .SRC-userImgSmall {
+  font-size: 12px;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  padding: 10px;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  text-transform: capitalize;
+  color: white;
+}
+
+.SRC-userImgMedium {
   font-size: 18px;
   border-radius: 50%;
   width: 30px;
@@ -594,6 +607,11 @@ div.SRC-logo-cursor * {
   text-transform: capitalize;
   color: white;
 }
+
+.SRC-inline-avatar {
+  margin-right: 5px;
+}
+
 .extraSmall {
   width: 10px !important;
   height: 10px !important;

--- a/src/lib/utils/hooks/useOverlay.tsx
+++ b/src/lib/utils/hooks/useOverlay.tsx
@@ -1,0 +1,64 @@
+import React, { RefObject, useRef, useState } from 'react'
+import { Overlay } from 'react-bootstrap'
+import { Placement } from 'react-bootstrap/esm/Overlay'
+
+function resetTimer(timer: React.MutableRefObject<NodeJS.Timeout | null>) {
+  if (timer.current) {
+    clearTimeout(timer.current)
+  }
+}
+
+export function useOverlay(
+  children: JSX.Element,
+  targetRef: RefObject<any>,
+  delayShow = 250,
+  delayHide = 500,
+  placement: Placement = 'top-start',
+) {
+  const timer = useRef<NodeJS.Timeout | null>(null)
+  const [isShowing, setIsShowing] = useState(false)
+
+  function toggle(show: boolean = isShowing, withDelay: boolean = true) {
+    resetTimer(timer)
+    if (withDelay) {
+      timer.current = setTimeout(
+        () => setIsShowing(show),
+        show ? delayShow : delayHide,
+      )
+    } else {
+      setIsShowing(show)
+    }
+  }
+
+  function toggleShow(withDelay: boolean = true) {
+    toggle(true, withDelay)
+  }
+
+  function toggleHide(withDelay: boolean = true) {
+    toggle(false, withDelay)
+  }
+
+  const OverlayComponent = (
+    <Overlay target={targetRef.current} show={isShowing} placement={placement}>
+      {({ placement, arrowProps, show: _show, popper, ...props }) => {
+        return (
+          <div
+            className="bootstrap-4-backport"
+            onMouseEnter={() => {
+              toggle(true, false)
+            }}
+            onMouseLeave={() => {
+              toggleHide(true)
+            }}
+            {...props}
+            style={{ ...props.style, width: 'max-content', minWidth: '300px' }}
+          >
+            {children}
+          </div>
+        )
+      }}
+    </Overlay>
+  )
+
+  return { OverlayComponent, isShowing, toggleShow, toggleHide, toggle }
+}


### PR DESCRIPTION
* Small card can show avatar using `withAvatar` prop
	* Avatar size can be controlled with `avatarSize` prop (`"SMALL" | "MEDIUM" | "LARGE"`) 
* Avatar can show card on hover

Screenshots:

Medium avatar, show card on hover:
![image](https://user-images.githubusercontent.com/17580037/115460564-685ec480-a1f6-11eb-93d5-4d1d15a1e5ae.png)

Small user card, show avatar (all sizes), show card on hover
![image](https://user-images.githubusercontent.com/17580037/115460977-e91dc080-a1f6-11eb-9c32-90fbe69ab6d6.png)


