### PR TITLE
PORTALS-1896

### DIFF
--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -66,7 +66,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
     facetsToFilter,
     hideDownload,
     searchConfiguration,
-    limit=DEFAULT_PAGE_SIZE,
+    limit = DEFAULT_PAGE_SIZE,
     ...rest
   } = props
   let sqlUsed = sql
@@ -110,7 +110,11 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
         />
         <QueryFilter {...rest} />
         <QueryFilterToggleButton />
-        <FacetNav facetsToPlot={facetsToPlot} showNotch={false} />
+        <FacetNav
+          facetsToPlot={facetsToPlot}
+          showNotch={false}
+          token={props.token}
+        />
         <FilterAndView
           facetsToFilter={facetsToFilter}
           tableConfiguration={tableConfiguration}

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -257,6 +257,7 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
                   }
                   facetAliases={facetAliases}
                   lastQueryRequest={lastQueryRequest}
+                  token={token}
                 ></FacetNavPanel>
               </div>
             ))}
@@ -302,7 +303,8 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
                     )
                   }
                   facetAliases={facetAliases}
-                ></FacetNavPanel>
+                  token={token}
+                />
               </div>
             ))}
           </div>


### PR DESCRIPTION
Missed a few more places where token wasn't passed along (I never manually verified the previous fix, assuming the token was already passed)

Some other things we could do (not sure if they've been considered)
* Set Context (in QueryWrapper, perhaps) so we don't have to worry about passing auth token down (wouldn't work if we wanted to reuse sub-components)
* Read the session token cookie when calling SynapseClient, potentially store it in memory or sessionStorage. We could expose a `setToken` method if we have cases where we're passing along a session token but it's not in the same cookie.