### PR TITLE
SWC-5372: Add focus style to custom checkboxes and radio options

### DIFF
--- a/src/__tests__/lib/containers/widgets/Checkbox.test.tsx
+++ b/src/__tests__/lib/containers/widgets/Checkbox.test.tsx
@@ -4,6 +4,10 @@ import {
   Checkbox,
   CheckboxProps,
 } from '../../../../lib/containers/widgets/Checkbox'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { resolveAllPending } from '../../../../lib/testutils/EnzymeHelpers'
+import { act } from 'react-dom/test-utils'
 
 const mockCallback = jest.fn()
 
@@ -35,12 +39,7 @@ describe('basic function', () => {
     expect(wrapper.find('span span').text()).toBe(props.label)
     expect(checkboxProps.checked).toBe(true)
     expect(checkboxProps.id).toBe(props.id)
-    expect(
-      wrapper
-        .find('div')
-        .at(0)
-        .hasClass('checkboxClass'),
-    ).toBe(true)
+    expect(wrapper.find('div').at(0).hasClass('checkboxClass')).toBe(true)
   })
 
   it('should render with correct checked state', () => {
@@ -61,5 +60,29 @@ describe('basic function', () => {
     wrapper.find('input').simulate('change', event)
     expect(mockCallback).toHaveBeenCalledWith(true)
     expect(wrapper.find('input').props().checked).toBe(true)
+  })
+
+  it('should be accessible via RTL', async () => {
+    render(<Checkbox {...props} />)
+    expect(() => screen.getByRole('checkbox')).not.toThrowError()
+
+    userEvent.click(screen.getByRole('checkbox'))
+    expect(mockCallback).toHaveBeenCalledWith(true)
+  })
+
+  it('should append focused class when focused', async () => {
+    init({ ...props, checked: false })
+
+    expect(wrapper.find('.checkbox-focused').length).toEqual(0)
+    act(() => {
+      wrapper.find('input').props().onFocus!({} as any)
+    })
+    await resolveAllPending(wrapper)
+    expect(wrapper.find('.checkbox-focused').length).toEqual(1)
+    act(() => {
+      wrapper.find('input').props().onBlur!({} as any)
+    })
+    await resolveAllPending(wrapper)
+    expect(wrapper.find('.checkbox-focused').length).toEqual(0)
   })
 })

--- a/src/__tests__/lib/containers/widgets/RadioGroup.test.tsx
+++ b/src/__tests__/lib/containers/widgets/RadioGroup.test.tsx
@@ -4,6 +4,8 @@ import {
   RadioGroup,
   RadioGroupProps,
 } from '../../../../lib/containers/widgets/RadioGroup'
+import { resolveAllPending } from '../../../../lib/testutils/EnzymeHelpers'
+import { act } from 'react-dom/test-utils'
 
 const mockCallback = jest.fn()
 
@@ -38,70 +40,26 @@ describe('basic function', () => {
     expect(wrapper.find('.radio')).toHaveLength(props.options.length)
     expect(wrapper.find('input')).toHaveLength(props.options.length)
     expect(wrapper.find('div').at(0).hasClass('radioGroupClass')).toBe(true)
-    expect(
-      wrapper
-        .find('label')
-        .at(0)
-        .find('span span')
-        .text(),
-    ).toBe(props.options[0].label)
+    expect(wrapper.find('label').at(0).find('span span').text()).toBe(
+      props.options[0].label,
+    )
 
-    expect(
-      wrapper
-        .find('input')
-        .at(1)
-        .props().checked,
-    ).toBe(true)
-    expect(
-      wrapper
-        .find('input')
-        .at(2)
-        .props().checked,
-    ).toBe(false)
+    expect(wrapper.find('input').at(1).props().checked).toBe(true)
+    expect(wrapper.find('input').at(2).props().checked).toBe(false)
   })
 
   it('should have correct item changed', () => {
     init({ ...props, value: 'value2' })
-    expect(
-      wrapper
-        .find('input')
-        .at(0)
-        .props().checked,
-    ).toBe(false)
-    expect(
-      wrapper
-        .find('input')
-        .at(1)
-        .props().checked,
-    ).toBe(false)
-    expect(
-      wrapper
-        .find('input')
-        .at(2)
-        .props().checked,
-    ).toBe(true)
+    expect(wrapper.find('input').at(0).props().checked).toBe(false)
+    expect(wrapper.find('input').at(1).props().checked).toBe(false)
+    expect(wrapper.find('input').at(2).props().checked).toBe(true)
   })
 
   it('should not crash without value specified', () => {
     init({ ...props, value: undefined })
-    expect(
-      wrapper
-        .find('input')
-        .at(0)
-        .props().checked,
-    ).toBe(false)
-    expect(
-      wrapper
-        .find('input')
-        .at(1)
-        .props().checked,
-    ).toBe(false)
-    expect(
-      wrapper
-        .find('input')
-        .at(2)
-        .props().checked,
-    ).toBe(false)
+    expect(wrapper.find('input').at(0).props().checked).toBe(false)
+    expect(wrapper.find('input').at(1).props().checked).toBe(false)
+    expect(wrapper.find('input').at(2).props().checked).toBe(false)
   })
 
   it('should call callbackFn on change with correct params and change the value', () => {
@@ -116,10 +74,23 @@ describe('basic function', () => {
       },
     }
 
-    wrapper
-      .find('input')
-      .at(1)
-      .simulate('change', event)
+    wrapper.find('input').at(1).simulate('change', event)
     expect(mockCallback).toHaveBeenCalledWith(props.options[1].value, false)
+  })
+
+  it('should append focused class when focused', async () => {
+    init({ ...props, value: undefined })
+
+    expect(wrapper.find('.radio-focused').length).toEqual(0)
+    act(() => {
+      wrapper.find('input').at(0).props().onFocus!({} as any)
+    })
+    await resolveAllPending(wrapper)
+    expect(wrapper.find('.radio-focused').length).toEqual(1)
+    act(() => {
+      wrapper.find('input').at(0).props().onBlur!({} as any)
+    })
+    await resolveAllPending(wrapper)
+    expect(wrapper.find('.radio-focused').length).toEqual(0)
   })
 })

