### PR TITLE
PORTALS-1821

### DIFF
--- a/src/__tests__/lib/containers/widgets/facet-nav/FacetNav.test.tsx
+++ b/src/__tests__/lib/containers/widgets/facet-nav/FacetNav.test.tsx
@@ -27,7 +27,6 @@ function createTestProps(overrides?: FacetNavProps): FacetNavProps {
   return {
     getLastQueryRequest: mockGetLastQueryRequest,
     data: testData as QueryResultBundle,
-    loadingScreen: <div className="loading"></div>,
     ...overrides,
     topLevelControlsState: {
       showFacetVisualization: true,
@@ -82,14 +81,17 @@ describe('facets display hide/show', () => {
       expectedLength,
     )
     expect(
-      isHidden(container.querySelector('.FacetNav__row')!.children[2]),
+      isHidden(container.querySelector('.FacetNav__row')!.children[1]),
     ).toBe(false)
+    expect(
+      isHidden(container.querySelector('.FacetNav__row')!.children[2]),
+    ).toBe(true)
     expect(
       isHidden(container.querySelector('.FacetNav__row')!.children[3]),
     ).toBe(true)
     expect(
       container.querySelector('button.FacetNav__showMore')?.innerHTML,
-    ).toBe('Show All Graphs')
+    ).toBe('View All Charts')
   })
 
   it('when show more is clicked', async () => {
@@ -97,6 +99,9 @@ describe('facets display hide/show', () => {
     const button = container.querySelector('button.FacetNav__showMore')
     fireEvent.click(button!)
     expect(
+      isHidden(container.querySelector('.FacetNav__row')!.children[1]),
+    ).toBe(false)
+    expect(
       isHidden(container.querySelector('.FacetNav__row')!.children[2]),
     ).toBe(false)
     expect(
@@ -104,17 +109,20 @@ describe('facets display hide/show', () => {
     ).toBe(false)
     expect(
       container.querySelector('button.FacetNav__showMore')?.innerHTML,
-    ).toBe('Hide Optional Graphs')
+    ).toBe('Hide Charts')
     fireEvent.click(button!)
     expect(
-      isHidden(container.querySelector('.FacetNav__row')!.children[2]),
+      isHidden(container.querySelector('.FacetNav__row')!.children[1]),
     ).toBe(false)
+    expect(
+      isHidden(container.querySelector('.FacetNav__row')!.children[2]),
+    ).toBe(true)
     expect(
       isHidden(container.querySelector('.FacetNav__row')!.children[3]),
     ).toBe(true)
     expect(
       container.querySelector('button.FacetNav__showMore')?.innerHTML,
-    ).toBe('Show All Graphs')
+    ).toBe('View All Charts')
   })
 
   it('if there are only 4 facets show more button should not exist', async () => {
@@ -157,15 +165,15 @@ describe('facets display hide/show', () => {
       ?.children
     expect(expandedFacets?.length).toBe(0)
     expect(
-      isHidden(container.querySelector('.FacetNav__row')!.children[2]),
+      isHidden(container.querySelector('.FacetNav__row')!.children[1]),
     ).toBe(false)
-    const icon = getButtonOnFacet(container, 'expand', 2)
+    const icon = getButtonOnFacet(container, 'expand', 1)
     fireEvent.click(icon?.parentNode as HTMLElement)
     expandedFacets = container.querySelector('.FacetNav__expanded')?.children
     expect(expandedFacets?.length).toBe(1)
 
     expect(
-      isHidden(container.querySelector('.FacetNav__row')!.children[2]),
+      isHidden(container.querySelector('.FacetNav__row')!.children[1]),
     ).toBe(true)
   })
 })

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -65,8 +65,8 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
     hideDownload,
     searchConfiguration,
     ...rest
-  } = props  
-  let sqlUsed = sql  
+  } = props
+  let sqlUsed = sql
   if (searchParams) {
     sqlUsed = insertConditionsFromSearchParams(
       searchParams,
@@ -107,13 +107,13 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
         />
         <QueryFilter {...rest} />
         <QueryFilterToggleButton />
-        <FacetNav facetsToPlot={facetsToPlot} showNotch={true} />
+        <FacetNav facetsToPlot={facetsToPlot} showNotch={false} />
         <FilterAndView
           facetsToFilter={facetsToFilter}
           tableConfiguration={tableConfiguration}
           hideDownload={hideDownload}
           cardConfiguration={cardConfiguration}
-        />        
+        />
         {showExportMetadata && (
           <ModalDownload onClose={() => setShowExportMetadata(false)} />
         )}

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -15,6 +15,7 @@ import {
 import { useState, useEffect } from 'react'
 import TotalQueryResults from '../../../containers/TotalQueryResults'
 import { applyChangesToValuesColumn } from '../query-filter/QueryFilter'
+import { Button } from 'react-bootstrap'
 
 export type FacetNavOwnProps = {
   facetsToPlot?: string[]
@@ -28,7 +29,7 @@ type UiFacetState = {
   index?: number
 }
 
-const DEFAULT_VISIBLE_FACETS = 3
+const DEFAULT_VISIBLE_FACETS = 2
 
 /*
 TODO: This component has a few bugs when its props are updated with new data, this should be handled
@@ -260,7 +261,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
               </div>
             ))}
           </div>
-          <div className="FacetNav__row clearfix">
+          <div className="FacetNav__row">
             {restOfFacets.map((facet, index) => (
               <div
                 className="col-sm-12 col-md-4"
@@ -305,17 +306,18 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
               </div>
             ))}
           </div>
-          <div className="FacetNav__showMoreContainer">
+          <div className="FacetNav__showMoreContainer bootstrap-4-backport">
             {showMoreButtonState !== 'NONE' && (
-              <button
-                className="btn btn-default FacetNav__showMore"
+              <Button
+                variant="secondary"
+                className="pill-xl FacetNav__showMore"
                 onClick={() => onShowMoreClick(showMoreButtonState === 'MORE')}
                 style={{ zIndex: 500 }}
               >
                 {showMoreButtonState === 'LESS'
-                  ? 'Hide Optional Graphs'
-                  : 'Show All Graphs'}
-              </button>
+                  ? 'Hide Charts'
+                  : 'View All Charts'}
+              </Button>
             )}
           </div>
         </div>

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -214,7 +214,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
           getInitQueryRequest={getInitQueryRequest}
           token={token}
           unitDescription={
-            hasSelectedFacets ? 'Results Filtered By:' : 'Results'
+            hasSelectedFacets ? 'Results Filtered By' : 'Results'
           }
           frontText={''}
           showNotch={showNotch}

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -198,8 +198,8 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
       <div className="SRC-loadingContainer SRC-centerContentColumn">
         {asyncJobStatus?.progressMessage && (
           <div>
-            {' '}
-            <span className="spinner" /> {asyncJobStatus.progressMessage}{' '}
+            <span className="spinner" />
+            {asyncJobStatus.progressMessage}
           </div>
         )}
       </div>

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
 import FacetNavPanel from './FacetNavPanel'
-import { QueryWrapperChildProps, QUERY_FILTERS_COLLAPSED_CSS, QUERY_FILTERS_EXPANDED_CSS } from '../../QueryWrapper'
+import {
+  QueryWrapperChildProps,
+  QUERY_FILTERS_COLLAPSED_CSS,
+  QUERY_FILTERS_EXPANDED_CSS,
+} from '../../QueryWrapper'
 import {
   FacetColumnResultValues,
   FacetColumnRequest,
@@ -35,7 +39,7 @@ export type FacetNavProps = FacetNavOwnProps & QueryWrapperChildProps
 
 type ShowMoreState = 'MORE' | 'LESS' | 'NONE'
 
-export function getFacets (
+export function getFacets(
   data: QueryResultBundle | undefined,
   facetsToPlot?: string[],
 ): FacetColumnResult[] {
@@ -193,14 +197,37 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
     return (
       <div className="SRC-loadingContainer SRC-centerContentColumn">
         {asyncJobStatus?.progressMessage && (
-          <div> <span className="spinner" /> {asyncJobStatus.progressMessage} </div>
+          <div>
+            {' '}
+            <span className="spinner" /> {asyncJobStatus.progressMessage}{' '}
+          </div>
         )}
       </div>
     )
   } else {
     return (
       <>
-        <div className={`FacetNav ${showFacetVisualization ? '' : 'hidden'} ${showFacetFilter ? QUERY_FILTERS_EXPANDED_CSS : QUERY_FILTERS_COLLAPSED_CSS} ${showMoreButtonState === 'LESS' ? 'less' : ''}`}>
+        <TotalQueryResults
+          isLoading={isLoading!}
+          executeQueryRequest={executeQueryRequest!}
+          lastQueryRequest={getLastQueryRequest?.()!}
+          getInitQueryRequest={getInitQueryRequest}
+          token={token}
+          unitDescription={
+            hasSelectedFacets ? 'Results Filtered By:' : 'Results'
+          }
+          frontText={''}
+          showNotch={showNotch}
+          topLevelControlsState={topLevelControlsState}
+        />
+
+        <div
+          className={`FacetNav ${showFacetVisualization ? '' : 'hidden'} ${
+            showFacetFilter
+              ? QUERY_FILTERS_EXPANDED_CSS
+              : QUERY_FILTERS_COLLAPSED_CSS
+          } ${showMoreButtonState === 'LESS' ? 'less' : ''}`}
+        >
           <div className="FacetNav__expanded">
             {expandedFacets.map((facet, index) => (
               <div key={facet.columnName}>
@@ -292,17 +319,6 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
             )}
           </div>
         </div>
-        <TotalQueryResults
-          isLoading={isLoading!}
-          executeQueryRequest={executeQueryRequest!}
-          lastQueryRequest={getLastQueryRequest?.()!}
-          getInitQueryRequest={getInitQueryRequest}
-          token={token}
-          unitDescription={hasSelectedFacets ? 'results via:' : 'results'}
-          frontText={'Showing'}
-          showNotch={showNotch}
-          topLevelControlsState={topLevelControlsState}
-        />
       </>
     )
   }

--- a/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
+++ b/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
@@ -7,10 +7,9 @@ import {
   FacetColumnResultValueCount,
 } from '../../../utils/synapseTypes'
 import { unCamelCase } from '../../../utils/functions/unCamelCase'
-import { faTimes } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ElementWithTooltip } from '../ElementWithTooltip'
 import { SynapseConstants } from '../../../utils'
+import { Close } from '@material-ui/icons'
 
 export type FacetWithSelection = {
   facet: FacetColumnResult
@@ -75,8 +74,9 @@ const SelectionCriteriaPill: FunctionComponent<SelectionCriteriaPillProps> = ({
         <button
           onClick={() => onRemove(facetWithSelection)}
           className="SelectionCriteriaPill__btnRemove"
+          title="deselect"
         >
-          <FontAwesomeIcon icon={faTimes} title="deselect" />
+          <Close />
         </button>
       </label>
     </ElementWithTooltip>

--- a/src/lib/style/abstracts/_variables.scss
+++ b/src/lib/style/abstracts/_variables.scss
@@ -10,6 +10,7 @@ $background-color-gray-light: #fcfcfc !default;
 $primary-action-color: rgb(64, 123, 160) !default;
 $primary-bgcolor-rgba: rgba(201, 66, 129, 0.03) !default;
 
+$text-color-dark: #1a1c29 !default;
 $text-color-disabled: #bbbbbc !default;
 
 $secondary-action-color: rgb(98, 172, 98) !default;

--- a/src/lib/style/components/_query-wrapper-plot-nav.scss
+++ b/src/lib/style/components/_query-wrapper-plot-nav.scss
@@ -1,6 +1,6 @@
 @use '../abstracts/variables' as SRC;
 
-.QueryWrapperPlotNav {  
+.QueryWrapperPlotNav {
   @media (min-width: map-get(SRC.$breakpoints, 'medium')) {
     .SRC-wrapper {
       display: grid;
@@ -23,9 +23,9 @@
           border: none;
           width: 45px;
           height: 45px;
-          &:hover{
+          &:hover {
             background-color: SRC.$primary-action-color;
-          }        
+          }
         }
       }
       // row
@@ -41,23 +41,24 @@
       .TopLevelControls {
         grid-row: 1 / span 1;
       }
-      .download-confirmation {
+      .TotalQueryResults {
         grid-row: 2 / span 1;
       }
-      .SearchV2 {
+      .download-confirmation {
         grid-row: 3 / span 1;
+      }
+      .SearchV2 {
+        grid-row: 4 / span 1;
         margin-bottom: 10px;
       }
       .FacetNav {
-        grid-row: 4 / span 1;
-      }
-      .TotalQueryResults {
         grid-row: 5 / span 1;
+        margin-bottom: 20px;
       }
       .FilterAndView {
         grid-row: 6 / span 1;
       }
-      
+
       // column (depends on if we are showing facet filters)
       .isShowingFacetFilters {
         &.QueryFilter {
@@ -69,7 +70,12 @@
             margin-left: 2px;
           }
         }
-        &.download-confirmation, &.FacetNav, &.TotalQueryResults, &.FilterAndView, &.TopLevelControls, &.SearchV2 {
+        &.download-confirmation,
+        &.FacetNav,
+        &.TotalQueryResults,
+        &.FilterAndView,
+        &.TopLevelControls,
+        &.SearchV2 {
           grid-column: 5 / span 1;
         }
       }
@@ -77,24 +83,29 @@
         &.QueryFilter {
           grid-column: 1 / span 1;
           > * {
-            display:none;
-          }          
+            display: none;
+          }
         }
         &.QueryFilterToggleButton {
           grid-column: 2 / span 1;
         }
       }
     }
-    .download-confirmation, .TotalQueryResults, .FacetNav, .FilterAndView, .TopLevelControls, .SearchV2 {
+    .download-confirmation,
+    .TotalQueryResults,
+    .FacetNav,
+    .FilterAndView,
+    .TopLevelControls,
+    .SearchV2 {
       margin-left: 30px;
-    }  
+    }
   }
 
   @media (max-width: map-get(SRC.$breakpoints, 'medium')) {
     .SRC-wrapper {
-        .QueryFilterToggleButton {
-          display:none;
-        }
+      .QueryFilterToggleButton {
+        display: none;
+      }
     }
   }
 
@@ -113,8 +124,8 @@
     padding-top: 20px;
     padding-bottom: 10px;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-    margin-bottom: 25px;
-    &__showhidefacetfilters{
+    margin-bottom: 15px;
+    &__showhidefacetfilters {
       display: none;
     }
     .QueryWrapperPlotNav__querycount {
@@ -130,7 +141,8 @@
         border: 0;
         border-radius: 0;
 
-        &:active:focus, &:focus {
+        &:active:focus,
+        &:focus {
           outline: none;
         }
 
@@ -146,7 +158,7 @@
     margin-top: 0px;
   }
   table {
-    &.grip-flex{
+    &.grip-flex {
       width: 100% !important; // Override !important from js library
       table-layout: auto;
     }

--- a/src/lib/style/components/_query-wrapper-plot-nav.scss
+++ b/src/lib/style/components/_query-wrapper-plot-nav.scss
@@ -41,19 +41,19 @@
       .TopLevelControls {
         grid-row: 1 / span 1;
       }
-      .TotalQueryResults {
+      .download-confirmation {
         grid-row: 2 / span 1;
       }
-      .download-confirmation {
-        grid-row: 3 / span 1;
-      }
       .SearchV2 {
-        grid-row: 4 / span 1;
+        grid-row: 3 / span 1;
         margin-bottom: 10px;
       }
+      .TotalQueryResults {
+        grid-row: 4 / span 1;
+      }
+
       .FacetNav {
         grid-row: 5 / span 1;
-        margin-bottom: 20px;
       }
       .FilterAndView {
         grid-row: 6 / span 1;
@@ -112,6 +112,14 @@
   .SearchV2 {
     // PORTALS-1856: z-index greater than the Show All Graphs button (500)
     z-index: 600;
+  }
+
+  .TotalQueryResults {
+    margin-top: 5px;
+  }
+  .FacetNav {
+    margin-top: 5px;
+    margin-bottom: 10px;
   }
 
   .TopLevelControls {

--- a/src/lib/style/components/_total-query-results.scss
+++ b/src/lib/style/components/_total-query-results.scss
@@ -37,7 +37,7 @@
   margin-left: 1rem;
   line-height: 100%;
   cursor: pointer;
-  background-color: color.change(SRC.$primary-action-color, $alpha: 0.1);
+  background-color: color.change(SRC.$secondary-action-color, $alpha: 0.1);
   color: SRC.$text-color-dark;
   font-weight: normal;
   margin: 10px;
@@ -46,7 +46,7 @@
   }
 
   &__btnRemove {
-    color: SRC.$primary-action-color;
+    color: SRC.$secondary-action-color;
     padding: 0;
     margin-left: 5px;
     margin-top: 1px;

--- a/src/lib/style/components/_total-query-results.scss
+++ b/src/lib/style/components/_total-query-results.scss
@@ -1,13 +1,13 @@
 @use '../abstracts/variables' as SRC;
+@use 'sass:color';
 
 .TotalQueryResults {
-  background: SRC.$gray-light;
+  color: SRC.$text-color-dark;
+  background: unset;
   /* Divider */
-  margin-top: -1px;
-  border: 1px solid #dcdcdc;
-  padding: 1.6rem 2.4rem;  
-  margin-bottom: 2rem;
+  padding: 1px 0px;
   display: flex;
+  align-items: baseline;
 
   &__selections {
     display: flex;
@@ -30,16 +30,15 @@
 }
 
 .SelectionCriteriaPill {
-  padding: 5px 10px;
+  padding: 3px 10px;
   display: inline-flex;
   justify-content: center;
   border-radius: 20px;
   margin-left: 1rem;
-  font-size: 1.2rem;
   line-height: 100%;
   cursor: pointer;
-  background-color: SRC.$primary-action-color !important;
-  color: #fff;
+  background-color: color.change(SRC.$primary-action-color, $alpha: 0.1);
+  color: SRC.$text-color-dark;
   font-weight: normal;
   margin: 10px;
   span {
@@ -47,9 +46,13 @@
   }
 
   &__btnRemove {
+    color: SRC.$primary-action-color;
     padding: 0;
     margin-left: 5px;
-    font-size: 1rem;
+    margin-top: 1px;
+    svg {
+      font-size: 1.25rem;
+    }
   }
 }
 

--- a/src/lib/style/components/facet_nav/_facet-nav.scss
+++ b/src/lib/style/components/facet_nav/_facet-nav.scss
@@ -12,9 +12,9 @@
     justify-content: space-between;
 
     > div {
-      margin: 5px;
-      flex-grow: 0;
-      flex-basis: 48%;
+      margin: 3px;
+      flex-grow: 1;
+      flex-basis: 49%;
     }
   }
 

--- a/src/lib/style/components/facet_nav/_facet-nav.scss
+++ b/src/lib/style/components/facet_nav/_facet-nav.scss
@@ -2,43 +2,32 @@
 
 .FacetNav {
   padding-top: 5px;
-  padding-bottom: 5px;
   border: 1px solid SRC.$gray-dark;
 
   &__row {
     background-color: #fff;
 
-    div[class*=' col-'] {
-      height: 200px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+
+    > div {
+      margin: 5px;
+      flex-grow: 0;
+      flex-basis: 48%;
     }
   }
 
   &__showMoreContainer {
+    background-color: SRC.$gray-light;
     display: flex;
-    justify-content: flex-end;
-    padding-right: 15px;
-    padding-bottom: 10px;
-    &__showMore {
-      margin-right: 15px;
-      margin-top: 15px;
-    }
-
-    .FacetNav__showMore:focus {
-      // somehow &__showMore:focus doesn't work
-      outline-color: SRC.$primary-action-color;
-    }
-  }
-}
-
-.container-full-width .FacetNav.less{
-  .FacetNav {
-    &__row {
-      display: flex;
-      flex-wrap: wrap;
-
-      > div {
-        flex: 0 0 380px;
-      }
+    justify-content: center;
+    padding: 10px;
+    margin-top: 10px;
+    button.FacetNav__showMore {
+      // padding: 5px 70px;
+      width: 250px;
+      text-transform: uppercase;
     }
   }
 }


### PR DESCRIPTION
Depends on #1002 

![image](https://user-images.githubusercontent.com/17580037/116735741-eff9bf80-a9bc-11eb-8c01-31e61169fa16.png)

After clicking View All:

![image](https://user-images.githubusercontent.com/17580037/116735715-ea9c7500-a9bc-11eb-8c83-4982375479bf.png)

Once the viewport narrows enough, flex-grow causes the graphs expand to fill the width
![image](https://user-images.githubusercontent.com/17580037/116736077-672f5380-a9bd-11eb-8476-bfd61715f50d.png)


Kind of weird side effect of flex grow, if there's an odd number of graphs:
![image](https://user-images.githubusercontent.com/17580037/116735849-16b7f600-a9bd-11eb-9eda-c0d7aafeca69.png)


