### PR TITLE
PORTALS-1910

### DIFF
--- a/src/lib/containers/Facets.tsx
+++ b/src/lib/containers/Facets.tsx
@@ -214,11 +214,9 @@ class Facets extends React.Component<QueryWrapperChildProps, FacetsState> {
       columnName: facet,
     } as FacetSelection
     isAllFilterSelectedForFacet[facet] = selector === SELECT_ALL
-    this.props.updateParentState!({
-      lastFacetSelection,
-      isAllFilterSelectedForFacet,
-      chartSelectionIndex: index,
-    })
+    this.props.setLastFacetSelection!(lastFacetSelection)
+    this.props.setIsAllFilterSelectedForFacet!(isAllFilterSelectedForFacet)
+    this.props.setChartSelectionIndex!(index)
 
     // read input and fetch data
     const htmlCheckboxes = Array.from(

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -1,16 +1,17 @@
-import * as React from 'react'
-
-import { SynapseClient, SynapseConstants } from '../utils/'
-import { getNextPageOfData } from '../utils/functions/queryUtils'
+import { cloneDeep } from 'lodash-es'
+import React, { useEffect, useState } from 'react'
+import { QueryClient } from 'react-query'
+import { SynapseConstants } from '../utils/'
 import * as DeepLinkingUtils from '../utils/functions/deepLinkingUtils'
+import { withQueryClientProvider } from '../utils/hooks/SynapseAPI/QueryClientProviderWrapper'
+import useGetQueryResultBundle from '../utils/hooks/SynapseAPI/useGetQueryResultBundle'
+import { SynapseClientError } from '../utils/SynapseClient'
 import {
-  AsynchronousJobStatus,
   FacetColumnResultValues,
   QueryBundleRequest,
   QueryResultBundle,
 } from '../utils/synapseTypes/'
-import { cloneDeep } from 'lodash-es'
-import { SynapseClientError } from '../utils/SynapseClient'
+
 export type QueryWrapperProps = {
   visibleColumnCount?: number
   initQueryRequest: QueryBundleRequest
@@ -19,7 +20,6 @@ export type QueryWrapperProps = {
   facet?: string
   unitDescription?: string
   facetAliases?: {}
-  loadNow?: boolean
   showBarChart?: boolean
   componentIndex?: number //used for deep linking
   shouldDeepLink?: boolean
@@ -42,30 +42,6 @@ export type SearchQuery = {
   searchText: string
 }
 
-export type QueryWrapperState = {
-  /*
-    isAllFilterSelectedForFacet tracks whether for a particular
-     facet if the 'All' button has been selected, this tracks the
-     click event and syncs Facets.tsx and SynapseTable.tsx
-  */
-  isAllFilterSelectedForFacet: {}
-  data: QueryResultBundle | undefined
-  isLoadingNewData: boolean // occurs when props change
-  isLoading: boolean // occurs when state changes
-  lastQueryRequest: QueryBundleRequest
-  hasMoreData: boolean
-  // TODO: Delete lastFacetSelection once StackedBarChart.tsx/Facets.tsx are deleted
-  lastFacetSelection: FacetSelection
-  chartSelectionIndex: number
-  asyncJobStatus?: AsynchronousJobStatus
-  facetAliases?: {}
-  loadNowStarted: boolean
-  topLevelControlsState?: TopLevelControlsState
-  isColumnSelected: string[]
-  selectedRowIndices?: number[]
-  error: SynapseClientError | undefined
-}
-
 /*
   For details page: to lock a facet name (e.g. study, grant) so that the facet name
   and its all possible values will not appear on the details page. The facet name is
@@ -73,7 +49,7 @@ export type QueryWrapperState = {
   in SRC won't generate type errors.
  */
 export type LockedFacet = {
-  facet?: string,
+  facet?: string
   value?: string
 }
 
@@ -91,358 +67,242 @@ export type QueryWrapperChildProps = {
   entityId?: string
   isLoadingNewData?: boolean
   executeQueryRequest?: (param: QueryBundleRequest) => void
-  executeInitialQueryRequest?: () => void
   getNextPageOfData?: (queryRequest: QueryBundleRequest) => void
   getLastQueryRequest?: () => QueryBundleRequest
   getInitQueryRequest?: () => QueryBundleRequest
   data?: QueryResultBundle
   facet?: string
-  updateParentState?: <K extends keyof QueryWrapperState>(
-    param: Pick<QueryWrapperState, K>,
+  setTopLevelControlsState?: (
+    topLevelControlsState: TopLevelControlsState,
   ) => void
+  setSelectedRowIndices?: (selectedRowIndices: number[]) => void
+  setLastFacetSelection?: (lastFacetSelection: FacetSelection) => void
+  setIsAllFilterSelectedForFacet?: (isAllFilterSelectedForFacet: any) => void
+  setChartSelectionIndex?: (chartSelectionIndex: number) => void
+  setIsColumnSelected?: (isColumnSelected: string[]) => void
   rgbIndex?: number
   unitDescription?: string
   facetAliases?: {}
   lastFacetSelection?: FacetSelection
   chartSelectionIndex?: number
-  asyncJobStatus?: AsynchronousJobStatus
   showBarChart?: boolean
   hasMoreData?: boolean
   topLevelControlsState?: TopLevelControlsState
   isColumnSelected?: string[]
   selectedRowIndices?: number[]
-  error?: SynapseClientError | undefined,
+  error?: SynapseClientError | null
   lockedFacet?: LockedFacet
 }
 export const QUERY_FILTERS_EXPANDED_CSS: string = 'isShowingFacetFilters'
 export const QUERY_FILTERS_COLLAPSED_CSS: string = 'isHidingFacetFilters'
 
 /**
- * Class wraps around any Synapse views that are dependent on a query bundle
+ * remove a particular facet name (e.g. study) and its all possible values based on the parameter specified in the url
+ * this is to remove the facet from the charts, search and filter.
+ * @return data: QueryResultBundle
+ */
+function removeLockedFacetData(
+  lockedFacet?: LockedFacet,
+  data?: QueryResultBundle,
+) {
+  const facet = lockedFacet?.facet
+  if (facet && data) {
+    // for details page, return data without the "locked" facet
+    const dataClone: QueryResultBundle = cloneDeep(data)
+    const facets = dataClone.facets?.filter(
+      item => item.columnName.toLowerCase() !== facet.toLowerCase(),
+    )
+    dataClone.facets = facets
+    return dataClone
+  } else {
+    // for other pages, just return the data
+    return data
+  }
+}
+
+// Create a client
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000 * 5, // 5 minutes
+      retry: false, // SynapseClient knows which queries to retry
+      refetchOnWindowFocus: false,
+    },
+  },
+})
+
+/**
+ * Component wraps around any Synapse views that are dependent on a query bundle
  * Those classes then take in as props:
  *
  * @class QueryWrapper
  * @extends {React.Component}
  */