--- a/src/lib/containers/widgets/Checkbox.tsx
+++ b/src/lib/containers/widgets/Checkbox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { useState, useEffect } from 'react'
 export type CheckboxProps = {
   label: string
@@ -15,6 +15,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
 ) => {
   const { checked: propsChecked = false, isSelectAll = false } = props
   const [checked, setChecked] = useState<boolean>(propsChecked)
+  const [focused, setFocused] = useState<boolean>(false)
 
   useEffect(() => {
     setChecked(propsChecked)
@@ -33,13 +34,21 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
     }
   }
 
-  const className = props.className ? `checkbox ${props.className}` : `checkbox`
+  let className = 'checkbox'
+  if (focused) {
+    className += ' checkbox-focused'
+  }
+  if (props.className) {
+    className += ` ${props.className}`
+  }
 
   return (
     <div className={className}>
       <label>
         <span>
           <input
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
             type="checkbox"
             checked={checked}
             id={props.id}

--- a/src/lib/containers/widgets/RadioGroup.tsx
+++ b/src/lib/containers/widgets/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useState } from 'react'
 
 export type RadioGroupProps = {
   options: { label: string; value: string }[]
@@ -18,23 +18,46 @@ export const RadioGroup: React.FunctionComponent<RadioGroupProps> = (
   return (
     <div className={className}>
       {props.options.map(option => (
-        <div className="radio" key={option.value}>
-          {props.value == option.value}
-          <label>
-            <span>
-              <input
-                type="radio"
-                checked={props.value === option.value}
-                value={option.value}
-                onChange={({ target }: React.ChangeEvent<HTMLInputElement>) =>
-                  props.onChange(target.value, target.checked)
-                }
-              />
-              <span>{option.label}</span>
-            </span>
-          </label>
-        </div>
+        <RadioOption
+          key={option.value}
+          label={option.label}
+          value={option.value}
+          currentValue={props.value}
+          onChange={props.onChange}
+        />
       ))}
+    </div>
+  )
+}
+
+type RadioOptionProps = {
+  label: string
+  value: string
+  currentValue?: string
+  onChange: (value: string, checked: boolean) => void
+}
+
+const RadioOption: React.FunctionComponent<RadioOptionProps> = (
+  props: RadioOptionProps,
+) => {
+  const [focused, setFocused] = useState(false)
+  return (
+    <div className={`radio ${focused ? 'radio-focused' : ''}`}>
+      <label>
+        <span>
+          <input
+            type="radio"
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            checked={props.currentValue === props.value}
+            value={props.value}
+            onChange={({ target }: React.ChangeEvent<HTMLInputElement>) =>
+              props.onChange(target.value, target.checked)
+            }
+          />
+          <span>{props.label}</span>
+        </span>
+      </label>
     </div>
   )
 }

--- a/src/lib/template_style/_form.scss
+++ b/src/lib/template_style/_form.scss
@@ -10,7 +10,11 @@
 }
 input[type='checkbox'],
 input[type='radio'] {
-  display: none;
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
 }
 .checkbox > label::before,
 .radio::before,
@@ -24,6 +28,11 @@ input[type='radio'] {
   border-radius: 2px;
   background: radial-gradient(white, #eee);
   margin-right: 5px;
+}
+
+.checkbox-focused > label::before,
+.radio-focused::before {
+  box-shadow: 0px 0px 2px 2px SRC.$primary-action-color-active;
 }
 
 .radio::before {


### PR DESCRIPTION
Before, you could not navigate to checkboxes with tab (because the `input` had `display: none`) and you could not tell when you had navigated to a radio button.

After (note, added a radio group to this modal just for this clip):

https://user-images.githubusercontent.com/17580037/116572577-17c42700-a8da-11eb-9a76-2d1c411cb1d8.mov


