### PR TITLE
SWC-5587

### DIFF
--- a/src/lib/containers/entity_finder/details/view/DetailsViewRow.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsViewRow.tsx
@@ -191,14 +191,13 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
                   }}
                 >
                   <option value={-1}>Always Latest Version</option>
-                  {versions?.map((version, index) => {
+                  {versions?.map(version => {
                     return (
                       <option
                         key={version.versionNumber}
                         value={version.versionNumber}
                       >
                         Version {version.versionNumber}
-                        {index === 0 ? ' (Current)' : ''}
                       </option>
                     )
                   })}


### PR DESCRIPTION
Remove "Current" from the version label because it's wrong for tables.