-export default class QueryWrapper extends React.Component<
-  QueryWrapperProps,
-  QueryWrapperState
-> {
-  private componentIndex: number
-  constructor(props: QueryWrapperProps) {
-    super(props)
-    this.executeInitialQueryRequest = this.executeInitialQueryRequest.bind(this)
-    this.executeQueryRequest = this.executeQueryRequest.bind(this)
-    this.getLastQueryRequest = this.getLastQueryRequest.bind(this)
-    this.getNextPageOfData = this.getNextPageOfData.bind(this)
-    this.updateParentState = this.updateParentState.bind(this)
-    this.getInitQueryRequest = this.getInitQueryRequest.bind(this)
-    const showFacetVisualization = props.defaultShowFacetVisualization ?? true
-    this.state = {
-      data: undefined,
-      isLoading: true,
-      isLoadingNewData: true,
-      hasMoreData: true,
-      lastFacetSelection: {
-        columnName: '',
-        facetValue: '',
-        selector: '',
-      },
-      chartSelectionIndex: 0,
-      isAllFilterSelectedForFacet: {},
-      loadNowStarted: false,
-      lastQueryRequest: cloneDeep(this.props.initQueryRequest!),
-      topLevelControlsState : {
-        showColumnFilter: true,
-        showFacetFilter: true,
-        showFacetVisualization,
-        showSearchBar: false,
-        showDownloadConfirmation: false,
-        showColumnSelectDropdown: false,
-      },
-      isColumnSelected: [],
-      selectedRowIndices: [],
-      error: undefined,
-    }
-    this.componentIndex = props.componentIndex || 0
-  }
+export const QueryWrapper: React.FunctionComponent<QueryWrapperProps> = withQueryClientProvider(
+  props => {
+    // These will probably be replaced by React Query
+    const [queryRequest, setQueryRequest] = useState(props.initQueryRequest)
 
-  /**
-   * Compute default query request
-   *
-   * @memberof QueryWrapper
-   */
-  public componentDidMount() {
-    const { loadNow = true } = this.props
-    const query = DeepLinkingUtils.getQueryRequestFromLink(
-      'QueryWrapper',
-      this.componentIndex,
-    )
+    const {
+      data,
+      isLoading: isLoadingNewData,
+      isFetching: isLoading,
+      error,
+    } = useGetQueryResultBundle(queryRequest, props.token, {
+      keepPreviousData: true,
+    })
+    const hasMoreData =
+      data?.queryResult.queryResults.rows.length === SynapseConstants.PAGE_SIZE
 
-    if (loadNow) {
-      this.executeInitialQueryRequest(query)
-    }
-  }
+    const [
+      topLevelControlsState,
+      setTopLevelControlsState,
+    ] = useState<TopLevelControlsState>({
+      showColumnFilter: true,
+      showFacetFilter: true,
+      showFacetVisualization: props.defaultShowFacetVisualization ?? true,
+      showSearchBar: false,
+      showDownloadConfirmation: false,
+      showColumnSelectDropdown: false,
+    })
+    const [isColumnSelected, setIsColumnSelected] = useState<string[]>([])
+    const [selectedRowIndices, setSelectedRowIndices] = useState<number[]>([])
 
-  /**
-   * @memberof QueryWrapper
-   */
-  public componentDidUpdate(prevProps: QueryWrapperProps) {
-    /**
-     *  If component updates and the token has changed (they signed in) then the data should be pulled in. Or if the
-     *  sql query has changed of the component then perform an update.
-     */
-
-    const { loadNow = true } = this.props
-    if (loadNow && !this.state.loadNowStarted) {
-      this.executeInitialQueryRequest()
-    } else if (loadNow && this.props.token !== prevProps.token) {
-      // if loadNow is true and they've logged in with a token that is not undefined, null, or an empty string when it was before
-      this.executeQueryRequest(this.getLastQueryRequest())
-    } else if (
-      prevProps.initQueryRequest.query.sql !==
-      this.props.initQueryRequest!.query.sql
-    ) {
-      this.executeInitialQueryRequest()
-    }
-  }
-
-  /**
-   * Pass down a deep clone (so no side affects on the child's part) of the
-   * last query request made
-   *
-   * @returns
-   * @memberof QueryWrapper
-   */
-  public getLastQueryRequest(): QueryBundleRequest {
-    return cloneDeep(this.state.lastQueryRequest)
-  }
-
-  /**
-   * Pass down a deep clone (so no side affects on the child's part) of the
-   * first query request made
-   *
-   * @returns
-   * @memberof QueryWrapper
-   */
-  public getInitQueryRequest(): QueryBundleRequest {
-    return cloneDeep(this.props.initQueryRequest)
-  }
-  /**
-   * Execute the given query
-   *
-   * @param {*} queryRequest Query request as specified by
-   *                         https://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/Query.html
-   * @memberof QueryWrapper
-   */
-  public executeQueryRequest(queryRequest: QueryBundleRequest) {
-    const clonedQueryRequest = cloneDeep(queryRequest)
-    this.setState({
-      isLoading: true,
-      lastQueryRequest: clonedQueryRequest,
-      selectedRowIndices: [], // reset selected row indices any time the query is re-run
+    const componentIndex = props.componentIndex ?? 0
+    const [
+      lastFacetSelection,
+      setLastFacetSelection,
+    ] = useState<FacetSelection>({
+      columnName: '',
+      facetValue: '',
+      selector: '',
     })
 
-    if (clonedQueryRequest.query) {
-      const stringifiedQuery = encodeURIComponent(
-        JSON.stringify(clonedQueryRequest.query),
+    const [chartSelectionIndex, setChartSelectionIndex] = useState(0)
+
+    const [
+      isAllFilterSelectedForFacet,
+      setIsAllFilterSelectedForFacet,
+    ] = useState({})
+
+    const [
+      dataWithLockedFacetRemoved,
+      setDataWithLockedFacetRemoved,
+    ] = useState(data)
+
+    useEffect(() => {
+      setIsColumnSelected(
+        data?.selectColumns
+          ?.slice(0, props.visibleColumnCount ?? Infinity)
+          .map(el => el.name) ?? [],
       )
-      if (this.props.shouldDeepLink) {
-        DeepLinkingUtils.updateUrlWithNewSearchParam(
-          'QueryWrapper',
-          this.componentIndex,
-          stringifiedQuery,
-        )
+    }, [data])
+
+    useEffect(() => {
+      // TODO: verify linking still works as expected
+      const linkedQuery = DeepLinkingUtils.getQueryRequestFromLink(
+        'QueryWrapper',
+        componentIndex,
+      )
+      if (linkedQuery) {
+        setQueryRequest(linkedQuery)
       }
-    }
-    return SynapseClient.getQueryTableResults(
-      clonedQueryRequest,
-      this.props.token,
-      this.updateParentState,
-    )
-      .then((data: QueryResultBundle) => {
-        const hasMoreData =
-          data.queryResult.queryResults.rows.length ===
-          SynapseConstants.PAGE_SIZE
-        const newState = {
-          hasMoreData,
-          data,
-          asyncJobStatus: undefined,
+
+      if (props.facet) {
+        if (!data?.facets) {
+          throw Error(
+            'Error on query request, must include facets in partmask to show facets',
+          )
         }
-        this.setState(newState)
-      })
-      .catch(error => {
-        console.error('Failed to get data ', error)
-        this.setState(error)
-      })
-      .finally(() => {
-        this.setState({ isLoading: false, isLoadingNewData: false })
-      })
-  }
-
-  /**
-   * Grab the next page of data, pulling in 25 more rows.
-   *
-   * @param {*} queryRequest Query request as specified by
-   *                         https://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/Query.html
-   * @memberof QueryWrapper
-   */
-  public async getNextPageOfData(queryRequest: QueryBundleRequest) {
-    this.setState({
-      isLoading: true,
-    })
-
-    await getNextPageOfData(
-      queryRequest,
-      this.state.data!,
-      this.props.token,
-    ).then(newState => {
-      this.setState({
-        ...newState,
-        isLoading: false,
-        lastQueryRequest: cloneDeep(queryRequest),
-      })
-    })
-  }
-
-  /**
-   * Execute the initial query passed into the component
-   *
-   * @param {*} queryRequest Query request as specified by
-   *                         https://docs.synapse.org/rest/org/sagebionetworks/repo/model/table/Query.html
-   * @memberof QueryWrapper
-   */
-  public executeInitialQueryRequest(
-    initQueryRequest: QueryBundleRequest = this.props.initQueryRequest,
-  ) {
-    const lastQueryRequest: QueryBundleRequest = cloneDeep(initQueryRequest)
-    this.setState({
-      isLoading: true,
-      chartSelectionIndex: 0,
-      loadNowStarted: true,
-      lastQueryRequest,
-    })
-    SynapseClient.getQueryTableResults(
-      initQueryRequest,
-      this.props.token,
-      this.updateParentState,
-    )
-      .then((data: QueryResultBundle) => {
-        const hasMoreData =
-          data.queryResult.queryResults.rows.length ===
-          SynapseConstants.PAGE_SIZE
-        const isAllFilterSelectedForFacet = cloneDeep(
-          this.state.isAllFilterSelectedForFacet,
-        )
-        let { chartSelectionIndex } = this.state
-        if (this.props.facet) {
-          if (!data.facets) {
-            throw Error(
-              'Error on query request, must include facets in partmask to show facets',
+        const enumFacets = data.facets.filter(
+          el => el.facetType === 'enumeration',
+        ) as FacetColumnResultValues[]
+        enumFacets.forEach(el => {
+          // isAll is only true iff there are no facets selected or all elements are selected
+          const { facetValues } = el
+          const isAllFalse = facetValues.every(facet => !facet.isSelected)
+          const isAllTrue = facetValues.every(facet => facet.isSelected)
+          const isByDefaultSelected = isAllFalse || isAllTrue
+          isAllFilterSelectedForFacet[el.columnName] = isByDefaultSelected
+          if (el.columnName === props.facet && !isAllFalse) {
+            // Note - this picks the first selected facet
+            setChartSelectionIndex(
+              facetValues
+                .sort((a, b) => b.count - a.count)
+                .findIndex(facet => facet.isSelected),
             )
           }
-          const enumFacets = data.facets.filter(
-            el => el.facetType === 'enumeration',
-          ) as FacetColumnResultValues[]
-          enumFacets.forEach(el => {
-            // isAll is only true iff there are no facets selected or all elements are selected
-            const { facetValues } = el
-            const isAllFalse = facetValues.every(facet => !facet.isSelected)
-            const isAllTrue = facetValues.every(facet => facet.isSelected)
-            const isByDefaultSelected = isAllFalse || isAllTrue
-            isAllFilterSelectedForFacet[el.columnName] = isByDefaultSelected
-            if (el.columnName === this.props.facet && !isAllFalse) {
-              // Note - this picks the first selected facet
-              chartSelectionIndex = facetValues
-                .sort((a, b) => b.count - a.count)
-                .findIndex(facet => facet.isSelected)
-            }
-          })
-        }
-        const newState = {
-          isAllFilterSelectedForFacet,
-          hasMoreData,
-          data,
-          chartSelectionIndex,
-          asyncJobStatus: undefined,
-          isColumnSelected:
-            data?.selectColumns
-              ?.slice(0, this.props.visibleColumnCount ?? Infinity)
-              .map(el => el.name) ?? [],
-        }
-        this.setState(newState)
-      })
-      .catch(error => {
-        console.error('Failed to get data ', error)
-        this.setState({
-          error,
         })
-      })
-      .finally(() => {
-        this.setState({
-          isLoading: false,
-          isLoadingNewData: false,
-        })
-      })
-  }
+      }
+      setIsAllFilterSelectedForFacet(isAllFilterSelectedForFacet)
+    }, [])
 
-  public updateParentState<K extends keyof QueryWrapperState>(
-    update: Pick<QueryWrapperState, K>,
-  ) {
-    this.setState(update)
-  }
+    useEffect(() => {
+      if (queryRequest !== props.initQueryRequest) {
+        setSelectedRowIndices([])
 
-  /**
-   * remove a particular facet name (e.g. study) and its all possible values based on the parameter specified in the url
-   * this is to remove the facet from the charts, search and filter.
-   * @return data: QueryResultBundle
-   */
-  public removeLockedFacetData (){
-    const lockedFacet = this.props.lockedFacet?.facet
-    if (lockedFacet && this.state.data) {  // for details page, return data without the "locked" facet
-      const data = cloneDeep(this.state.data)
-      const facets = data.facets?.filter( item => item.columnName.toLowerCase() !== lockedFacet.toLowerCase())
-      data.facets = facets
-      return data
-    } else {  // for other pages, just return the data
-      return this.state.data
-    }
-  }
+        const clonedQueryRequest = cloneDeep(queryRequest)
+        if (clonedQueryRequest.query) {
+          const stringifiedQuery = encodeURIComponent(
+            JSON.stringify(clonedQueryRequest.query),
+          )
+          if (props.shouldDeepLink) {
+            DeepLinkingUtils.updateUrlWithNewSearchParam(
+              'QueryWrapper',
+              componentIndex,
+              stringifiedQuery,
+            )
+          }
+        }
+      }
+    }, [queryRequest])
 
-  /**
-   * Render the children without any formatting
-   */
-  public render() {
-    const { isLoading } = this.state
-    const { children, ...rest } = this.props
+    useEffect(() => {
+      if (data) {
+        setDataWithLockedFacetRemoved(
+          removeLockedFacetData(props.lockedFacet, data),
+        )
+      }
+    }, [props.lockedFacet, data])
+
+    const { children, ...rest } = props
     // inject props in children of this component
-    const childrenWithProps = React.Children.map(children, (child: any) => {
-      if (!child) {
-        return child
-      }
-      const queryWrapperChildProps: QueryWrapperChildProps = {
-        isAllFilterSelectedForFacet: this.state.isAllFilterSelectedForFacet,
-        data: this.removeLockedFacetData(),
-        hasMoreData: this.state.hasMoreData,
-        lastFacetSelection: this.state.lastFacetSelection,
-        chartSelectionIndex: this.state.chartSelectionIndex,
-        isLoading: this.state.isLoading,
-        isLoadingNewData: this.state.isLoadingNewData,
-        asyncJobStatus: this.state.asyncJobStatus,
-        topLevelControlsState: this.state.topLevelControlsState,
-        isColumnSelected: this.state.isColumnSelected,
-        selectedRowIndices: this.state.selectedRowIndices,
-        error: this.state.error,
-        executeInitialQueryRequest: this.executeInitialQueryRequest,
-        executeQueryRequest: this.executeQueryRequest,
-        getLastQueryRequest: this.getLastQueryRequest,
-        getNextPageOfData: this.getNextPageOfData,
-        updateParentState: this.updateParentState,
-        getInitQueryRequest: this.getInitQueryRequest,
-        ...rest,
-      }
-      return React.cloneElement(child, queryWrapperChildProps)
-    })
+    const childrenWithProps = React.Children.map(
+      props.children,
+      (child: any) => {
+        if (!child) {
+          return child
+        }
+        const queryWrapperChildProps: QueryWrapperChildProps = {
+          isAllFilterSelectedForFacet,
+          data: dataWithLockedFacetRemoved,
+          hasMoreData: hasMoreData,
+          lastFacetSelection: lastFacetSelection,
+          chartSelectionIndex: chartSelectionIndex,
+          isLoading: isLoading,
+          isLoadingNewData: isLoadingNewData,
+          topLevelControlsState: topLevelControlsState,
+          isColumnSelected: isColumnSelected,
+          selectedRowIndices: selectedRowIndices,
+          error: error,
+          executeQueryRequest: param => {
+            console.log('calling execute query request with ', param)
+            setQueryRequest(cloneDeep(param))
+          },
+          getNextPageOfData: setQueryRequest,
+          getLastQueryRequest: () => queryRequest,
+          getInitQueryRequest: () => props.initQueryRequest,
+          setTopLevelControlsState: setTopLevelControlsState,
+          setSelectedRowIndices: setSelectedRowIndices,
+          setLastFacetSelection: setLastFacetSelection,
+          setIsAllFilterSelectedForFacet: setIsAllFilterSelectedForFacet,
+          setChartSelectionIndex: setChartSelectionIndex,
+          setIsColumnSelected: setIsColumnSelected,
+          ...rest,
+        }
+        return React.cloneElement(child, queryWrapperChildProps)
+      },
+    )
 
     const loadingCusrorClass = isLoading ? 'SRC-logo-cursor' : ''
     return (
@@ -450,5 +310,8 @@ export default class QueryWrapper extends React.Component<
         {childrenWithProps}
       </div>
     )
-  }
-}
+  },
+  queryClient,
+)
+
+export default QueryWrapper

--- a/src/lib/containers/SearchV2.tsx
+++ b/src/lib/containers/SearchV2.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react'
 import { CSSTransition } from 'react-transition-group'
-import { LockedFacet, QueryWrapperChildProps, QUERY_FILTERS_COLLAPSED_CSS, QUERY_FILTERS_EXPANDED_CSS } from './QueryWrapper'
+import {
+  LockedFacet,
+  QueryWrapperChildProps,
+  QUERY_FILTERS_COLLAPSED_CSS,
+  QUERY_FILTERS_EXPANDED_CSS,
+} from './QueryWrapper'
 import { library } from '@fortawesome/fontawesome-svg-core'
 import {
   faCaretDown,
@@ -126,12 +131,15 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
     if (columnName === '') {
       if (searchable) {
         // If searchable column names are defined in the config, grab the first one (that is not locked)
-        columnName = searchable.filter(colName => colName !== lockedFacet?.facet)[0]        
+        columnName = searchable.filter(
+          colName => colName !== lockedFacet?.facet,
+        )[0]
       } else {
         // Otherwise, get the first column model that can be searched.
         // And for study details page: if lockedFacet is defined, remove it from the search
-        const searchableColumnModels = this.props.data?.columnModels?.filter(el => el.name !== lockedFacet?.facet)
-            .filter(el => this.isSupportedColumn(el))
+        const searchableColumnModels = this.props.data?.columnModels
+          ?.filter(el => el.name !== lockedFacet?.facet)
+          .filter(el => this.isSupportedColumn(el))
         columnName = searchableColumnModels?.[0].name ?? ''
       }
     }
@@ -187,24 +195,28 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
 
   public isSupportedColumnAndInProps = (columnModel?: ColumnModel) => {
     if (this.isSupportedColumn(columnModel)) {
-        // return true if the searchable array contains this column name
-        const { searchable } = this.props
-        return searchable?.some(e => e === columnModel?.name)
+      // return true if the searchable array contains this column name
+      const { searchable } = this.props
+      return searchable?.some(e => e === columnModel?.name)
     }
     return false
   }
 
   render() {
-    const { data, topLevelControlsState, facetAliases, searchable, lockedFacet } = this.props
+    const {
+      data,
+      topLevelControlsState,
+      facetAliases,
+      searchable,
+      lockedFacet,
+    } = this.props
     const { searchText, show, columnName } = this.state
     let searchColumns: string[] = []
 
     // searchable specifies the order of the columns to search
     if (searchable) {
       searchColumns = searchable
-        .map(el =>
-          data?.columnModels?.find(model => model.name === el),
-        )
+        .map(el => data?.columnModels?.find(model => model.name === el))
         .filter(this.isSupportedColumnAndInProps)
         .map(el => el!.name)
     } else if (data?.columnModels) {
@@ -219,7 +231,13 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
     }
     const showFacetFilter = topLevelControlsState?.showFacetFilter
     return (
-      <div className={`SearchV2 ${showFacetFilter ? QUERY_FILTERS_EXPANDED_CSS : QUERY_FILTERS_COLLAPSED_CSS}`}>
+      <div
+        className={`SearchV2 ${
+          showFacetFilter
+            ? QUERY_FILTERS_EXPANDED_CSS
+            : QUERY_FILTERS_COLLAPSED_CSS
+        }`}
+      >
         <CSSTransition
           in={topLevelControlsState?.showSearchBar}
           classNames="SearchV2__animate_bar"
@@ -287,7 +305,7 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
                 const isSelected =
                   (columnName === '' && index === 0) || columnName === name
                 return (
-                  <div className="radio">
+                  <div className="radio" key={index}>
                     <label>
                       <span>
                         <input
@@ -296,7 +314,9 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
                           value={name}
                           checked={isSelected}
                           onClick={() => {
-                            this.searchFormRef?.current?.querySelector('input')?.focus()
+                            this.searchFormRef?.current
+                              ?.querySelector('input')
+                              ?.focus()
                             this.setState({
                               columnName: name,
                             })

--- a/src/lib/containers/StackedBarChart.tsx
+++ b/src/lib/containers/StackedBarChart.tsx
@@ -109,7 +109,7 @@ export default class StackedBarChart extends React.Component<
     _event: React.MouseEvent<SVGElement>,
   ) => {
     // https://medium.freecodecamp.org/reactjs-pass-parameters-to-event-handlers-ca1f5c422b9
-    this.props.updateParentState!({ chartSelectionIndex: dict.index })
+    this.props.setChartSelectionIndex!(dict.index)
   }
 
   public handleArrowClick = (direction: string) => (
@@ -129,7 +129,7 @@ export default class StackedBarChart extends React.Component<
     chartSelectionIndex = chartSelectionIndex % length
 
     dict = dict[chartSelectionIndex]
-    this.props.updateParentState!({ chartSelectionIndex })
+    this.props.setChartSelectionIndex!(chartSelectionIndex)
     // return is only for testing purposes
     return chartSelectionIndex
   }
@@ -171,14 +171,12 @@ export default class StackedBarChart extends React.Component<
       lastFacetSelection,
       isAllFilterSelectedForFacet,
       chartSelectionIndex,
-      asyncJobStatus,
     } = this.props
     // while loading
     if (isLoadingNewData) {
       return (
         <div className="SRC-loadingContainer SRC-centerContentColumn">
           {loadingScreen}
-          <div>{asyncJobStatus && asyncJobStatus.progressMessage}</div>
         </div>
       )
     }

--- a/src/lib/containers/download_list/DownloadConfirmation.tsx
+++ b/src/lib/containers/download_list/DownloadConfirmation.tsx
@@ -10,7 +10,7 @@ import {
 import DownloadDetails from './DownloadDetails'
 import DownloadListTable from './DownloadListTable'
 import useDeepCompareEffect from 'use-deep-compare-effect'
-import { TopLevelControlsState, QueryWrapperState } from '../QueryWrapper'
+import { TopLevelControlsState } from '../QueryWrapper'
 import SignInButton from '../SignInButton'
 
 enum StatusEnum {
@@ -35,9 +35,7 @@ export type DownloadConfirmationProps = {
   token?: string
   getLastQueryRequest?: () => QueryBundleRequest
   topLevelControlsState?: TopLevelControlsState
-  updateParentState?: <K extends keyof QueryWrapperState>(
-    param: Pick<QueryWrapperState, K>,
-  ) => void
+  setTopLevelControlsState?: (state: TopLevelControlsState) => void
   onExportTable?: () => void
 }
 
@@ -116,7 +114,7 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
   getLastQueryRequest,
   token,
   fnClose,
-  updateParentState,
+  setTopLevelControlsState,
   topLevelControlsState,
   onExportTable,
 }) => {
@@ -176,11 +174,9 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
   const onCancel = fnClose
     ? () => fnClose()
     : () => {
-        updateParentState!({
-          topLevelControlsState: {
-            ...topLevelControlsState!,
-            showDownloadConfirmation: false,
-          },
+        setTopLevelControlsState!({
+          ...topLevelControlsState!,
+          showDownloadConfirmation: false,
         })
       }
 
@@ -242,9 +238,10 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
             >
               View Download List
             </button>
-            
-            {onExportTable && <span>
-                or 
+
+            {onExportTable && (
+              <span>
+                or
                 <button
                   className="test-download-metadata btn-link"
                   onClick={onExportTable}
@@ -252,7 +249,7 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
                   Download File Metadata
                 </button>
               </span>
-            }
+            )}
           </span>
         )
 

--- a/src/lib/containers/home_page/featured-data/FacetPlotsCard.tsx
+++ b/src/lib/containers/home_page/featured-data/FacetPlotsCard.tsx
@@ -65,7 +65,7 @@ const FacetPlotsCard: React.FunctionComponent<FacetPlotsCardProps> = ({
   const [facetDataArray, setFacetDataArray] = useState<FacetColumnResult[]>([])
   const [selectedFacetValue, setSelectedFacetValue] = useState<string>('')
   const { colorPalette } = getColorPalette(rgbIndex ?? 0, 2)
-  
+
   useEffect(() => {
     if (!facetsToPlot || !data) {
       return
@@ -126,7 +126,7 @@ const FacetPlotsCard: React.FunctionComponent<FacetPlotsCardProps> = ({
       detailsPageLink = (
         <div className="FacetPlotsCard__link">
           <a href={detailsPagePath}>View {selectedFacetValue}</a>
-        </div>      
+        </div>
       )
     }
     const isShowingMultiplePlots = facetPlotDataArray.length > 1
@@ -142,7 +142,9 @@ const FacetPlotsCard: React.FunctionComponent<FacetPlotsCardProps> = ({
           style={{ backgroundColor: colorPalette[0].replace(')', ',.05)') }}
         >
           <span className="FacetPlotsCard__title">{cardTitle}</span>
-          {description && <span className="FacetPlotsCard__description">{description}</span>}
+          {description && (
+            <span className="FacetPlotsCard__description">{description}</span>
+          )}
           {detailsPageLink}
           {isLoading && (
             <span style={{ marginLeft: '2px' }} className={'spinner'} />
@@ -182,7 +184,7 @@ const FacetPlotsCard: React.FunctionComponent<FacetPlotsCardProps> = ({
                 </div>
               </div>
             )
-          })}          
+          })}
         </div>
       </div>
     )

--- a/src/lib/containers/query_wrapper_plot_nav/FilterAndView.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/FilterAndView.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react'
-import { QueryWrapperChildProps, QUERY_FILTERS_COLLAPSED_CSS, QUERY_FILTERS_EXPANDED_CSS } from '../QueryWrapper'
+import {
+  QueryWrapperChildProps,
+  QUERY_FILTERS_COLLAPSED_CSS,
+  QUERY_FILTERS_EXPANDED_CSS,
+} from '../QueryWrapper'
 import CardContainer from '../CardContainer'
 import SynapseTable, { SynapseTableProps } from '../table/SynapseTable'
 import { CardConfiguration } from '../CardContainerLogic'
@@ -18,10 +22,16 @@ const FilterAndView = (props: QueryWrapperChildProps & OwnProps) => {
     cardConfiguration,
     hideDownload,
     ...rest
-  } = props  
+  } = props
   const { showFacetFilter } = topLevelControlsState!
   return (
-    <div className={`FilterAndView ${showFacetFilter ? QUERY_FILTERS_EXPANDED_CSS : QUERY_FILTERS_COLLAPSED_CSS}`} >
+    <div
+      className={`FilterAndView ${
+        showFacetFilter
+          ? QUERY_FILTERS_EXPANDED_CSS
+          : QUERY_FILTERS_COLLAPSED_CSS
+      }`}
+    >
       {tableConfiguration ? (
         <SynapseTable
           {...rest}

--- a/src/lib/containers/query_wrapper_plot_nav/QueryFilterToggleButton.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryFilterToggleButton.tsx
@@ -1,32 +1,34 @@
 import React from 'react'
-import { QueryWrapperChildProps, QUERY_FILTERS_COLLAPSED_CSS, QUERY_FILTERS_EXPANDED_CSS, TopLevelControlsState } from '../QueryWrapper'
+import {
+  QueryWrapperChildProps,
+  QUERY_FILTERS_COLLAPSED_CSS,
+  QUERY_FILTERS_EXPANDED_CSS,
+  TopLevelControlsState,
+} from '../QueryWrapper'
 import { Button } from 'react-bootstrap'
 import IconSvg, { IconSvgOptions } from '../IconSvg'
 
-
-const QueryFilterToggleButton = (
-  props: QueryWrapperChildProps,
-) => {
-  const {
-    updateParentState,
-    topLevelControlsState,
-  } = props
-  const { showFacetFilter } = topLevelControlsState!
+const QueryFilterToggleButton = (props: QueryWrapperChildProps) => {
+  const showFacetFilter = props.topLevelControlsState?.showFacetFilter
   const toggleFilterShowingState = () => {
     const updatedTopLevelControlsState: TopLevelControlsState = {
-      ...topLevelControlsState!,
-      'showFacetFilter': !topLevelControlsState!['showFacetFilter'],
+      ...props.topLevelControlsState!,
+      showFacetFilter: !props.topLevelControlsState?.showFacetFilter,
     }
-    updateParentState!({
-      topLevelControlsState: updatedTopLevelControlsState,
-    })
+    props.setTopLevelControlsState!(updatedTopLevelControlsState)
   }
-  const iconOptions:IconSvgOptions = {
+  const iconOptions: IconSvgOptions = {
     icon: showFacetFilter ? 'arrowBack' : 'arrowForward',
-    color: 'inherit'
+    color: 'inherit',
   }
   return (
-    <div className={`QueryFilterToggleButton bootstrap-4-backport ${showFacetFilter ? QUERY_FILTERS_EXPANDED_CSS : QUERY_FILTERS_COLLAPSED_CSS}`}>
+    <div
+      className={`QueryFilterToggleButton bootstrap-4-backport ${
+        showFacetFilter
+          ? QUERY_FILTERS_EXPANDED_CSS
+          : QUERY_FILTERS_COLLAPSED_CSS
+      }`}
+    >
       <Button
         variant="outline-primary"
         onClick={toggleFilterShowingState}
@@ -36,7 +38,6 @@ const QueryFilterToggleButton = (
         <IconSvg options={iconOptions}></IconSvg>
       </Button>
     </div>
-
   )
 }
 

--- a/src/lib/containers/query_wrapper_plot_nav/TopLevelControls.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/TopLevelControls.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import QueryCount from '../QueryCount'
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
-import { QueryWrapperChildProps, QUERY_FILTERS_COLLAPSED_CSS, QUERY_FILTERS_EXPANDED_CSS, TopLevelControlsState } from '../QueryWrapper'
+import {
+  QueryWrapperChildProps,
+  QUERY_FILTERS_COLLAPSED_CSS,
+  QUERY_FILTERS_EXPANDED_CSS,
+  TopLevelControlsState,
+} from '../QueryWrapper'
 import { ColumnSelection } from '../table/table-top/ColumnSelection'
 import { SynapseClient } from '../../utils'
 import { ElementWithTooltip } from '../widgets/ElementWithTooltip'
@@ -69,7 +74,8 @@ const TopLevelControls = (
     token,
     name,
     sql,
-    updateParentState,
+    setTopLevelControlsState,
+    setIsColumnSelected,
     topLevelControlsState,
     data,
     showColumnSelection = false,
@@ -95,9 +101,8 @@ const TopLevelControls = (
     if (control === 'showDownloadConfirmation') {
       updatedTopLevelControlsState.showSearchBar = false
     }
-    updateParentState!({
-      topLevelControlsState: updatedTopLevelControlsState,
-    })
+
+    setTopLevelControlsState!(updatedTopLevelControlsState)
   }
 
   useEffect(() => {
@@ -126,12 +131,18 @@ const TopLevelControls = (
     } else {
       isColumnSelectedCopy.push(columnName)
     }
-    updateParentState!({ isColumnSelected: isColumnSelectedCopy })
+    setIsColumnSelected!(isColumnSelectedCopy)
   }
   const showFacetFilter = topLevelControlsState?.showFacetFilter
   return (
-    <div className={`TopLevelControls ${showFacetFilter ? QUERY_FILTERS_EXPANDED_CSS : QUERY_FILTERS_COLLAPSED_CSS}`}>
-      <h3>        
+    <div
+      className={`TopLevelControls ${
+        showFacetFilter
+          ? QUERY_FILTERS_EXPANDED_CSS
+          : QUERY_FILTERS_COLLAPSED_CSS
+      }`}
+    >
+      <h3>
         <div className="QueryWrapperPlotNav__querycount">
           <QueryCount token={token} name={name} sql={sql} parens={true} />
         </div>
@@ -165,14 +176,12 @@ const TopLevelControls = (
               return (
                 <DownloadOptions
                   darkTheme={true}
-                  onDownloadFiles={() =>
-                    updateParentState!({
-                      topLevelControlsState: {
-                        ...topLevelControlsState!,
-                        showDownloadConfirmation: true,
-                      },
+                  onDownloadFiles={() => {
+                    setTopLevelControlsState!({
+                      ...topLevelControlsState!,
+                      showDownloadConfirmation: true,
                     })
-                  }
+                  }}
                   token={token}
                   queryResultBundle={data}
                   queryBundleRequest={getLastQueryRequest!()}

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -99,7 +99,7 @@ export type SynapseTableProps = {
   showAccessColumn?: boolean
   showDownloadColumn?: boolean
   columnLinks?: LabelLinkConfig
-  hideDownload?: boolean  
+  hideDownload?: boolean
   isRowSelectionVisible?: boolean
 }
 
@@ -316,7 +316,7 @@ export default class SynapseTable extends React.Component<
    * Display the view
    */
   public render() {
-    if (this.props.isLoadingNewData) {
+    if (this.props.isLoading) {
       return loadingScreen
     } else if (!this.props.data) {
       return <></>
@@ -346,7 +346,7 @@ export default class SynapseTable extends React.Component<
     const hasResults = data.queryResult.queryResults.rows.length > 0
     if (!hasResults) {
       if (queryRequest.query.additionalFilters) {
-        return (<SearchResultsNotFound />)
+        return <SearchResultsNotFound />
       } else {
         return (
           <div className="text-center SRCBorderedPanel SRCBorderedPanel--padded2x">
@@ -359,10 +359,7 @@ export default class SynapseTable extends React.Component<
       }
     }
     const table = (
-
-      <div>
-        {this.renderTable(headers, columnModels, facets, rows)}
-      </div>
+      <div>{this.renderTable(headers, columnModels, facets, rows)}</div>
     )
     const content = (
       <>
@@ -395,6 +392,7 @@ export default class SynapseTable extends React.Component<
                   applyChanges={(newFacets: FacetColumnRequest[]) =>
                     this.applyChangesFromQueryFilter(newFacets)
                   }
+                  {...this.props}
                 />
               </div>
             )}
@@ -721,15 +719,16 @@ export default class SynapseTable extends React.Component<
     isShowingAccessColumn: boolean | undefined,
     isShowingDownloadColumn: boolean | undefined,
     isRowSelectionVisible: boolean | undefined,
-    tableEntityId: string | undefined
+    tableEntityId: string | undefined,
   ) {
+    console.log('createTableRows called')
     const rowsFormatted: JSX.Element[] = []
     const {
       token,
       data,
       isColumnSelected,
       selectedRowIndices,
-      updateParentState,
+      setSelectedRowIndices,
       columnLinks = [],
     } = this.props
     const { selectColumns = [], columnModels = [] } = data!
@@ -853,12 +852,12 @@ export default class SynapseTable extends React.Component<
         rowContent.unshift(
           <td className="SRC_noBorderTop direct-download">
             <DirectDownload
-              key={"direct-download-"+rowSynapseId}
+              key={'direct-download-' + rowSynapseId}
               token={token}
               associatedObjectId={rowSynapseId}
               entityVersionNumber={entityVersionNumber}
             ></DirectDownload>
-          </td>
+          </td>,
         )
       }
 
@@ -880,9 +879,7 @@ export default class SynapseTable extends React.Component<
                   }
                 }
                 // update parent state on change
-                updateParentState!({
-                  selectedRowIndices: cloneSelectedRowIndices,
-                })
+                setSelectedRowIndices!(cloneSelectedRowIndices)
               }}
             ></Checkbox>
           </td>,
@@ -1017,7 +1014,7 @@ export default class SynapseTable extends React.Component<
       tableColumnHeaderElements.unshift(
         <th key="downloadColumn">
           <div className="SRC-centerContent">&nbsp;</div>
-        </th>
+        </th>,
       )
     }
     if (isRowSelectionVisible) {
@@ -1080,7 +1077,7 @@ export default class SynapseTable extends React.Component<
     } else {
       isColumnSelected.push(columnName)
     }
-    this.props.updateParentState!({ isColumnSelected })
+    this.props.setIsColumnSelected!(isColumnSelected)
   }
 
   /**

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
 import FacetNavPanel from './FacetNavPanel'
-import { QueryWrapperChildProps, QUERY_FILTERS_COLLAPSED_CSS, QUERY_FILTERS_EXPANDED_CSS } from '../../QueryWrapper'
+import {
+  QueryWrapperChildProps,
+  QUERY_FILTERS_COLLAPSED_CSS,
+  QUERY_FILTERS_EXPANDED_CSS,
+} from '../../QueryWrapper'
 import {
   FacetColumnResultValues,
   FacetColumnRequest,
@@ -35,7 +39,7 @@ export type FacetNavProps = FacetNavOwnProps & QueryWrapperChildProps
 
 type ShowMoreState = 'MORE' | 'LESS' | 'NONE'
 
-export function getFacets (
+export function getFacets(
   data: QueryResultBundle | undefined,
   facetsToPlot?: string[],
 ): FacetColumnResult[] {
@@ -55,14 +59,13 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   isLoading,
   executeQueryRequest,
   token,
-  asyncJobStatus,
   topLevelControlsState,
   facetsToPlot,
   getInitQueryRequest,
-  updateParentState,
   facetAliases,
   showNotch = false,
   error,
+  ...rest
 }: FacetNavProps): JSX.Element => {
   const [facetUiStateArray, setFacetUiStateArray] = useState<UiFacetState[]>([])
   const [isFirstTime, setIsFirstTime] = useState(true)
@@ -192,15 +195,19 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   } else if (isLoadingNewData) {
     return (
       <div className="SRC-loadingContainer SRC-centerContentColumn">
-        {asyncJobStatus?.progressMessage && (
-          <div> <span className="spinner" /> {asyncJobStatus.progressMessage} </div>
-        )}
+        <span className="spinner" />
       </div>
     )
   } else {
     return (
       <>
-        <div className={`FacetNav ${showFacetVisualization ? '' : 'hidden'} ${showFacetFilter ? QUERY_FILTERS_EXPANDED_CSS : QUERY_FILTERS_COLLAPSED_CSS} ${showMoreButtonState === 'LESS' ? 'less' : ''}`}>
+        <div
+          className={`FacetNav ${showFacetVisualization ? '' : 'hidden'} ${
+            showFacetFilter
+              ? QUERY_FILTERS_EXPANDED_CSS
+              : QUERY_FILTERS_COLLAPSED_CSS
+          } ${showMoreButtonState === 'LESS' ? 'less' : ''}`}
+        >
           <div className="FacetNav__expanded">
             {expandedFacets.map((facet, index) => (
               <div key={facet.columnName}>
@@ -229,6 +236,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
                   }
                   facetAliases={facetAliases}
                   lastQueryRequest={lastQueryRequest}
+                  {...rest}
                 ></FacetNavPanel>
               </div>
             ))}
@@ -274,6 +282,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
                     )
                   }
                   facetAliases={facetAliases}
+                  {...rest}
                 ></FacetNavPanel>
               </div>
             ))}
@@ -302,6 +311,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
           frontText={'Showing'}
           showNotch={showNotch}
           topLevelControlsState={topLevelControlsState}
+          {...rest}
         />
       </>
     )

--- a/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
@@ -122,7 +122,7 @@ export function extractPlotDataArray(
   const getLabel = (
     facetValue: FacetColumnResultValueCount,
     truncateFlag: boolean,
-    columnType?: ColumnType,    
+    columnType?: ColumnType,
   ): string => {
     if (facetValue.value === SynapseConstants.VALUE_NOT_SET) {
       return SynapseConstants.FRIENDLY_VALUE_NOT_SET
@@ -149,17 +149,25 @@ export function extractPlotDataArray(
     const value = facetValue.value
     return truncateFlag ? truncate(value, maxLabelLength)! : value
   }
-  
+
   const labels = getLabels(facetToPlot.facetValues, false, columnType)
   const text = getLabels(facetToPlot.facetValues, true, columnType).map(
     el => el.label,
   )
 
-  const anyFacetsSelected = facetToPlot.facetValues.some(value => value.isSelected)
+  const anyFacetsSelected = facetToPlot.facetValues.some(
+    value => value.isSelected,
+  )
 
-  const selectionAwareColorPalette = anyFacetsSelected ? facetToPlot.facetValues.map((facetValue, index) =>
-    facetValue.isSelected ? colorPalette[index] : colorPalette[index].replace('rgb(', 'rgba(').replace(')', ', 0.25)'),
-  ) : colorPalette
+  const selectionAwareColorPalette = anyFacetsSelected
+    ? facetToPlot.facetValues.map((facetValue, index) =>
+        facetValue.isSelected
+          ? colorPalette[index]
+          : colorPalette[index]
+              .replace('rgb(', 'rgba(')
+              .replace(')', ', 0.25)'),
+      )
+    : colorPalette
   const singleChartData: PlotlyTyped.Data = {
     values:
       plotType === 'PIE'
@@ -191,7 +199,7 @@ export function extractPlotDataArray(
     pull:
       plotType === 'PIE'
         ? facetToPlot.facetValues.map(facetValue =>
-            facetValue.isSelected ? 0.10 : 0,
+            facetValue.isSelected ? 0.1 : 0,
           )
         : undefined,
     marker: {
@@ -206,7 +214,7 @@ export function extractPlotDataArray(
     colors:
       plotType === 'PIE'
         ? ((singleChartData as any).marker?.colors as string[])
-        : ((singleChartData as any).marker?.color as string[]),    
+        : ((singleChartData as any).marker?.color as string[]),
   }
   return result
 }
@@ -231,7 +239,7 @@ const applyFacetFilter = (
   }
 }
 
-export function getPlotStyle (
+export function getPlotStyle(
   parentWidth: number | null,
   plotType: PlotType,
   maxHeight: number,
@@ -255,7 +263,7 @@ export type FacetWithLabel = {
   count: number
 }
 
-export function renderLegend (
+export function renderLegend(
   labels: FacetWithLabel[] | undefined,
   colors: string[] = [],
   isExpanded: boolean,
@@ -375,7 +383,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
         key="toggleChart"
         className="SRC-primary-color"
         darkTheme={true}
-        icon={"chart"}
+        icon={'chart'}
       />
       <Dropdown.Menu className="chart-tools">
         <Dropdown.Item as="button" onClick={() => changePlotType('BAR')}>
@@ -440,7 +448,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
                 callbackFn={() => onExpand!(index)}
                 className="SRC-primary-color"
                 darkTheme={true}
-                icon={"expand"}
+                icon={'expand'}
               />
             )}
             {isExpanded && (
@@ -451,7 +459,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
                 callbackFn={() => onCollapse!(index)}
                 className="SRC-primary-color"
                 darkTheme={true}
-                icon={"collapse"}
+                icon={'collapse'}
               />
             )}
             <ElementWithTooltip
@@ -461,7 +469,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
               callbackFn={() => onHide(index)}
               className="SRC-primary-color"
               darkTheme={true}
-              icon={"close"}
+              icon={'close'}
             />
           </div>
         </div>

--- a/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
@@ -313,7 +313,9 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
   // is defined the event occuring is inside the dropdown which we then want to keep open, otherwise
   // we close it.
   const onToggle = (_show: boolean, _event: any, metadata: any) => {
-    if (metadata.source) {
+    if (!_show) {
+      setIsShowDropdown(false)
+    } else if (metadata.source) {
       setIsShowDropdown(true)
     } else {
       setIsShowDropdown(false)
@@ -332,7 +334,7 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
           tooltipText="Filter by specific facet"
           key="facetFilterTooltip"
           darkTheme={true}
-          icon={"filter"}
+          icon={'filter'}
         />
         <Dropdown.Menu>{content}</Dropdown.Menu>
       </Dropdown>

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -709,12 +709,12 @@ export type UserProfileList = { list: UserProfile[] }
  * http://docs.synapse.org/rest/POST/userProfile.html
  */
 export const getUserProfiles = (
-  list: string[],
+  userIds: string[],
   sessionToken: string | undefined = undefined,
 ): Promise<UserProfileList> => {
   return doPost(
     '/repo/v1/userProfile',
-    { list },
+    { list: userIds },
     sessionToken,
     undefined,
     BackendDestinationEnum.REPO_ENDPOINT,
@@ -831,12 +831,12 @@ export const getEntity: GetEntity = <T>(
  * Get a list of entity headers given by entity ids
  * http://rest-docs.synapse.org/rest/GET/entity/type.html
  */
-export const getEntityHeadersByIds = <T extends PaginatedResults<EntityHeader>> (
+export const getEntityHeadersByIds = <T extends PaginatedResults<EntityHeader>>(
   entityIds: string[],
   sessionToken?: string,
 ) => {
   return doGet(
-    `/repo/v1/entity/type?batch=${entityIds.join(",")}`,
+    `/repo/v1/entity/type?batch=${entityIds.join(',')}`,
     sessionToken,
     undefined,
     BackendDestinationEnum.REPO_ENDPOINT,

--- a/src/lib/utils/hooks/SynapseAPI/QueryClientProviderWrapper.tsx
+++ b/src/lib/utils/hooks/SynapseAPI/QueryClientProviderWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 // Create a client
-const queryClient = new QueryClient({
+const defaultQueryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 30 * 1000, // 30s
@@ -25,6 +25,7 @@ const queryClient = new QueryClient({
  */
 export const withQueryClientProvider = <P extends object>(
   Component: React.ComponentType<P>,
+  queryClient: QueryClient = defaultQueryClient,
 ): React.FC<P> =>
   function _(props: P) {
     return (

--- a/src/lib/utils/hooks/SynapseAPI/useGetEntityHeaders.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useGetEntityHeaders.ts
@@ -1,4 +1,4 @@
-import { QueryOptions, useQuery } from 'react-query'
+import { useQuery, useQueryClient, UseQueryOptions } from 'react-query'
 import { SynapseClient } from '../..'
 import { SynapseClientError } from '../../SynapseClient'
 import {
@@ -10,15 +10,38 @@ import {
 export function useGetEntityHeaders(
   references: ReferenceList,
   sessionToken?: string,
-  options?: QueryOptions<
+  options?: UseQueryOptions<
     PaginatedResults<EntityHeader>,
     SynapseClientError,
     PaginatedResults<EntityHeader>
   >,
 ) {
+  const queryClient = useQueryClient()
   return useQuery<PaginatedResults<EntityHeader>, SynapseClientError>(
-    ['entityHeaders', sessionToken, references],
+    [sessionToken, 'entityHeaders', references],
     () => SynapseClient.getEntityHeaders(references, sessionToken),
+    {
+      ...options,
+      onSuccess: results => {
+        for (const header of results.results) {
+          queryClient.setQueryData(
+            [sessionToken, 'entity', header.id, 'header'],
+            header,
+          )
+        }
+      },
+    },
+  )
+}
+
+export function useGetEntityHeader(
+  entityId: string,
+  sessionToken?: string,
+  options?: UseQueryOptions<EntityHeader, SynapseClientError, EntityHeader>,
+) {
+  return useQuery<EntityHeader, SynapseClientError>(
+    [sessionToken, 'entity', entityId, 'header'],
+    () => SynapseClient.getEntityHeader(entityId, sessionToken),
     options,
   )
 }

--- a/src/lib/utils/hooks/SynapseAPI/useGetQueryResultBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useGetQueryResultBundle.ts
@@ -1,4 +1,4 @@
-import { QueryOptions, useQuery } from 'react-query'
+import { useQuery, UseQueryOptions } from 'react-query'
 import { SynapseClient } from '../..'
 import { SynapseClientError } from '../../SynapseClient'
 import { QueryBundleRequest, QueryResultBundle } from '../../synapseTypes'
@@ -6,7 +6,7 @@ import { QueryBundleRequest, QueryResultBundle } from '../../synapseTypes'
 export default function useGetQueryResultBundle(
   queryBundleRequest: QueryBundleRequest,
   token?: string,
-  options?: QueryOptions<
+  options?: UseQueryOptions<
     QueryResultBundle,
     SynapseClientError,
     QueryResultBundle

--- a/src/lib/utils/hooks/SynapseAPI/useUserProfile.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useUserProfile.ts
@@ -1,0 +1,43 @@
+import { UseQueryOptions, useQuery, useQueryClient } from 'react-query'
+import { SynapseClient } from '../..'
+import { SynapseClientError, UserProfileList } from '../../SynapseClient'
+import { UserProfile } from '../../synapseTypes'
+
+export function useGetUserProfiles(
+  userIds: string[],
+  sessionToken?: string,
+  options?: UseQueryOptions<
+    UserProfileList,
+    SynapseClientError,
+    UserProfileList
+  >,
+) {
+  const queryClient = useQueryClient()
+  return useQuery<UserProfileList, SynapseClientError>(
+    [sessionToken, 'user', 'batch', userIds],
+    () => SynapseClient.getUserProfiles(userIds, sessionToken),
+    {
+      ...options,
+      onSuccess: results => {
+        for (const profile of results.list) {
+          queryClient.setQueryData(
+            [sessionToken, 'user', profile.ownerId, 'userProfile'],
+            profile,
+          )
+        }
+      },
+    },
+  )
+}
+
+export function useGetUserProfile(
+  userId: string,
+  sessionToken?: string,
+  options?: UseQueryOptions<UserProfile, SynapseClientError, UserProfile>,
+) {
+  return useQuery<UserProfile, SynapseClientError>(
+    [sessionToken, 'user', userId, 'userProfile'],
+    () => SynapseClient.getUserProfileById(sessionToken, userId),
+    options,
+  )
+}


### PR DESCRIPTION
[JIRA](https://sagebionetworks.jira.com/browse/PORTALS-1910)

This change adds a table query cache to the `QueryWrapper` component using `react-query`.

I was trying to solve [PORTALS-1896](https://sagebionetworks.jira.com/browse/PORTALS-1896) with `react-query` and went down a rabbit hole trying to get it to work.

This won't fix that issue, but provides a sizable performance improvement for components that use `QueryWrapper`, which tend to rely heavily on slow table queries over data that rarely changes.