### PR TITLE
Entity Finder scrub: SWC-5563, SWC-5565, SWC-5566, SWC-5568, SWC-5571

### DIFF
--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -215,6 +215,12 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
     }
   }, [sessionToken, searchTerms, handleError])
 
+  const mainPanelClass = searchActive
+    ? 'MainPanelSearch'
+    : treeOnly
+    ? 'MainPanelSinglePane'
+    : 'MainPanelDualPane'
+
   return (
     <QueryClientProvider client={queryClient}>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
@@ -281,100 +287,106 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
               </Button>
             )}
           </div>
-          {/* We have a separate Details component for search in order to preserve state in the other component between searches */}
-          {searchActive && (
-            <EntityDetailsList
-              sessionToken={sessionToken}
-              configuration={
-                searchByIdResults && searchByIdResults.length > 0
-                  ? {
-                      type: EntityDetailsListDataConfigurationType.HEADER_LIST,
-                      headerList: searchByIdResults,
-                    }
-                  : {
-                      type:
-                        EntityDetailsListDataConfigurationType.ENTITY_SEARCH,
-                      query: {
-                        queryTerm: searchTerms,
-                      },
-                    }
-              }
-              showVersionSelection={showVersionSelection}
-              selectColumnType={selectMultiple ? 'checkbox' : 'none'}
-              selected={selectedEntities}
-              visibleTypes={selectableTypes}
-              selectableTypes={selectableTypes}
-              toggleSelection={toggleSelection}
-            />
-          )}
-          {
-            <div style={searchActive ? { display: 'none' } : {}}>
-              {treeOnly ? (
-                <div>
-                  <TreeView
-                    sessionToken={sessionToken}
-                    toggleSelection={toggleSelection}
-                    showDropdown={true}
-                    visibleTypes={selectableAndVisibleTypesInTree}
-                    initialScope={initialScope}
-                    selectedEntities={selectedEntities}
-                    projectId={projectId}
-                    initialContainer={initialContainer}
-                    showScopeAsRootNode={false}
-                    nodeAppearance={NodeAppearance.SELECT}
-                    selectableTypes={selectableTypes}
-                  />
-                </div>
-              ) : (
-                <div className="EntityFinderReflexContainer">
-                  <SizeMe>
-                    {({ size }) => (
-                      <ReflexContainer
-                        key={(!!size.width).toString()}
-                        orientation="vertical"
-                        windowResizeAware
-                      >
-                        <ReflexElement
-                          className="TreeViewReflexElement"
-                          flex={0.18}
+          <div className={`EntityFinder__MainPanel ${mainPanelClass}`}>
+            {/* We have a separate Details component for search in order to preserve state in the other component between searches */}
+            {searchActive && (
+              <EntityDetailsList
+                sessionToken={sessionToken}
+                configuration={
+                  searchByIdResults && searchByIdResults.length > 0
+                    ? {
+                        type:
+                          EntityDetailsListDataConfigurationType.HEADER_LIST,
+                        headerList: searchByIdResults,
+                      }
+                    : {
+                        type:
+                          EntityDetailsListDataConfigurationType.ENTITY_SEARCH,
+                        query: {
+                          queryTerm: searchTerms,
+                        },
+                      }
+                }
+                showVersionSelection={showVersionSelection}
+                selectColumnType={selectMultiple ? 'checkbox' : 'none'}
+                selected={selectedEntities}
+                visibleTypes={selectableTypes}
+                selectableTypes={selectableTypes}
+                toggleSelection={toggleSelection}
+              />
+            )}
+            {
+              <div style={searchActive ? { display: 'none' } : {}}>
+                {treeOnly ? (
+                  <div>
+                    <TreeView
+                      sessionToken={sessionToken}
+                      toggleSelection={toggleSelection}
+                      showDropdown={true}
+                      visibleTypes={selectableAndVisibleTypesInTree}
+                      initialScope={initialScope}
+                      selectedEntities={selectedEntities}
+                      projectId={projectId}
+                      initialContainer={initialContainer}
+                      showScopeAsRootNode={false}
+                      nodeAppearance={NodeAppearance.SELECT}
+                      selectableTypes={selectableTypes}
+                    />
+                  </div>
+                ) : (
+                  <div className="EntityFinderReflexContainer">
+                    <SizeMe>
+                      {({ size }) => (
+                        <ReflexContainer
+                          key={(!!size.width).toString()}
+                          orientation="vertical"
+                          windowResizeAware
                         >
-                          <TreeView
-                            sessionToken={sessionToken}
-                            selectedEntities={selectedEntities}
-                            setDetailsViewConfiguration={setConfigFromTreeView}
-                            showDropdown={true}
-                            visibleTypes={visibleTypesInTree}
-                            initialScope={initialScope}
-                            projectId={projectId}
-                            initialContainer={initialContainer}
-                            nodeAppearance={NodeAppearance.BROWSE}
-                            setBreadcrumbItems={setBreadcrumbs}
-                            selectableTypes={visibleTypesInTree}
-                          />
-                        </ReflexElement>
-                        <ReflexSplitter></ReflexSplitter>
-                        <ReflexElement className="DetailsViewReflexElement">
-                          <EntityDetailsList
-                            sessionToken={sessionToken}
-                            configuration={configFromTreeView}
-                            showVersionSelection={showVersionSelection}
-                            selected={selectedEntities}
-                            visibleTypes={selectableAndVisibleTypesInList}
-                            selectableTypes={selectableTypes}
-                            selectColumnType={
-                              selectMultiple ? 'checkbox' : 'none'
-                            }
-                            toggleSelection={toggleSelection}
-                          />
-                          <Breadcrumbs {...breadcrumbsProps} />
-                        </ReflexElement>
-                      </ReflexContainer>
-                    )}
-                  </SizeMe>
-                </div>
-              )}
-            </div>
-          }
+                          <ReflexElement
+                            className="TreeViewReflexElement"
+                            flex={0.18}
+                          >
+                            <TreeView
+                              sessionToken={sessionToken}
+                              selectedEntities={selectedEntities}
+                              setDetailsViewConfiguration={
+                                setConfigFromTreeView
+                              }
+                              showDropdown={true}
+                              visibleTypes={visibleTypesInTree}
+                              initialScope={initialScope}
+                              projectId={projectId}
+                              initialContainer={initialContainer}
+                              nodeAppearance={NodeAppearance.BROWSE}
+                              setBreadcrumbItems={setBreadcrumbs}
+                              selectableTypes={visibleTypesInTree}
+                            />
+                          </ReflexElement>
+                          <ReflexSplitter></ReflexSplitter>
+                          <ReflexElement className="DetailsViewReflexElement">
+                            <EntityDetailsList
+                              sessionToken={sessionToken}
+                              configuration={configFromTreeView}
+                              showVersionSelection={showVersionSelection}
+                              selected={selectedEntities}
+                              visibleTypes={selectableAndVisibleTypesInList}
+                              selectableTypes={selectableTypes}
+                              selectColumnType={
+                                selectMultiple ? 'checkbox' : 'none'
+                              }
+                              toggleSelection={toggleSelection}
+                            />
+                            <Breadcrumbs {...breadcrumbsProps} />
+                          </ReflexElement>
+                        </ReflexContainer>
+                      )}
+                    </SizeMe>
+                  </div>
+                )}
+              </div>
+            }
+          </div>
+
           {selectedEntities.length > 0 && (
             <SelectionPane
               sessionToken={sessionToken}

--- a/src/lib/containers/entity_finder/SelectionPane.tsx
+++ b/src/lib/containers/entity_finder/SelectionPane.tsx
@@ -20,24 +20,22 @@ export const SelectionPane: React.FC<SelectionPaneProps> = ({
   toggleSelection,
 }: SelectionPaneProps) => {
   return (
-    <div className="EntityFinder__Selected">
-      <div className="alert alert-warning">
-        <h4>{title}</h4>
-        <div>
-          {selectedEntities.map(e => (
-            <div
-              key={`${e.targetId}${
-                e.targetVersionNumber ? `.${e.targetVersionNumber}` : ''
-              }`}
-            >
-              <EntityPathDisplay
-                sessionToken={sessionToken}
-                entity={e}
-                toggleSelection={toggleSelection}
-              ></EntityPathDisplay>
-            </div>
-          ))}
-        </div>
+    <div className="EntityFinder__Selected alert alert-warning">
+      <h4>{title}</h4>
+      <div>
+        {selectedEntities.map(e => (
+          <div
+            key={`${e.targetId}${
+              e.targetVersionNumber ? `.${e.targetVersionNumber}` : ''
+            }`}
+          >
+            <EntityPathDisplay
+              sessionToken={sessionToken}
+              entity={e}
+              toggleSelection={toggleSelection}
+            ></EntityPathDisplay>
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/src/lib/containers/entity_finder/tree/TreeView.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeView.tsx
@@ -371,7 +371,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
       }`}
     >
       <div className="Header">
-        <div className="Browse">Browse</div>
+        <div className="Browse">Browse:</div>
         <div onClick={e => e.stopPropagation()}>
           <Dropdown>
             <Dropdown.Toggle variant="gray-primary-500" id="dropdown-basic">

--- a/src/lib/style/abstracts/_variables.scss
+++ b/src/lib/style/abstracts/_variables.scss
@@ -2,10 +2,10 @@
 // This file contains all application-wide Sass variables.
 // -----------------------------------------------------------------------------
 
-$border-color-gray: #dddddf !default;
 $gray-dark: #dcdcdc !default;
 $gray-light: #f9f9f9 !default;
 $background-color-gray: $gray-light !default;
+$border-color-gray: $gray-dark !default;
 $background-color-gray-light: #fcfcfc !default;
 $primary-action-color: rgb(64, 123, 160) !default;
 $primary-bgcolor-rgba: rgba(201, 66, 129, 0.03) !default;

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -655,6 +655,10 @@ div.SRC-userImg {
   }
 }
 
+.fade > .SRC-userCard {
+  max-width: 450px;
+}
+
 .SRC-userCardName {
   font-weight: bold;
   font-size: 16px;

--- a/src/lib/style/components/entity_finder/_details-view.scss
+++ b/src/lib/style/components/entity_finder/_details-view.scss
@@ -2,19 +2,16 @@
 @use './entity-finder' as EntityFinder;
 
 .DetailsViewReflexElement {
-  right: $-splitter-width;
   .EntityFinderDetailsView {
-    border: none;
+    height: $-finder-height - $-breadcrumb-height;
     border-bottom: 1px solid SRC.$border-color-gray;
   }
 }
 
 .EntityFinderDetailsView {
-  border: 2px solid SRC.$border-color-gray;
-  height: $-finder-height - $-breadcrumb-height;
+  height: $-finder-height;
   width: 100%;
   overflow: auto;
-  border-bottom: $-border;
   background-color: SRC.$background-color-gray-light;
   table {
     width: 100%;
@@ -24,6 +21,7 @@
     thead {
       border-bottom: $-border;
       border-top: 1px solid white;
+      display: contents; // For some reason, this fixes https://sagebionetworks.jira.com/browse/SWC-5566
       th {
         height: $-header-height;
         font-weight: bold;

--- a/src/lib/style/components/entity_finder/_entity-finder.scss
+++ b/src/lib/style/components/entity_finder/_entity-finder.scss
@@ -21,9 +21,6 @@ $-splitter-width: 12px;
 // https://github.com/leefsmp/Re-Flex/issues/27
 .EntityFinderReflexContainer {
   width: 100%;
-  $-border-size: 2px;
-  height: $-finder-height + ($-border-size * 2);
-  border: $-border-size solid SRC.$border-color-gray;
 }
 
 .EntityFinder {
@@ -74,12 +71,32 @@ $-splitter-width: 12px;
     }
   }
 
+  &__MainPanel {
+    max-width: 100%;
+    transition: width 0.25s linear;
+    $-border-size: 1px;
+    border: $-border-size solid SRC.$border-color-gray;
+    height: $-finder-height + ($-border-size * 2);
+  }
+
+  &__MainPanel.MainPanelSearch {
+    width: 85vw;
+  }
+  &__MainPanel.MainPanelSinglePane {
+    width: $-tree-only-width + 5px;
+  }
+  &__MainPanel.MainPanelDualPane {
+    width: 85vw;
+  }
+
   &__Selected {
     min-width: max-content;
     max-width: $-tree-only-width;
     white-space: nowrap;
     padding: 15px;
     margin: 15px 0px 0px auto;
+    max-height: 200px;
+    overflow-y: auto;
     &__Row {
       display: flex;
       align-items: center;
@@ -105,11 +122,13 @@ $-splitter-width: 12px;
   }
 
   .reflex-container.vertical > .reflex-splitter {
+    height: $-finder-height;
     border-left: 3px solid transparent;
     border-right: none;
     background: transparent;
     box-sizing: border-box;
     width: $-splitter-width;
+    margin-right: -1 * $-splitter-width;
   }
   .reflex-container.vertical > .reflex-splitter:hover,
   .reflex-container.vertical > .reflex-splitter:active {

--- a/src/lib/style/components/entity_finder/_entity-finder.scss
+++ b/src/lib/style/components/entity_finder/_entity-finder.scss
@@ -1,8 +1,9 @@
 @use '../../abstracts/variables' as SRC;
 @use 'sass:color';
 
+$-border-size: 1px;
 $-header-height: 45px;
-$-border: 1px solid SRC.$border-color-gray;
+$-border: $-border-size solid SRC.$border-color-gray;
 $-finder-height: 500px;
 $-breadcrumb-height: 40px;
 $-selected-color: color.change(SRC.$primary-action-color-300, $alpha: 0.3);
@@ -74,7 +75,6 @@ $-splitter-width: 12px;
   &__MainPanel {
     max-width: 100%;
     transition: width 0.25s linear;
-    $-border-size: 1px;
     border: $-border-size solid SRC.$border-color-gray;
     height: $-finder-height + ($-border-size * 2);
   }
@@ -83,7 +83,7 @@ $-splitter-width: 12px;
     width: 85vw;
   }
   &__MainPanel.MainPanelSinglePane {
-    width: $-tree-only-width + 5px;
+    width: $-tree-only-width + ($-border-size * 2);
   }
   &__MainPanel.MainPanelDualPane {
     width: 85vw;

--- a/src/lib/style/components/entity_finder/_tree-view.scss
+++ b/src/lib/style/components/entity_finder/_tree-view.scss
@@ -17,7 +17,6 @@ $-selected-descendant-color: color.adjust($-selected-color, $lightness: 25%);
 .TreeView {
   background-color: SRC.$background-color-gray;
   height: $-finder-height;
-  border: 2px solid SRC.$border-color-gray;
   overflow: hidden;
   .Tree {
     height: $-finder-height - $-header-height;


### PR DESCRIPTION
* [SWC-5563](https://sagebionetworks.jira.com/browse/SWC-5563) Added a colon to the "Browse" text
* [SWC-5565](https://sagebionetworks.jira.com/browse/SWC-5565) Reduced border width
* [SWC-5566](https://sagebionetworks.jira.com/browse/SWC-5566) Fixed column headers in table view in Chrome not being totally top-aligned
* [SWC-5568](https://sagebionetworks.jira.com/browse/SWC-5568) Reworked how width is set and propagated to get a nice CSS transition when toggling search. This will have the desired effect of animating the modal size in SWC (which uses `width: max-content`, so it cannot be animated itself).


https://user-images.githubusercontent.com/17580037/115899913-5d41a980-a42d-11eb-8d82-d721857f0789.mov


* [SWC-5571](https://sagebionetworks.jira.com/browse/SWC-5571) Set a max height on the selection pane
* I also set a max-width of 450px on the overlayed user cards. Before this, they would stretch to be as wide as the content in them, which could be very long.