### PR TITLE
Store the session token in memory and refresh page on change

### DIFF
--- a/src/__tests__/lib/containers/CardContainerLogic.test.tsx
+++ b/src/__tests__/lib/containers/CardContainerLogic.test.tsx
@@ -128,23 +128,12 @@ describe('it performs basic functionality', () => {
     const { wrapper, instance } = await createShallowComponent(props)
 
     const newSql = 'SELECT * FROM OTHER_TABLE'
-    const newToken = '123'
     const spy = jest.spyOn(instance, 'executeInitialQueryRequest')
     // if sql changes in props then we expect the component to have called executeInitialQueryRequest
     // since there's an entirely new sql statement
-    await wrapper.setProps({
+    wrapper.setProps({
       sql: newSql,
-      token: '',
     })
-
-    spy.mockReset()
-    // if token changes in props then we expect the component to have called executeInitialQueryRequest
-    await wrapper.setProps({ sql: newSql, token: newToken })
     expect(spy).toHaveBeenCalled()
-
-    spy.mockReset()
-    // if token changes in props then we expect the component to have called executeInitialQueryRequest
-    await wrapper.setProps({ sql: newSql, token: newToken })
-    expect(spy).toHaveBeenCalledTimes(0)
   })
 })

--- a/src/__tests__/lib/containers/DownloadConfirmation.test.tsx
+++ b/src/__tests__/lib/containers/DownloadConfirmation.test.tsx
@@ -86,6 +86,8 @@ describe('it performs the expected functionality', () => {
     .fn()
     .mockResolvedValue(addFilesToDownloadListResponse)
 
+  SynapseClient.isSignedIn = jest.fn().mockReturnValue(true)
+
   TestDownloadSpeed.testDownloadSpeed = jest.fn().mockResolvedValue(55)
   getQueryTableResultsFn = SynapseClient.getQueryTableResults = jest
     .fn()
@@ -93,7 +95,6 @@ describe('it performs the expected functionality', () => {
 
   const props: DownloadConfirmationProps = {
     fnClose: mockClose,
-    token: '12345',
     getLastQueryRequest: () => queryBundleRequest,
   }
 
@@ -122,7 +123,6 @@ describe('it performs the expected functionality', () => {
     await resolveAllPending(wrapper)
     expect(getQueryTableResultsFn).toHaveBeenCalledWith(
       mockGetQueryTableRequest,
-      props.token,
     )
     expect(getQueryTableResultsFn).toHaveBeenCalledTimes(1)
     expect(wrapper.find('button')).toHaveLength(2)
@@ -137,7 +137,6 @@ describe('it performs the expected functionality', () => {
     wrapper.find('button.btn-primary').simulate('click')
     expect(addFilesToDownloadRequestFn).toHaveBeenCalledWith(
       addFilesToDownloadListRequest,
-      props.token,
     )
     expect(wrapper.text()).toBe('Adding Files To List')
     expect(wrapper.find('button')).toHaveLength(0)

--- a/src/__tests__/lib/containers/HasAccess.test.tsx
+++ b/src/__tests__/lib/containers/HasAccess.test.tsx
@@ -28,7 +28,6 @@ import { mockFolderEntity } from '../../../mocks/mock_folder_entity'
 import { mockFileEntity } from '../../../mocks/mock_file_entity'
 
 const SynapseClient = require('../../../lib/utils/SynapseClient')
-const token: string = '123444'
 const entityId = 'syn9988882982'
 const isInDownloadList: boolean = true
 const externalFileHandle: FileHandle = {
@@ -68,7 +67,6 @@ const createShallowComponent = async (
   return { wrapper, instance }
 }
 const props: HasAccessProps = {
-  token,
   entityId,
   isInDownloadList,
 }
@@ -80,9 +78,7 @@ describe('basic tests', () => {
 
   it('works with open data no restrictions', async () => {
     SynapseClient.getEntity = jest.fn(() => Promise.resolve(mockFileEntity))
-    SynapseClient.getFileResult = jest.fn(() =>
-      Promise.resolve(mockFileHandle),
-    )
+    SynapseClient.getFileResult = jest.fn(() => Promise.resolve(mockFileHandle))
 
     SynapseClient.getRestrictionInformation = jest.fn(() =>
       Promise.resolve(mockOpenRestrictionInformation),
@@ -96,7 +92,6 @@ describe('basic tests', () => {
     expect(SynapseClient.getRestrictionInformation).toHaveBeenCalledTimes(1)
     expect(SynapseClient.getRestrictionInformation).toHaveBeenCalledWith(
       request,
-      token,
     )
     expect(instance.state.restrictionInformation).toEqual(
       mockOpenRestrictionInformation,
@@ -105,7 +100,7 @@ describe('basic tests', () => {
     expect(SynapseClient.getFileResult).toHaveBeenCalledTimes(1)
     // verify UI
     instance.setState({
-      fileHandleDownloadType: FileHandleDownloadTypeEnum.Accessible
+      fileHandleDownloadType: FileHandleDownloadTypeEnum.Accessible,
     })
 
     const icons = wrapper.find(FontAwesomeIcon)
@@ -167,7 +162,8 @@ describe('basic tests', () => {
       etag: '',
       createdBy: '',
       createdOn: '',
-      concreteType: CloudProviderFileHandleConcreteTypeEnum.GoogleCloudFileHandle,
+      concreteType:
+        CloudProviderFileHandleConcreteTypeEnum.GoogleCloudFileHandle,
       contentType: '',
       contentMd5: '',
       fileName: '',
@@ -250,6 +246,7 @@ describe('basic tests', () => {
   })
 
   it('works with unmet controlled access data AND an UNAUTHORIZED ACL', async () => {
+    SynapseClient.isSignedIn = jest.fn().mockReturnValue(true)
     SynapseClient.getEntity = jest.fn(() => Promise.reject('UNAUTHORIZED'))
     SynapseClient.getRestrictionInformation = jest.fn(() =>
       Promise.resolve(mockUnmetControlledDataRestrictionInformationACT),
@@ -262,7 +259,6 @@ describe('basic tests', () => {
     }
     expect(SynapseClient.getRestrictionInformation).toHaveBeenCalledWith(
       request,
-      token,
     )
     expect(wrapper.instance().state.restrictionInformation).toEqual(
       mockUnmetControlledDataRestrictionInformationACT,
@@ -293,7 +289,6 @@ describe('basic tests', () => {
     }
     expect(SynapseClient.getRestrictionInformation).toHaveBeenCalledWith(
       request,
-      token,
     )
     expect(wrapper.instance().state.restrictionInformation).toEqual(
       mockOpenRestrictionInformation,

--- a/src/__tests__/lib/containers/ModalDownload.test.tsx
+++ b/src/__tests__/lib/containers/ModalDownload.test.tsx
@@ -24,6 +24,7 @@ describe('it performs the expected functionality', () => {
       resultFileHandleId: 'hello',
     }),
   )
+  SynapseClient.isSignedIn = jest.fn().mockReturnValue(true)
   SynapseClient.getDownloadFromTableRequest = mockGetDownloadFromTableRequest
   SynapseClient.getFileHandleByIdURL = jest.fn(() => 'testurl')
   const props: ModalDownloadProps = {
@@ -62,7 +63,6 @@ describe('it performs the expected functionality', () => {
         writeHeader: true,
         includeRowIdAndRowVersion: true,
       }),
-      undefined,
     )
   })
 
@@ -87,7 +87,6 @@ describe('it performs the expected functionality', () => {
         writeHeader: false,
         includeRowIdAndRowVersion: true,
       }),
-      undefined,
     )
   })
 
@@ -111,7 +110,6 @@ describe('it performs the expected functionality', () => {
         writeHeader: true,
         includeRowIdAndRowVersion: true,
       }),
-      undefined,
     )
   })
 
@@ -135,7 +133,6 @@ describe('it performs the expected functionality', () => {
         writeHeader: false,
         includeRowIdAndRowVersion: true,
       }),
-      undefined,
     )
   })
 })

--- a/src/__tests__/lib/containers/QueryWrapper.test.tsx
+++ b/src/__tests__/lib/containers/QueryWrapper.test.tsx
@@ -78,15 +78,6 @@ describe('basic functionality', () => {
   it('componentDidUpdate works', async () => {
     const { instance, wrapper } = await createShallowComponent(lastQueryRequest)
 
-    const newToken = '123'
-    const spyOnExecuteQueryRequest = jest.spyOn(instance, 'executeQueryRequest')
-
-    // test login
-    wrapper.setProps({
-      token: newToken,
-    })
-    expect(spyOnExecuteQueryRequest).toHaveBeenCalled()
-
     const spyOnExecuteInitQueryRequest = jest.spyOn(
       instance,
       'executeInitialQueryRequest',
@@ -180,40 +171,39 @@ describe('deep linking', () => {
 })
 
 describe('locked facet', () => {
-
   const newProps = {
     lockedFacet: {
       facet: 'abc',
-      value: '123'
-    }
+      value: '123',
+    },
   }
   const newProps2 = {
-    lockedFacet: {}
+    lockedFacet: {},
   }
   const newState = {
     data: {
       facets: [
-        {columnName: 'abc', facetType: "enumeration", concreteType: "blah"},
-        {columnName: 'def', facetType: "enumeration", concreteType: "blah"}
-      ]
-    }
+        { columnName: 'abc', facetType: 'enumeration', concreteType: 'blah' },
+        { columnName: 'def', facetType: 'enumeration', concreteType: 'blah' },
+      ],
+    },
   }
 
-  it('removeLockedFacetData should remove locked facet data', async() => {
+  it('removeLockedFacetData should remove locked facet data', async () => {
     const { instance, wrapper } = await createShallowComponent(lastQueryRequest)
     wrapper.setProps(newProps)
     wrapper.setState(newState)
     expect(instance.removeLockedFacetData()).toEqual({
-        facets: [{columnName: 'def', facetType: "enumeration", concreteType: "blah"}]
-      }
-    )
+      facets: [
+        { columnName: 'def', facetType: 'enumeration', concreteType: 'blah' },
+      ],
+    })
   })
 
-  it('removeLockedFacetData should not remove any data if locked facet value is not set', async() => {
+  it('removeLockedFacetData should not remove any data if locked facet value is not set', async () => {
     const { instance, wrapper } = await createShallowComponent(lastQueryRequest)
     wrapper.setProps(newProps2)
     wrapper.setState(newState)
     expect(instance.removeLockedFacetData()?.facets).toHaveLength(2)
   })
-
 })

--- a/src/__tests__/lib/containers/SynapseTable.test.tsx
+++ b/src/__tests__/lib/containers/SynapseTable.test.tsx
@@ -98,7 +98,7 @@ describe('basic functionality', () => {
     chartSelectionIndex: 0,
     isAllFilterSelectedForFacet: {},
     data: castData,
-    topLevelControlsState : {
+    topLevelControlsState: {
       showColumnFilter: true,
       showFacetFilter: true,
       showFacetVisualization: true,
@@ -144,14 +144,14 @@ describe('basic functionality', () => {
     dataWithNewTableId.queryResult.queryResults.tableId = 'syn123'
     // listen to function call
 
-    await wrapper.setProps({
+    wrapper.setProps({
       data: dataWithNewTableId,
     })
     // since we now disable lifecycle methods during construction (because of DOM interaction for column-resizer), manually call update functions
     instance.getEntityHeadersInData(true)
     instance.getTableConcreteType(props)
 
-    expect(mockEntityCall).toHaveBeenCalledWith(undefined, newTableId)
+    expect(mockEntityCall).toHaveBeenCalledWith(newTableId)
   })
 
   describe('unCamelCase', () => {
@@ -545,7 +545,6 @@ describe('basic functionality', () => {
         EntityColumnType.FILEHANDLEID,
       )
       expect(fileHandleId).toEqual([FILEHANDLEID_INDEX])
-
     })
 
     it('gets unique entities', () => {
@@ -595,9 +594,9 @@ describe('basic functionality', () => {
       const mapEntityIdToHeader = {
         [mockEntityLinkValue]: {} as EntityHeader,
       }
-      const mapUserIdToHeader: Dictionary<Partial<
-        UserGroupHeader & UserProfile
-      >> = {
+      const mapUserIdToHeader: Dictionary<
+        Partial<UserGroupHeader & UserProfile>
+      > = {
         [mockAllAuthenticatedUsersValue]: {
           isIndividual: false,
           userName: AUTHENTICATED_USERS,
@@ -797,7 +796,9 @@ describe('basic functionality', () => {
             })}
           </div>,
         )
-        expect(tableCell.find('p').first().text().trim()).toEqual(NOT_SET_DISPLAY_VALUE)
+        expect(tableCell.find('p').first().text().trim()).toEqual(
+          NOT_SET_DISPLAY_VALUE,
+        )
       })
     })
   })

--- a/src/__tests__/lib/containers/TotalQueryResults.test.tsx
+++ b/src/__tests__/lib/containers/TotalQueryResults.test.tsx
@@ -102,7 +102,6 @@ describe('it works', () => {
   const props: TotalQueryResultsProps = {
     unitDescription,
     isLoading: false,
-    token: '',
     lastQueryRequest,
     frontText: 'Displaying',
   }
@@ -127,7 +126,6 @@ describe('it works', () => {
             SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
             SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS,
         }),
-        '',
       )
     })
   })

--- a/src/__tests__/lib/containers/download_list/DownloadDetails.test.tsx
+++ b/src/__tests__/lib/containers/download_list/DownloadDetails.test.tsx
@@ -18,11 +18,12 @@ describe('it performs all functionality ', () => {
   })
 
   const fn = require('../../../../lib/utils/functions/testDownloadSpeed')
+  const SynapseClient = require('../../../../lib/utils/SynapseClient')
   fn.testDownloadSpeed = jest.fn().mockResolvedValue(20)
+  SynapseClient.isSignedIn = jest.fn().mockReturnValue(true)
   const props: DownloadDetailsProps = {
     numFiles: 3,
     numBytes: 10,
-    token: 'token',
   }
   it('renders without crashing', async () => {
     await act(async () => {

--- a/src/__tests__/lib/containers/download_list/DownloadListTable.test.tsx
+++ b/src/__tests__/lib/containers/download_list/DownloadListTable.test.tsx
@@ -54,13 +54,14 @@ describe('it performs all functionality ', () => {
   }
   const mockGetDownloadListFn = jest.fn().mockResolvedValue(downloadListMock)
   SynapseClient.getDownloadList = mockGetDownloadListFn
+  SynapseClient.isSignedIn = jest.fn().mockReturnValue(true)
   const entityHeaderMock: PaginatedResults<EntityHeader> = {
     totalNumberOfResults: 3,
     results: [
       {
         name: fileOneName,
         id: entityOneId,
-        type: '',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
         versionNumber: 0,
         versionLabel: '',
         benefactorId: 0,
@@ -72,7 +73,7 @@ describe('it performs all functionality ', () => {
       {
         name: fileTwoName,
         id: entityTwoId,
-        type: '',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
         versionNumber: 0,
         versionLabel: '',
         benefactorId: 0,
@@ -103,10 +104,7 @@ describe('it performs all functionality ', () => {
   const mockClearDownloadListFn = jest.fn().mockResolvedValue('')
   SynapseClient.deleteDownloadList = mockClearDownloadListFn
 
-  const tokenMock = 'token'
-  const props: DownloadListTableProps = {
-    token: tokenMock,
-  }
+  const props: DownloadListTableProps = {}
   it('renders without crashing', async () => {
     await act(async () => {
       ReactDOM.render(<DownloadListTable {...props} />, container)
@@ -150,7 +148,6 @@ describe('it performs all functionality ', () => {
           fileHandleId: fileOneId,
         }),
       ]),
-      tokenMock,
     )
     expect(mockGetDownloadListFn).not.toHaveBeenCalled()
     expect(mockGetEntityHeadersFn).not.toHaveBeenCalled()

--- a/src/__tests__/lib/containers/entity_finder/EntityFinder.test.tsx
+++ b/src/__tests__/lib/containers/entity_finder/EntityFinder.test.tsx
@@ -62,7 +62,6 @@ DetailsList.EntityDetailsList = jest
     return <div role="table"></div>
   })
 
-const mockTreeView = TreeView.TreeView
 const mockDetailsList = DetailsList.EntityDetailsList
 
 jest.mock('../../../../lib/utils/SynapseClient', () => {
@@ -78,7 +77,6 @@ const mockUseGetEntityBundle = useGetEntityBundle as jest.Mock
 const mockOnSelectionChange = jest.fn()
 
 const defaultProps: EntityFinderProps = {
-  sessionToken: 'abcd',
   initialScope: FinderScope.CURRENT_PROJECT,
   projectId: 'syn456',
   initialContainer: 'syn123',
@@ -315,7 +313,6 @@ describe('EntityFinder tests', () => {
       expect(mockDetailsList).toHaveBeenLastCalledWith(
         expect.objectContaining({
           configuration: configuration, // !
-          sessionToken: defaultProps.sessionToken,
           selectableTypes: defaultProps.selectableTypes,
           visibleTypes: [
             ...defaultProps.visibleTypesInList!,
@@ -430,14 +427,11 @@ describe('EntityFinder tests', () => {
     }
 
     when(mockGetEntityHeaders)
-      .calledWith([{ targetId: entityId }], defaultProps.sessionToken)
+      .calledWith([{ targetId: entityId }])
       .mockResolvedValue(entityHeaderResult)
 
     when(mockGetEntityHeaders)
-      .calledWith(
-        [{ targetId: entityId, targetVersionNumber: version }],
-        defaultProps.sessionToken,
-      )
+      .calledWith([{ targetId: entityId, targetVersionNumber: version }])
       .mockResolvedValue(entityHeaderResultWithVersion)
 
     userEvent.click(screen.getByText('Search all of Synapse'))

--- a/src/__tests__/lib/containers/entity_finder/details/DetailsViewRow.test.tsx
+++ b/src/__tests__/lib/containers/entity_finder/details/DetailsViewRow.test.tsx
@@ -29,7 +29,6 @@ const mockToggleSelection = jest.fn()
 const mockUseGetEntityBundle = useGetEntityBundle as jest.Mock
 
 const defaultProps: DetailsViewRowProps = {
-  sessionToken: 'abcd',
   entityHeader: {
     id: 'syn123',
     name: 'My File',
@@ -145,7 +144,6 @@ describe('DetailsViewRow tests', () => {
     renderComponent()
 
     expect(mockUseGetEntityBundle).toBeCalledWith(
-      defaultProps.sessionToken,
       defaultProps.entityHeader.id,
       expect.anything(),
       undefined,
@@ -158,7 +156,6 @@ describe('DetailsViewRow tests', () => {
     mockAllIsIntersecting(true)
 
     expect(mockUseGetEntityBundle).toBeCalledWith(
-      defaultProps.sessionToken,
       defaultProps.entityHeader.id,
       expect.anything(),
       undefined,
@@ -223,7 +220,6 @@ describe('DetailsViewRow tests', () => {
       expect(await screen.findByRole('listbox')).toBeDefined()
 
       expect(SynapseClient.getEntityVersions).toBeCalledWith(
-        defaultProps.sessionToken,
         defaultProps.entityHeader.id,
       )
     })

--- a/src/__tests__/lib/containers/entity_finder/tree/TreeNode.test.tsx
+++ b/src/__tests__/lib/containers/entity_finder/tree/TreeNode.test.tsx
@@ -31,7 +31,6 @@ const mockUseGetEntityBundle = useGetEntityBundle as jest.Mock
 const mockUseGetEntityChildren = useGetEntityChildrenInfinite as jest.Mock
 
 const defaultProps: TreeNodeProps = {
-  sessionToken: 'abcd',
   entityHeader: {
     id: 'syn123',
     name: 'My File',
@@ -114,7 +113,7 @@ function renderComponent(propOverrides?: Partial<TreeNodeProps>) {
 
 const mockFetchNextPageOfChildren = jest.fn()
 
-describe('TreeViewNode tests', () => {
+describe('TreeNode tests', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockAllIsIntersecting(false)
@@ -123,7 +122,6 @@ describe('TreeViewNode tests', () => {
     }))
     when(mockUseGetEntityChildren)
       .calledWith(
-        expect.anything(),
         expect.objectContaining({
           parentId: expect.stringContaining(defaultProps.entityHeader!.id),
         }),
@@ -148,7 +146,6 @@ describe('TreeViewNode tests', () => {
         isSuccess: true,
       })
       .calledWith(
-        expect.anything(),
         expect.objectContaining({
           parentId: expect.not.stringContaining(defaultProps.entityHeader!.id),
         }),
@@ -172,7 +169,6 @@ describe('TreeViewNode tests', () => {
     renderComponent()
     await waitFor(() =>
       expect(mockUseGetEntityChildren).toBeCalledWith(
-        expect.anything(),
         expect.objectContaining({
           parentId: expect.stringContaining(defaultProps.entityHeader!.id),
         }),
@@ -195,7 +191,6 @@ describe('TreeViewNode tests', () => {
     renderComponent({ autoExpand: () => true })
     await waitFor(() =>
       expect(mockUseGetEntityChildren).toBeCalledWith(
-        expect.anything(),
         expect.objectContaining({
           parentId: expect.stringContaining(defaultProps.entityHeader!.id),
         }),
@@ -210,7 +205,6 @@ describe('TreeViewNode tests', () => {
     // Not in view
     mockAllIsIntersecting(false)
     expect(useGetEntityBundle).toBeCalledWith(
-      defaultProps.sessionToken,
       defaultProps.entityHeader!.id,
       expect.anything(),
       undefined,
@@ -222,7 +216,6 @@ describe('TreeViewNode tests', () => {
     // Comes into view, call under test:
     mockAllIsIntersecting(true)
     expect(useGetEntityBundle).toBeCalledWith(
-      defaultProps.sessionToken,
       defaultProps.entityHeader!.id,
       expect.anything(),
       undefined,
@@ -251,7 +244,6 @@ describe('TreeViewNode tests', () => {
     })
     await waitFor(() =>
       expect(mockUseGetEntityChildren).toBeCalledWith(
-        expect.anything(),
         expect.objectContaining({
           parentId: expect.stringContaining(defaultProps.entityHeader!.id),
         }),
@@ -281,7 +273,6 @@ describe('TreeViewNode tests', () => {
       screen.getByLabelText(`Select ${entityName}`)
     await waitFor(() =>
       expect(mockUseGetEntityChildren).toBeCalledWith(
-        expect.anything(),
         expect.objectContaining({
           parentId: expect.stringContaining(defaultProps.entityHeader!.id),
         }),
@@ -332,14 +323,12 @@ describe('TreeViewNode tests', () => {
         },
       })
       expect(mockUseGetEntityChildren).toBeCalledWith(
-        defaultProps.sessionToken,
         expect.anything(),
         expect.objectContaining({
           enabled: false, // !
         }),
       )
       expect(mockUseGetEntityBundle).toBeCalledWith(
-        defaultProps.sessionToken,
         expect.anything(),
         expect.anything(),
         undefined,

--- a/src/__tests__/lib/containers/entity_finder/tree/TreeView.test.tsx
+++ b/src/__tests__/lib/containers/entity_finder/tree/TreeView.test.tsx
@@ -67,7 +67,6 @@ const mockSetBreadcrumbItems = jest.fn()
 const mockToggleSelection = jest.fn()
 
 const defaultProps: TreeViewProps = {
-  sessionToken: 'abcd',
   selectedEntities: [],
   initialScope: FinderScope.CURRENT_PROJECT,
   projectId: 'syn5',
@@ -370,7 +369,6 @@ describe('TreeView tests', () => {
 
     expect(mockTreeNode).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        sessionToken: defaultProps.sessionToken,
         level: 0,
         rootNodeConfiguration: {
           nodeText: 'Projects',
@@ -399,7 +397,6 @@ describe('TreeView tests', () => {
 
     expect(mockTreeNode).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        sessionToken: defaultProps.sessionToken,
         level: 0,
         rootNodeConfiguration: {
           nodeText: 'Projects',

--- a/src/__tests__/lib/containers/evaluation_queues/EvaluationEditor.test.tsx
+++ b/src/__tests__/lib/containers/evaluation_queues/EvaluationEditor.test.tsx
@@ -12,7 +12,6 @@ import { ErrorBanner } from '../../../../lib/containers/ErrorBanner'
 import WarningModal from '../../../../lib/containers/synapse_form_wrapper/WarningModal'
 
 describe('test EvaluationEditor', () => {
-  const sessionToken = 'sssssssssssssssssssssss'
   const evaluationId = '1234'
   const entityId = 'syn1111111'
   let evaluation: Evaluation
@@ -43,7 +42,6 @@ describe('test EvaluationEditor', () => {
     mockOnSaveSuccess = jest.fn()
 
     props = {
-      sessionToken: sessionToken,
       evaluationId: evaluationId,
       utc: true,
       onDeleteSuccess: mockOnDeleteSuccess,
@@ -87,7 +85,7 @@ describe('test EvaluationEditor', () => {
     const wrapper = mount(<EvaluationEditor {...props} />)
 
     expect(wrapper.find('h4').text()).toBe('Edit Evaluation Queue')
-    expect(mockGetEvaluation).toBeCalledWith(evaluationId, sessionToken)
+    expect(mockGetEvaluation).toBeCalledWith(evaluationId)
     expect(wrapper.find(ErrorBanner).exists()).toBe(false)
   })
 
@@ -110,7 +108,7 @@ describe('test EvaluationEditor', () => {
 
     const wrapper = mount(<EvaluationEditor {...props} />)
 
-    expect(mockGetEvaluation).toBeCalledWith(evaluationId, sessionToken)
+    expect(mockGetEvaluation).toBeCalledWith(evaluationId)
     expect(wrapper.find(ErrorBanner).exists()).toBe(true)
   })
 
@@ -135,22 +133,19 @@ describe('test EvaluationEditor', () => {
 
     wrapper.find('Button.save-button').simulate('click')
 
-    expect(mockCreateEvaluation).toBeCalledWith(
-      {
-        contentSource: 'syn1111111',
-        description: '',
-        name: 'E V A L U A T I O N',
-        submissionInstructionsMessage: '',
-        submissionReceiptMessage: '',
-      },
-      sessionToken,
-    )
+    expect(mockCreateEvaluation).toBeCalledWith({
+      contentSource: 'syn1111111',
+      description: '',
+      name: 'E V A L U A T I O N',
+      submissionInstructionsMessage: '',
+      submissionReceiptMessage: '',
+    })
     expect(mockUpdateEvaluation).not.toBeCalled()
     expect(mockOnSaveSuccess).toBeCalledWith(evaluationId)
 
     //clicking save button again after the first time should call update instead
     wrapper.find('Button.save-button').simulate('click')
-    expect(mockUpdateEvaluation).toBeCalledWith(evaluation, sessionToken)
+    expect(mockUpdateEvaluation).toBeCalledWith(evaluation)
     expect(mockOnSaveSuccess).toBeCalledWith(evaluationId)
     expect(wrapper.find(ErrorBanner).exists()).toBe(false)
     expect(wrapper.find('Alert.save-success-alert').exists()).toBe(true)
@@ -161,7 +156,7 @@ describe('test EvaluationEditor', () => {
 
     //clicking save button again after the first time should call update instead
     wrapper.find('Button.save-button').simulate('click')
-    expect(mockUpdateEvaluation).toBeCalledWith(evaluation, sessionToken)
+    expect(mockUpdateEvaluation).toBeCalledWith(evaluation)
     expect(mockCreateEvaluation).not.toBeCalled()
     expect(mockOnSaveSuccess).toBeCalledWith(evaluationId)
     expect(wrapper.find(ErrorBanner).exists()).toBe(false)
@@ -180,7 +175,7 @@ describe('test EvaluationEditor', () => {
 
     //clicking save button again after the first time should call update instead
     wrapper.find('Button.save-button').simulate('click')
-    expect(mockUpdateEvaluation).toBeCalledWith(evaluation, sessionToken)
+    expect(mockUpdateEvaluation).toBeCalledWith(evaluation)
     expect(mockCreateEvaluation).not.toBeCalled()
     expect(mockOnSaveSuccess).not.toBeCalled()
     expect(wrapper.find(ErrorBanner).exists()).toBe(true)

--- a/src/__tests__/lib/containers/evaluation_queues/EvaluationRoundEditor.test.tsx
+++ b/src/__tests__/lib/containers/evaluation_queues/EvaluationRoundEditor.test.tsx
@@ -35,8 +35,6 @@ describe('test EvaluationRoundEditor', () => {
     roundEnd: '1231232',
   }
 
-  const fakeSessionToken = 'fakeToken'
-
   beforeEach(() => {
     mockOnDelete = jest.fn()
     mockOnSave = jest.fn()
@@ -63,7 +61,6 @@ describe('test EvaluationRoundEditor', () => {
       .mockImplementation(mockDeleteEvaluationRound)
 
     props = {
-      sessionToken: fakeSessionToken,
       evaluationRoundInput: {
         reactListKey: 'SOME FAKE KEY',
         evaluationId: '123',
@@ -176,7 +173,6 @@ describe('test EvaluationRoundEditor', () => {
 
     expect(mockCreateEvaluationRound).toBeCalledWith(
       expectedConvertedEvaulationRound,
-      fakeSessionToken,
     )
     expect(mockUpdateEvaluationRound).not.toBeCalled()
 
@@ -209,7 +205,6 @@ describe('test EvaluationRoundEditor', () => {
 
     expect(mockUpdateEvaluationRound).toBeCalledWith(
       expectedConvertedEvaulationRound,
-      fakeSessionToken,
     )
     expect(mockCreateEvaluationRound).not.toBeCalled()
 
@@ -250,7 +245,6 @@ describe('test EvaluationRoundEditor', () => {
 
     expect(mockUpdateEvaluationRound).toBeCalledWith(
       expectedConvertedEvaulationRound,
-      fakeSessionToken,
     )
     expect(mockCreateEvaluationRound).not.toBeCalled()
 
@@ -307,7 +301,6 @@ describe('test EvaluationRoundEditor', () => {
     expect(mockDeleteEvaluationRound).toBeCalledWith(
       props.evaluationRoundInput.evaluationId,
       id,
-      fakeSessionToken,
     )
   })
 
@@ -332,7 +325,6 @@ describe('test EvaluationRoundEditor', () => {
     expect(mockDeleteEvaluationRound).toBeCalledWith(
       props.evaluationRoundInput.evaluationId,
       id,
-      fakeSessionToken,
     )
 
     //error occurred so we never used the passed in callback from props

--- a/src/__tests__/lib/containers/evaluation_queues/EvaluationRoundEditorList.test.tsx
+++ b/src/__tests__/lib/containers/evaluation_queues/EvaluationRoundEditorList.test.tsx
@@ -7,7 +7,6 @@ import React from 'react'
 import { ErrorBanner } from '../../../../lib/containers/ErrorBanner'
 
 describe('test EvaluationRoundEditorList', () => {
-  const fakeSessionToken = 'asdfasdfasdf'
   const evaluationId = '123123123'
   const nextPageToken = 'firstPage'
 
@@ -86,11 +85,7 @@ describe('test EvaluationRoundEditorList', () => {
     )
 
     const wrapper = mount(
-      <EvaluationRoundEditorList
-        sessionToken={fakeSessionToken}
-        evaluationId={evaluationId}
-        utc={true}
-      />,
+      <EvaluationRoundEditorList evaluationId={evaluationId} utc={true} />,
     )
 
     expect(wrapper.find('.evaluation-round-editor').exists()).toBe(false)
@@ -99,23 +94,15 @@ describe('test EvaluationRoundEditorList', () => {
 
   it('fetched pages', () => {
     const wrapper = mount(
-      <EvaluationRoundEditorList
-        sessionToken={fakeSessionToken}
-        evaluationId={evaluationId}
-        utc={true}
-      />,
+      <EvaluationRoundEditorList evaluationId={evaluationId} utc={true} />,
     )
 
-    expect(mockGetEvaulationsList).toBeCalledWith(
-      evaluationId,
-      { nextPageToken: undefined },
-      fakeSessionToken,
-    )
-    expect(mockGetEvaulationsList).toBeCalledWith(
-      evaluationId,
-      { nextPageToken: nextPageToken },
-      fakeSessionToken,
-    )
+    expect(mockGetEvaulationsList).toBeCalledWith(evaluationId, {
+      nextPageToken: undefined,
+    })
+    expect(mockGetEvaulationsList).toBeCalledWith(evaluationId, {
+      nextPageToken: nextPageToken,
+    })
 
     expect(wrapper.find('.evaluation-round-editor')).toHaveLength(3)
     expect(wrapper.find(ErrorBanner).exists()).toBe(false)
@@ -123,11 +110,7 @@ describe('test EvaluationRoundEditorList', () => {
 
   it('add round button', () => {
     const wrapper = mount(
-      <EvaluationRoundEditorList
-        sessionToken={fakeSessionToken}
-        evaluationId={evaluationId}
-        utc={true}
-      />,
+      <EvaluationRoundEditorList evaluationId={evaluationId} utc={true} />,
     )
 
     expect(wrapper.find('.evaluation-round-editor')).toHaveLength(3)

--- a/src/__tests__/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid.test.tsx
+++ b/src/__tests__/lib/containers/synapse_form_wrapper/SynapseFormSubmissionsGrid.test.tsx
@@ -10,7 +10,6 @@ import {
 } from '../../../../mocks/mock_drug_tool_data'
 const SynapseClient = require('../../../../lib/utils/SynapseClient')
 
-const token: string = '123444'
 const pathpart = 'someTool'
 const formGroupId = '5'
 const itemNoun = 'submission'
@@ -30,7 +29,6 @@ const createShallowComponent = async (
 
 describe('basic tests', () => {
   const props: SynapseFormSubmissionGridProps = {
-    token,
     pathpart,
     formGroupId,
     itemNoun,
@@ -42,6 +40,8 @@ describe('basic tests', () => {
       .mockResolvedValue(formListDataSubmitted)
       .mockResolvedValueOnce(formListDataSubmitted)
       .mockResolvedValueOnce(formListDataInProgress)
+
+    SynapseClient.isSignedIn = jest.fn().mockReturnValue(true)
   })
 
   it('displays table with file list when files are present', async () => {
@@ -58,13 +58,11 @@ describe('basic tests', () => {
     expect(spy).toHaveBeenCalledTimes(1)
     expect(synapseCall).toHaveBeenCalledWith(
       expect.objectContaining({ filterByState: ['WAITING_FOR_SUBMISSION'] }),
-      expect.anything(),
     )
     expect(synapseCall).toHaveBeenCalledWith(
       expect.objectContaining({
         filterByState: ['SUBMITTED_WAITING_FOR_REVIEW', 'ACCEPTED', 'REJECTED'],
       }),
-      expect.anything(),
     )
   })
 
@@ -92,8 +90,8 @@ describe('basic tests', () => {
     const spy = jest.spyOn(SynapseClient, 'deleteFormData')
     const { instance } = await createShallowComponent(props)
     await instance.componentDidMount()
-    await instance.deleteFile('123', '456')
-    expect(spy).toHaveBeenCalledWith('456', '123')
+    await instance.deleteFile('456')
+    expect(spy).toHaveBeenCalledWith('456')
   })
 
   it('should have view more link if there is a token for next page and call the back end fn to get the additional items', async () => {
@@ -103,13 +101,10 @@ describe('basic tests', () => {
     const viewMoreButton = wrapper.find('.view-more button')
     expect(viewMoreButton).toHaveLength(1)
     viewMoreButton.simulate('click')
-    expect(spy).lastCalledWith(
-      {
-        filterByState: ['WAITING_FOR_SUBMISSION'],
-        groupId: formGroupId,
-        nextPageToken: formListDataInProgress.nextPageToken,
-      },
-      token,
-    )
+    expect(spy).lastCalledWith({
+      filterByState: ['WAITING_FOR_SUBMISSION'],
+      groupId: formGroupId,
+      nextPageToken: formListDataInProgress.nextPageToken,
+    })
   })
 })

--- a/src/__tests__/lib/containers/synapse_form_wrapper/SynapseFormWrapper.test.tsx
+++ b/src/__tests__/lib/containers/synapse_form_wrapper/SynapseFormWrapper.test.tsx
@@ -16,7 +16,6 @@ import {
 import _ from 'lodash-es'
 
 const SynapseClient = require('../../../../lib/utils/SynapseClient')
-const token: string = '123444'
 const formSchemaEntityId = 'syn9988882982'
 const formUiSchemaEntityId = 'syn9988882983'
 const formNavSchemaEntityId = 'syn9988882984'
@@ -34,15 +33,17 @@ const createShallowComponent = async (
   props: SynapseFormWrapperProps,
   disableLifecycleMethods: boolean = false,
 ) => {
-  const wrapper = await shallow<SynapseFormWrapper>(<SynapseFormWrapper {...props} />, {
-    disableLifecycleMethods,
-  })
+  const wrapper = await shallow<SynapseFormWrapper>(
+    <SynapseFormWrapper {...props} />,
+    {
+      disableLifecycleMethods,
+    },
+  )
 
   const instance = wrapper.instance()
   return { wrapper, instance }
 }
 const props: SynapseFormWrapperProps = {
-  token,
   formSchemaEntityId,
   formUiSchemaEntityId,
   formNavSchemaEntityId,
@@ -54,9 +55,8 @@ const props: SynapseFormWrapperProps = {
 
 describe('basic tests', () => {
   beforeEach(() => {
-    SynapseClient.getFileResult = jest.fn(() =>
-      Promise.resolve(mockFileHandle),
-    )
+    SynapseClient.isSignedIn = jest.fn().mockReturnValue(true)
+    SynapseClient.getFileResult = jest.fn(() => Promise.resolve(mockFileHandle))
     SynapseClient.getFileHandleContent = jest.fn(() =>
       Promise.resolve(JSON.stringify(formschemaJson)),
     )
@@ -71,21 +71,32 @@ describe('basic tests', () => {
   it('gets configuration data calls should be called with correct params', async () => {
     const { instance } = await createShallowComponent(props)
     await instance.componentDidMount()
-    expect(SynapseClient.getEntity).toHaveBeenNthCalledWith(1, token, 'syn9988882982', undefined)
-    expect(SynapseClient.getEntity).toHaveBeenNthCalledWith(2, token, 'syn9988882983', undefined)
-    expect(SynapseClient.getEntity).toHaveBeenNthCalledWith(3, token, 'syn9988882984', undefined)
+    expect(SynapseClient.getEntity).toHaveBeenNthCalledWith(
+      1,
+      'syn9988882982',
+      undefined,
+    )
+    expect(SynapseClient.getEntity).toHaveBeenNthCalledWith(
+      2,
+      'syn9988882983',
+      undefined,
+    )
+    expect(SynapseClient.getEntity).toHaveBeenNthCalledWith(
+      3,
+      'syn9988882984',
+      undefined,
+    )
     expect(SynapseClient.getFileResult).toHaveBeenCalledWith(
       mockFileEntity,
-      token,
       true,
-      true
+      true,
     )
   })
 
-  it('gets configuration data', async() => {
+  it('gets configuration data', async () => {
     const { instance } = await createShallowComponent(props)
     await instance.componentDidMount()
-    const result = await instance.getFileEntityData(token, '123444')
+    const result = await instance.getFileEntityData('123444')
     expect(result).toEqual({ content: formschemaJson, version: undefined })
   })
 
@@ -139,12 +150,10 @@ describe('basic tests', () => {
       expect(instance.state.formData).toEqual(mockFormData)
       expect(getFileHandleContentFromID).toHaveBeenCalled()
       expect(getFileEntityData).not.toHaveBeenCalledWith(
-        token,
         formSchemaEntityId,
         mockFormData.metadata.formSchemaVersion,
       )
       expect(getFileEntityData).toHaveBeenCalledWith(
-        token,
         formSchemaEntityId,
         undefined,
       )
@@ -174,12 +183,10 @@ describe('basic tests', () => {
       expect(getFileEntityData).toHaveBeenCalledTimes(3)
       expect(instance.state.formData).toEqual(mockFormData)
       expect(getFileEntityData).toHaveBeenCalledWith(
-        token,
         formSchemaEntityId,
         mockFormData.metadata.formSchemaVersion,
       )
       expect(getFileEntityData).not.toHaveBeenCalledWith(
-        token,
         formSchemaEntityId,
         undefined,
       )
@@ -195,10 +202,7 @@ describe('basic tests', () => {
       const { wrapper, instance } = await createShallowComponent(_props)
       await instance.componentDidMount()
       expect(wrapper).toBeDefined()
-      wrapper
-        .find('div')
-        .first()
-        .hasClass('someFormClass')
+      wrapper.find('div').first().hasClass('someFormClass')
       const formProps: SynapseFormProps = (wrapper
         .find('SynapseForm')
         .props() as any) as SynapseFormProps
@@ -212,10 +216,7 @@ describe('basic tests', () => {
       await instance.componentDidMount()
 
       expect(wrapper).toBeDefined()
-      wrapper
-        .find('div')
-        .first()
-        .hasClass('someFormClass')
+      wrapper.find('div').first().hasClass('someFormClass')
       const formProps: SynapseFormProps = (wrapper
         .find('SynapseForm')
         .props() as any) as SynapseFormProps

--- a/src/__tests__/lib/utils/SynapseClient.test.tsx
+++ b/src/__tests__/lib/utils/SynapseClient.test.tsx
@@ -2,8 +2,11 @@ import { fail } from 'assert'
 import { BackendDestinationEnum } from '../../../lib/utils/functions/getEndpoint'
 import {
   BatchFileRequest,
+  Direction,
+  EntityType,
   FileHandleAssociateType,
   PaginatedResults,
+  SortBy,
 } from '../../../lib/utils/synapseTypes/'
 import { SynapseClient, SynapseConstants } from '../../../lib/utils/'
 import { FunctionReturningPaginatedResults } from '../../../lib/utils/SynapseClient'
@@ -13,9 +16,8 @@ describe('it works at integration level testing', () => {
     return SynapseClient.doGet(
       '/repo/v1/invalid',
       undefined,
-      undefined,
       BackendDestinationEnum.REPO_ENDPOINT,
-    ).catch((error) => {
+    ).catch(error => {
       expect(error.status).toEqual(404)
       expect(error.reason).toEqual(
         'GET was not found. Please reference API documentation at https://docs.synapse.org/rest/',
@@ -25,64 +27,53 @@ describe('it works at integration level testing', () => {
 
   it('version call', () => {
     return SynapseClient.getVersion()
-      .then((data) => {
+      .then(data => {
         expect(data.version).toBeDefined()
       })
-      .catch((err) => {
+      .catch(err => {
         fail(err.reason)
       })
   })
 
-  it('delete entity', () => {
-    return SynapseClient.deleteEntity(
-      'invalid_session_token',
-      'invalid_entity_id',
-    )
-      .then((data) => {
-        fail(
-          'should not be able to delete an entity with an invalid session token',
-        )
-      })
-      .catch((resp) => {
-        // invalid session token
-        expect(resp['status']).toBe(401)
-      })
-  })
-
   it('get entity with version', async () => {
-    return SynapseClient.getEntity('', 'syn20692910', '53')
-      .then((data) => {
+    return SynapseClient.getEntity('syn20692910', '53')
+      .then(data => {
         expect(data).toBeDefined()
         expect(data['versionNumber']).toBe(53)
       })
-      .catch((err) => {
+      .catch(err => {
         fail(err.reason)
       })
   })
 
   it('get user profiles', () => {
     return SynapseClient.getUserProfiles(['345424', '273978', '273991'])
-      .then((data) => {
+      .then(data => {
         expect(data.list).toBeDefined()
         expect(data.list.length).toEqual(3)
       })
-      .catch((err) => {
+      .catch(err => {
         fail(err.reason)
       })
   })
 
   it('list entity children', () => {
     const request = {
-      includeTypes: ['project', 'folder', 'file', 'link'],
+      includeTypes: [
+        EntityType.PROJECT,
+        EntityType.FOLDER,
+        EntityType.FILE,
+        EntityType.LINK,
+      ],
       parentId: 'syn300013',
-      sortBy: 'NAME',
-      sortDirection: 'ASC',
+      sortBy: SortBy.NAME,
+      sortDirection: Direction.ASC,
     }
     return SynapseClient.getEntityChildren(request)
-      .then((data) => {
+      .then(data => {
         expect(data.page).toBeDefined()
       })
-      .catch((err) => {
+      .catch(err => {
         fail(err.reason)
       })
   })
@@ -106,10 +97,10 @@ describe('it works at integration level testing', () => {
       ],
     }
     return SynapseClient.getFiles(request)
-      .then((data) => {
+      .then(data => {
         expect(data.requestedFiles).toBeDefined()
       })
-      .catch((err) => {
+      .catch(err => {
         fail(err.reason)
       })
   })
@@ -124,12 +115,12 @@ describe('it works at integration level testing', () => {
       undefined,
       partsMask,
     )
-      .then((data) => {
+      .then(data => {
         expect(data.entity).toBeDefined()
         expect(data.restrictionInformation).toBeDefined()
         expect(data.fileHandles).toBeDefined()
       })
-      .catch((err) => {
+      .catch(err => {
         fail(err.reason)
       })
   })
@@ -137,37 +128,37 @@ describe('it works at integration level testing', () => {
   it('get synapse wiki', () => {
     const ownerId = 'syn2580853'
     const wikiId = '409840'
-    return SynapseClient.getEntityWiki('', ownerId, wikiId)
-      .then((data) => {
+    return SynapseClient.getEntityWiki(ownerId, wikiId)
+      .then(data => {
         expect(data.markdown).toBeDefined()
       })
-      .catch((err) => {
+      .catch(err => {
         fail(err.reason)
       })
   })
 
   it('get user favorites', () => {
-    return SynapseClient.getUserFavorites('')
-      .then((data) => {
+    return SynapseClient.getUserFavorites()
+      .then(data => {
         expect(data.results).toBeDefined()
       })
-      .catch((err) => {
+      .catch(err => {
         fail(err)
       })
   })
 
   it('get user teams', () => {
-    return SynapseClient.getUserProfile('')
-      .then((data) => {
-        return SynapseClient.getUserTeamList('', data.ownerId)
-          .then((data) => {
+    return SynapseClient.getUserProfile()
+      .then(data => {
+        return SynapseClient.getUserTeamList(data.ownerId)
+          .then(data => {
             expect(data).toBeDefined()
           })
-          .catch((err) => {
+          .catch(err => {
             fail(err)
           })
       })
-      .catch((err) => {
+      .catch(err => {
         fail(err)
       })
   })
@@ -177,11 +168,11 @@ describe('it works at integration level testing', () => {
   })
 
   it('delete entity', () => {
-    return SynapseClient.deleteEntity('', '123')
-      .then((data) => {
+    return SynapseClient.deleteEntity('123')
+      .then(data => {
         expect(data).toBeDefined()
       })
-      .catch((err) => {
+      .catch(err => {
         fail(err.reason)
       })
   })

--- a/src/__tests__/lib/utils/hooks/SynapseAPI/useEntityBundle.test.tsx
+++ b/src/__tests__/lib/utils/hooks/SynapseAPI/useEntityBundle.test.tsx
@@ -23,20 +23,17 @@ SynapseClient.getEntityBundleV2 = jest.fn().mockResolvedValue(expected)
 
 describe('useEntityBundle functionality', () => {
   it('correctly calls SynapseClient', async () => {
-    const sessionToken = 'abcdef'
     const entityId = 'syn123'
 
-    const { result, waitFor } = renderHook(
-      () => useGetEntityBundle(sessionToken, entityId),
-      { wrapper },
-    )
+    const { result, waitFor } = renderHook(() => useGetEntityBundle(entityId), {
+      wrapper,
+    })
 
     await waitFor(() => result.current.isSuccess)
     expect(SynapseClient.getEntityBundleV2).toBeCalledWith(
       entityId,
       expect.anything(),
       undefined,
-      sessionToken,
     )
     expect(result.current.data).toEqual(expected)
   })

--- a/src/__tests__/lib/utils/hooks/SynapseAPI/useFavorites.test.tsx
+++ b/src/__tests__/lib/utils/hooks/SynapseAPI/useFavorites.test.tsx
@@ -4,8 +4,7 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 import { useGetFavorites } from '../../../../../lib/utils/hooks/SynapseAPI/useFavorites'
 import {
   EntityHeader,
-  EntityType,
-  PaginatedResults
+  PaginatedResults,
 } from '../../../../../lib/utils/synapseTypes'
 
 const wrapper = (props: { children: React.ReactChildren }) => (
@@ -19,7 +18,7 @@ const expected: PaginatedResults<EntityHeader> = {
     {
       id: 'syn123',
       name: 'My Favorite Entity',
-      type: EntityType.FILE,
+      type: 'org.sagebionetworks.repo.model.FileEntity',
       versionNumber: 1,
       versionLabel: '1',
       benefactorId: 122,
@@ -36,16 +35,11 @@ SynapseClient.getUserFavorites = jest.fn().mockResolvedValue(expected)
 
 describe('useFavorites functionality', () => {
   it('correctly calls SynapseClient', async () => {
-    const sessionToken = 'abcdef'
-
-    const { result, waitFor } = renderHook(
-      () => useGetFavorites(sessionToken),
-      { wrapper },
-    )
+    const { result, waitFor } = renderHook(() => useGetFavorites(), { wrapper })
 
     await waitFor(() => result.current.isSuccess)
 
-    expect(SynapseClient.getUserFavorites).toBeCalledWith(sessionToken)
+    expect(SynapseClient.getUserFavorites).toBeCalled()
     expect(result.current.data).toEqual(expected)
   })
 })

--- a/src/__tests__/lib/utils/hooks/SynapseAPI/useGetEntityChildren.test.tsx
+++ b/src/__tests__/lib/utils/hooks/SynapseAPI/useGetEntityChildren.test.tsx
@@ -27,7 +27,7 @@ const page1: EntityChildrenResponse = {
     {
       id: 'syn123',
       name: 'Child 1',
-      type: EntityType.FILE,
+      type: 'org.sagebionetworks.repo.model.FileEntity',
       versionNumber: 1,
       versionLabel: '1',
       benefactorId: 122,
@@ -45,7 +45,7 @@ const page2: EntityChildrenResponse = {
     {
       id: 'syn124',
       name: 'Child 2',
-      type: EntityType.FILE,
+      type: 'org.sagebionetworks.repo.model.FileEntity',
       versionNumber: 1,
       versionLabel: '1',
       benefactorId: 122,
@@ -65,19 +65,14 @@ describe('basic functionality', () => {
   it('correctly calls SynapseClient', async () => {
     SynapseClient.getEntityChildren.mockResolvedValueOnce(page1)
 
-    const sessionToken = 'abcdef'
-
     const { result, waitFor } = renderHook(
-      () => useGetEntityChildren(sessionToken, request),
+      () => useGetEntityChildren(request),
       { wrapper },
     )
 
     await waitFor(() => result.current.isSuccess)
 
-    expect(SynapseClient.getEntityChildren).toBeCalledWith(
-      request,
-      sessionToken,
-    )
+    expect(SynapseClient.getEntityChildren).toBeCalledWith(request)
     expect(result.current.data).toEqual(page1)
   })
 
@@ -86,19 +81,14 @@ describe('basic functionality', () => {
       .mockResolvedValueOnce(page1)
       .mockResolvedValueOnce(page2)
 
-    const sessionToken = 'abcdef'
-
     const { result, waitFor } = renderHook(
-      () => useGetEntityChildrenInfinite(sessionToken, request),
+      () => useGetEntityChildrenInfinite(request),
       { wrapper },
     )
 
     await waitFor(() => result.current.isSuccess)
 
-    expect(SynapseClient.getEntityChildren).toBeCalledWith(
-      request,
-      sessionToken,
-    )
+    expect(SynapseClient.getEntityChildren).toBeCalledWith(request)
     expect(result.current.data?.pages[0]).toEqual(page1)
     expect(result.current.hasNextPage).toBe(true)
 
@@ -107,13 +97,10 @@ describe('basic functionality', () => {
     await waitFor(() => result.current.isFetching)
     await waitFor(() => !result.current.isFetching)
 
-    expect(SynapseClient.getEntityChildren).toBeCalledWith(
-      {
-        ...request,
-        nextPageToken: page1.nextPageToken,
-      },
-      sessionToken,
-    )
+    expect(SynapseClient.getEntityChildren).toBeCalledWith({
+      ...request,
+      nextPageToken: page1.nextPageToken,
+    })
     expect(result.current.data?.pages[1]).toEqual(page2)
     expect(result.current.hasNextPage).toBe(false)
   })

--- a/src/__tests__/lib/utils/hooks/SynapseAPI/useGetEntityHeaders.test.tsx
+++ b/src/__tests__/lib/utils/hooks/SynapseAPI/useGetEntityHeaders.test.tsx
@@ -4,7 +4,6 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 import { useGetEntityHeaders } from '../../../../../lib/utils/hooks/SynapseAPI/useGetEntityHeaders'
 import {
   EntityHeader,
-  EntityType,
   PaginatedResults,
   ReferenceList,
 } from '../../../../../lib/utils/synapseTypes'
@@ -20,7 +19,7 @@ const expected: PaginatedResults<EntityHeader> = {
     {
       id: 'syn123',
       name: 'My Entity',
-      type: EntityType.FILE,
+      type: 'org.sagebionetworks.repo.model.FileEntity',
       versionNumber: 1,
       versionLabel: '1',
       benefactorId: 122,
@@ -37,20 +36,16 @@ SynapseClient.getEntityHeaders = jest.fn().mockResolvedValue(expected)
 
 describe('basic functionality', () => {
   it('correctly calls SynapseClient', async () => {
-    const sessionToken = 'abcdef'
     const references: ReferenceList = [{ targetId: 'syn123' }]
 
     const { result, waitFor } = renderHook(
-      () => useGetEntityHeaders(references, sessionToken),
+      () => useGetEntityHeaders(references),
       { wrapper },
     )
 
     await waitFor(() => result.current.isSuccess)
 
-    expect(SynapseClient.getEntityHeaders).toBeCalledWith(
-      references,
-      sessionToken,
-    )
+    expect(SynapseClient.getEntityHeaders).toBeCalledWith(references)
     expect(result.current.data).toEqual(expected)
   })
 })

--- a/src/__tests__/lib/utils/hooks/SynapseAPI/useProjects.test.tsx
+++ b/src/__tests__/lib/utils/hooks/SynapseAPI/useProjects.test.tsx
@@ -55,16 +55,13 @@ describe('basic functionality', () => {
   it('correctly calls SynapseClient', async () => {
     SynapseClient.getMyProjects.mockResolvedValueOnce(page1)
 
-    const sessionToken = 'abcdef'
-
-    const { result, waitFor } = renderHook(
-      () => useGetProjects(sessionToken, request),
-      { wrapper },
-    )
+    const { result, waitFor } = renderHook(() => useGetProjects(request), {
+      wrapper,
+    })
 
     await waitFor(() => result.current.isSuccess)
 
-    expect(SynapseClient.getMyProjects).toBeCalledWith(sessionToken, request)
+    expect(SynapseClient.getMyProjects).toBeCalledWith(request)
     expect(result.current.data).toEqual(page1)
   })
 
@@ -73,16 +70,14 @@ describe('basic functionality', () => {
       .mockResolvedValueOnce(page1)
       .mockResolvedValueOnce(page2)
 
-    const sessionToken = 'abcdef'
-
     const { result, waitFor } = renderHook(
-      () => useGetProjectsInfinite(sessionToken, request),
+      () => useGetProjectsInfinite(request),
       { wrapper },
     )
 
     await waitFor(() => result.current.isSuccess)
 
-    expect(SynapseClient.getMyProjects).toBeCalledWith(sessionToken, request)
+    expect(SynapseClient.getMyProjects).toBeCalledWith(request)
     expect(result.current.data?.pages[0]).toEqual(page1)
     expect(result.current.hasNextPage).toBe(true)
 
@@ -91,7 +86,7 @@ describe('basic functionality', () => {
     await waitFor(() => result.current.isFetching)
     await waitFor(() => !result.current.isFetching)
 
-    expect(SynapseClient.getMyProjects).toBeCalledWith(sessionToken, {
+    expect(SynapseClient.getMyProjects).toBeCalledWith({
       ...request,
       nextPageToken: page1.nextPageToken,
     })

--- a/src/__tests__/lib/utils/hooks/SynapseAPI/useSearch.test.tsx
+++ b/src/__tests__/lib/utils/hooks/SynapseAPI/useSearch.test.tsx
@@ -82,18 +82,15 @@ describe('basic functionality', () => {
   it('correctly calls SynapseClient', async () => {
     SynapseClient.searchEntities.mockResolvedValueOnce(page1)
 
-    const sessionToken = 'abcdef'
-
-    const { result, waitFor } = renderHook(
-      () => useSearch(request, sessionToken),
-      { wrapper },
-    )
+    const { result, waitFor } = renderHook(() => useSearch(request), {
+      wrapper,
+    })
 
     await waitFor(() => {
       return result.current.isSuccess
     })
 
-    expect(SynapseClient.searchEntities).toBeCalledWith(request, sessionToken)
+    expect(SynapseClient.searchEntities).toBeCalledWith(request)
     expect(result.current.data).toEqual(page1)
   })
 
@@ -102,15 +99,12 @@ describe('basic functionality', () => {
       .mockResolvedValueOnce(page1)
       .mockResolvedValueOnce(page2)
 
-    const sessionToken = 'abcdef'
-
-    const { result, waitFor } = renderHook(
-      () => useSearchInfinite(request, sessionToken),
-      { wrapper },
-    )
+    const { result, waitFor } = renderHook(() => useSearchInfinite(request), {
+      wrapper,
+    })
     await waitFor(() => result.current.isSuccess)
 
-    expect(SynapseClient.searchEntities).toBeCalledWith(request, sessionToken)
+    expect(SynapseClient.searchEntities).toBeCalledWith(request)
     expect(result.current.data?.pages[0]).toEqual(page1)
     expect(result.current.hasNextPage).toBe(true)
 
@@ -119,13 +113,10 @@ describe('basic functionality', () => {
     await waitFor(() => result.current.isFetching)
     await waitFor(() => !result.current.isFetching)
 
-    expect(SynapseClient.searchEntities).toBeCalledWith(
-      {
-        ...request,
-        start: 1,
-      },
-      sessionToken,
-    )
+    expect(SynapseClient.searchEntities).toBeCalledWith({
+      ...request,
+      start: 1,
+    })
     expect(result.current.data?.pages[1]).toEqual(page2)
     expect(result.current.hasNextPage).toBe(false)
   })

--- a/src/demo/containers/Demo.tsx
+++ b/src/demo/containers/Demo.tsx
@@ -6,9 +6,9 @@ import FileContentDownloadUploadDemo from '../../lib/containers/FileContentDownl
 import StatisticsPlot from '../../lib/containers/StatisticsPlot'
 import { testDownloadSpeed } from '../../lib/utils/functions/testDownloadSpeed'
 import HasAccess from '../../lib/containers/HasAccess'
+import { isSignedIn } from '../../lib/utils/SynapseClient'
 
 type DemoState = {
-  token: string | null
   ownerId: string
   isLoading: boolean
   showMarkdown: boolean
@@ -38,7 +38,6 @@ class Demo extends React.Component<DemoProps, DemoState> {
       isLoading: true,
       ownerId: '',
       showMarkdown: true,
-      token: '',
       version: 0,
     }
     this.getVersion = this.getVersion.bind(this)
@@ -59,9 +58,8 @@ class Demo extends React.Component<DemoProps, DemoState> {
   }
 
   public onRunDownloadSpeedTest() {
-    const { token } = this.state
-    if (token) {
-      testDownloadSpeed(token)
+    if (isSignedIn()) {
+      testDownloadSpeed()
         .then((estimatedDownloadBytesPerSecond: number) => {
           this.setState({ estimatedDownloadBytesPerSecond })
         })
@@ -90,26 +88,20 @@ class Demo extends React.Component<DemoProps, DemoState> {
     // Note:  All portals should do this once on the initial app load.
     // This looks for the session token cookie (HttpOnly, unable to directly access), and initialize the session if it does exists.
     SynapseClient.detectSSOCode()
-    SynapseClient.getSessionTokenFromCookie()
-      .then(sessionToken => {
-        this.setState({
-          token: sessionToken,
-        })
-      })
-      .catch((error: any) => {
-        console.error(error)
-      })
+    SynapseClient.getSessionTokenFromCookie().catch((error: any) => {
+      console.error(error)
+    })
     this.getVersion()
   }
   public render(): JSX.Element {
     const { forceSamePage = false } = this.props
-    const { token, estimatedDownloadBytesPerSecond } = this.state
+    const { estimatedDownloadBytesPerSecond } = this.state
     return (
       <div>
         <p className="App-intro text-center">
           Synapse production version: {this.state.version}
         </p>
-        {token && (
+        {isSignedIn() && (
           <div className="container">
             <button
               className="btn btn-default"
@@ -129,20 +121,17 @@ class Demo extends React.Component<DemoProps, DemoState> {
             <hr />
           </div>
         )}
-        {token && (
+        {isSignedIn() && (
           <div className="container">
             <h5>Upload File(s) Demo</h5>
-            <Uploader token={token} parentContainerId="syn18987891" />
+            <Uploader parentContainerId="syn18987891" />
             <hr />
           </div>
         )}
-        {token && (
+        {isSignedIn() && (
           <div className="container">
             <h5>Download File Content Demo (syn12196718)</h5>
-            <FileContentDownloadUploadDemo
-              token={token}
-              targetEntityId="syn12196718"
-            />
+            <FileContentDownloadUploadDemo targetEntityId="syn12196718" />
             <hr />
           </div>
         )}
@@ -150,28 +139,24 @@ class Demo extends React.Component<DemoProps, DemoState> {
           <div className="container">
             <h5>Public Folder - HasAccess widget</h5>
             <HasAccess
-              token={token ? token : undefined}
               entityId={'syn7122428'}
               isInDownloadList={false}
               forceSamePage={forceSamePage}
             />
             <h5>A Controlled Access Folder - HasAccess widget</h5>
             <HasAccess
-              token={token ? token : undefined}
               entityId={'syn7383419'}
               isInDownloadList={false}
               forceSamePage={forceSamePage}
             />
             <h5>Open Data</h5>
             <HasAccess
-              token={token ? token : undefined}
               entityId={'syn5481758'}
               isInDownloadList={false}
               forceSamePage={forceSamePage}
             />
             <h5>Acces Requirements required Data</h5>
             <HasAccess
-              token={token ? token : undefined}
               entityId={'syn2426398'}
               isInDownloadList={false}
               forceSamePage={forceSamePage}
@@ -180,7 +165,6 @@ class Demo extends React.Component<DemoProps, DemoState> {
               Acces Requirements required Data without unsupported requirement
             </h5>
             <HasAccess
-              token={token ? token : undefined}
               entityId={'syn4993293'}
               isInDownloadList={false}
               forceSamePage={forceSamePage}
@@ -189,11 +173,10 @@ class Demo extends React.Component<DemoProps, DemoState> {
             <hr />
           </div>
         }
-        {token && (
+        {isSignedIn() && (
           <div className="container">
             <h5>Project Statistics Demo</h5>
             <StatisticsPlot
-              token={token}
               request={{
                 concreteType:
                   'org.sagebionetworks.repo.model.statistics.ProjectFilesStatisticsRequest',
@@ -203,7 +186,6 @@ class Demo extends React.Component<DemoProps, DemoState> {
               }}
             />
             <StatisticsPlot
-              token={token}
               request={{
                 concreteType:
                   'org.sagebionetworks.repo.model.statistics.ProjectFilesStatisticsRequest',
@@ -215,7 +197,6 @@ class Demo extends React.Component<DemoProps, DemoState> {
             <hr />
           </div>
         )}
-
       </div>
     )
   }

--- a/src/demo/containers/playground/AccessRequirementDemo.tsx
+++ b/src/demo/containers/playground/AccessRequirementDemo.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react'
 import AccessRequirementList from '../../../lib/containers/access_requirement_list/AccessRequirementList'
 
-type AccessRequirementDemoProps = {
-  token: string
-}
+type AccessRequirementDemoProps = {}
 
 export const AccessRequirementDemo: React.FunctionComponent<AccessRequirementDemoProps> = props => {
-  const { token } = props
   const [
     displayAccessRequirement,
     setDisplayAccessRequirement,
@@ -29,7 +26,6 @@ export const AccessRequirementDemo: React.FunctionComponent<AccessRequirementDem
             setDisplayAccessRequirement(false)
           }}
           entityId={inputValue}
-          token={token}
         />
       ) : (
         <>

--- a/src/demo/containers/playground/Playground.tsx
+++ b/src/demo/containers/playground/Playground.tsx
@@ -19,13 +19,7 @@ import ColorPaletteInspector from './ColorPaletteInspector'
  * Demo of features that can be used from src/demo/utils/SynapseClient
  * module
  */
-const App = ({
-  match,
-  token,
-}: {
-  match?: RouteChildrenProps['match']
-  token: string
-}) => {
+const App = ({ match }: { match?: RouteChildrenProps['match'] }) => {
   if (!match) {
     return <div />
   }
@@ -112,7 +106,6 @@ const App = ({
           <div className="container download-list-demo">
             <div className="col-xs-10">
               <DownloadListTable
-                token={token}
                 listUpdatedCallback={() => {
                   console.log('DownloadList updated')
                 }}
@@ -125,13 +118,13 @@ const App = ({
       <Route
         exact={true}
         path={`${match.url}/WidgetDemo`}
-        component={() => <WidgetDemo token={token} />}
+        component={() => <WidgetDemo />}
       />
 
       <Route
         exact={true}
         path={`${match.url}/AccessRequirementDemo`}
-        component={() => <AccessRequirementDemo token={token} />}
+        component={() => <AccessRequirementDemo />}
       />
 
       <Route
@@ -143,13 +136,13 @@ const App = ({
       <Route
         exact={true}
         path={`${match.url}/ShowDownloadDemo`}
-        component={() => <ShowDownloadDemo token={token} />}
+        component={() => <ShowDownloadDemo />}
       />
 
       <Route
         exact={true}
         path={`${match.url}/SynapsePlotDemo`}
-        component={() => <SynapsePlotDemo token={token} />}
+        component={() => <SynapsePlotDemo />}
       />
 
       <Route
@@ -158,7 +151,7 @@ const App = ({
         component={() => (
           <div className="container">
             {' '}
-            <Resources entityId="syn22311127" token={token} />{' '}
+            <Resources entityId="syn22311127" />{' '}
           </div>
         )}
       />
@@ -166,9 +159,7 @@ const App = ({
       <Route
         exact={true}
         path={`${match.url}/ExternalFileHandleLink`}
-        component={() => (
-          <ExternalFileHandleLink synId={'syn22276050'} token={token} />
-        )}
+        component={() => <ExternalFileHandleLink synId={'syn22276050'} />}
       />
 
       <Route

--- a/src/demo/containers/playground/ShowDownloadDemo.tsx
+++ b/src/demo/containers/playground/ShowDownloadDemo.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import ShowDownload from '../../../lib/containers/download_list/ShowDownload'
+import { isSignedIn } from '../../../lib/utils/SynapseClient'
 
-const ShowDownloadDemo = ({ token }: { token: string | undefined }) => {
-  if (!token) {
+const ShowDownloadDemo = () => {
+  if (!isSignedIn()) {
     return <p> You need to sign in to for ShowDownload to render </p>
   }
   return (
     <div>
-      <ShowDownload token={token} />
+      <ShowDownload />
     </div>
   )
 }

--- a/src/demo/containers/playground/SynapsePlotDemo.tsx
+++ b/src/demo/containers/playground/SynapsePlotDemo.tsx
@@ -1,25 +1,22 @@
 import * as React from 'react'
 import SynapsePlot from '../../../lib/containers/widgets/SynapsePlot'
 
-type SynapsePlotDemoProps = {
-  token: string
-}
+type SynapsePlotDemoProps = {}
 
-export const SynapsePlotDemo: React.FunctionComponent<SynapsePlotDemoProps> = ({token}) => {
+export const SynapsePlotDemo: React.FunctionComponent<SynapsePlotDemoProps> = () => {
   return (
     <SynapsePlot
-      token={token}
       widgetparamsMapped={{
-        query:'SELECT \'date\', survey_1, survey_2, survey_3, survey_4 FROM syn22314856',
-        title:'New Participants Per Survey Per Day',
-        xtitle:'Date',
+        query:
+          "SELECT 'date', survey_1, survey_2, survey_3, survey_4 FROM syn22314856",
+        title: 'New Participants Per Survey Per Day',
+        xtitle: 'Date',
         ytitle: 'Count',
         type: 'scatter',
         horizontal: 'true',
         // xaxistype:,
-        showlegend:'true'
-      }
-      }      
+        showlegend: 'true',
+      }}
     />
   )
 }

--- a/src/demo/containers/playground/WidgetDemo.tsx
+++ b/src/demo/containers/playground/WidgetDemo.tsx
@@ -10,9 +10,7 @@ import { Range, RangeValues } from '../../../lib/containers/widgets/Range'
 import { RangeSlider } from '../../../lib/containers/widgets/RangeSlider'
 import { useState } from 'react'
 
-type WigetDemoPros = {
-  token: string
-}
+type WigetDemoPros = {}
 
 export const WidgetDemo: React.FunctionComponent<WigetDemoPros> = (
   props: WigetDemoPros,
@@ -157,7 +155,6 @@ export const WidgetDemo: React.FunctionComponent<WigetDemoPros> = (
         step={1}
       ></RangeSlider>
       <ThemesPlot
-        token={props.token}
         onPointClick={plotCallback}
         topBarPlot={topBarPlotProps}
         sideBarPlot={sideBarPlotProps}

--- a/src/lib/containers/AccountLevelBadge.tsx
+++ b/src/lib/containers/AccountLevelBadge.tsx
@@ -36,7 +36,6 @@ export const AccountLevelBadge: React.FunctionComponent<AccountLevelBadgeProps> 
         const bundle: UserBundle = await SynapseClient.getUserBundle(
           userId,
           certificationOrVerification,
-          undefined,
         )
         setUserBundle(bundle)
       } catch (err) {

--- a/src/lib/containers/AddToDownloadListV2.tsx
+++ b/src/lib/containers/AddToDownloadListV2.tsx
@@ -1,37 +1,38 @@
 import React from 'react'
-import {
-  AddBatchOfFilesToDownloadListResponse,
-} from '../utils/synapseTypes/DownloadListV2/AddBatchOfFilesToDownloadListResponse'
-import {
-  addFileToDownloadListV2,
-} from '../utils/SynapseClient'
+import { addFileToDownloadListV2 } from '../utils/SynapseClient'
+import { AddBatchOfFilesToDownloadListResponse } from '../utils/synapseTypes/DownloadListV2/AddBatchOfFilesToDownloadListResponse'
 import IconSvg from './IconSvg'
 
 export type AddToDownloadListV2Props = {
-  token?: string
   entityId: string
   entityVersionNumber?: number
 }
 
-const AddToDownloadListV2: React.FunctionComponent<AddToDownloadListV2Props> = (props) => {
-
-  const {token, entityId, entityVersionNumber} = props
+const AddToDownloadListV2: React.FunctionComponent<AddToDownloadListV2Props> = props => {
+  const { entityId, entityVersionNumber } = props
   const addToDownloadListV2 = async () => {
     try {
-      const result:AddBatchOfFilesToDownloadListResponse = await addFileToDownloadListV2(entityId, entityVersionNumber, token)
+      const result: AddBatchOfFilesToDownloadListResponse = await addFileToDownloadListV2(
+        entityId,
+        entityVersionNumber,
+      )
       if (result.numberOfFilesAdded === 1)
-        console.log(`Successfully added ${entityId} (version=${entityVersionNumber}) to the Download List v2`)
+        console.log(
+          `Successfully added ${entityId} (version=${entityVersionNumber}) to the Download List v2`,
+        )
       else
-        console.log(`Adding to the Download List v2 resulted in ${result.numberOfFilesAdded} files being added.`)
+        console.log(
+          `Adding to the Download List v2 resulted in ${result.numberOfFilesAdded} files being added.`,
+        )
     } catch (e) {
-      console.log("Failed to add to the Download List v2: ", e)
+      console.log('Failed to add to the Download List v2: ', e)
     }
   }
 
   return (
     <span className="SRC-primary-text-color">
-      <button className={"btn-download-icon"} onClick={addToDownloadListV2}>
-        <IconSvg options={{icon: "addToCart"}} />
+      <button className={'btn-download-icon'} onClick={addToDownloadListV2}>
+        <IconSvg options={{ icon: 'addToCart' }} />
       </button>
     </span>
   )

--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -35,7 +35,6 @@ export type CardContainerProps = {
   unitDescription?: string
   hasMoreData?: boolean
   showBarChart?: boolean
-  token?: string
 } & CardConfiguration
 
 export const CardContainer = (props: CardContainerProps) => {
@@ -49,7 +48,6 @@ export const CardContainer = (props: CardContainerProps) => {
     secondaryLabelLimit = 3,
     showBarChart = true,
     title,
-    token,
     getLastQueryRequest,
     executeQueryRequest,
     hasMoreData,
@@ -89,7 +87,6 @@ export const CardContainer = (props: CardContainerProps) => {
   const tableEntityConcreteType = useGetInfoFromIds<EntityHeader>({
     ids,
     type: 'ENTITY_HEADER',
-    token: props.token,
   })
   // the cards only show the loading screen on initial load, this occurs when data is undefined
   if (!data) {
@@ -100,14 +97,17 @@ export const CardContainer = (props: CardContainerProps) => {
       return <SearchResultsNotFound />
     }
     // else show "no results" UI (see PORTALS-1497)
-    return <>
-      <p className="SRC-no-results-title">
-        There is currently no content here.
-      </p>
-      <p className="SRC-no-results-description">
-        Information is always being updated, so check back later to see if content has been added.
-      </p>
-    </>
+    return (
+      <>
+        <p className="SRC-no-results-title">
+          There is currently no content here.
+        </p>
+        <p className="SRC-no-results-description">
+          Information is always being updated, so check back later to see if
+          content has been added.
+        </p>
+      </>
+    )
   }
   const schema = {}
   data.queryResult.queryResults.headers.forEach((element, index) => {
@@ -139,25 +139,28 @@ export const CardContainer = (props: CardContainerProps) => {
   } else {
     // render the cards
     const cardsData = data.queryResult.queryResults.rows
-    cards = cardsData.length ? cardsData.map((rowData: any, index) => {
-      const key = JSON.stringify(rowData.values)
-      const propsForCard = {
-        key,
-        type,
-        schema,
-        isHeader,
-        secondaryLabelLimit,
-        data: rowData.values,
-        selectColumns: data.selectColumns,
-        columnModels: data.columnModels,
-        tableEntityConcreteType:
-          tableEntityConcreteType[0] && tableEntityConcreteType[0].type,
-        tableId: props.data?.queryResult.queryResults.tableId,
-        token,
-        ...rest,
-      }
-      return renderCard(propsForCard, type)
-    }) : <></>
+    cards = cardsData.length ? (
+      cardsData.map((rowData: any, index) => {
+        const key = JSON.stringify(rowData.values)
+        const propsForCard = {
+          key,
+          type,
+          schema,
+          isHeader,
+          secondaryLabelLimit,
+          data: rowData.values,
+          selectColumns: data.selectColumns,
+          columnModels: data.columnModels,
+          tableEntityConcreteType:
+            tableEntityConcreteType[0] && tableEntityConcreteType[0].type,
+          tableId: props.data?.queryResult.queryResults.tableId,
+          ...rest,
+        }
+        return renderCard(propsForCard, type)
+      })
+    ) : (
+      <></>
+    )
   }
 
   return (
@@ -165,7 +168,6 @@ export const CardContainer = (props: CardContainerProps) => {
       {title && <h2 className="SRC-card-overview-title">{title}</h2>}
       {!title && unitDescription && showBarChart && (
         <TotalQueryResults
-          token={token}
           isLoading={isLoading!}
           unitDescription={unitDescription}
           executeQueryRequest={executeQueryRequest}

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -50,8 +50,8 @@ export type LabelLinkConfig = (MarkdownLink | CardLink)[]
 
 export type ColumnIconConfigs = {
   columns: {
-    [index:string]: {
-      [index:string]: IconSvgOptions
+    [index: string]: {
+      [index: string]: IconSvgOptions
     }
   }
 }
@@ -73,14 +73,13 @@ export type CardConfiguration = {
 } & CommonCardProps
 
 export type CardContainerLogicProps = {
-  token?: string
   limit?: number
   title?: string
   unitDescription?: string
   sqlOperator?: SQLOperator
   searchParams?: KeyValue
   facet?: string
-  facetAliases?: {}  
+  facetAliases?: {}
   rgbIndex?: number
   isHeader?: boolean
   isAlignToLeftNav?: boolean
@@ -138,8 +137,7 @@ export default class CardContainerLogic extends React.Component<
    */
   public componentDidUpdate(prevProps: CardContainerLogicProps) {
     /**
-     *  If token has changed (they signed in) or sql query has changed
-     *  or search params have updated then perform an update.
+     *  If sql query has changed or search params have updated then perform an update.
      */
     const { searchParams: prevSearchParams = {} } = prevProps
     const { searchParams: currentSearchParams = {} } = this.props
@@ -147,9 +145,8 @@ export default class CardContainerLogic extends React.Component<
       prevSearchParams,
       currentSearchParams,
     )
-    const hasTokenChanged = this.props.token !== prevProps.token
     const hasSqlChanged = this.props.sql !== prevProps.sql
-    if (hasTokenChanged || hasSqlChanged || hasSearchParamsChanged) {
+    if (hasSqlChanged || hasSearchParamsChanged) {
       this.executeInitialQueryRequest()
     }
   }
@@ -177,11 +174,7 @@ export default class CardContainerLogic extends React.Component<
       isLoading: true,
     })
 
-    await getNextPageOfData(
-      queryRequest,
-      this.state.data!,
-      this.props.token,
-    ).then(newState => {
+    await getNextPageOfData(queryRequest, this.state.data!).then(newState => {
       this.setState({
         ...newState,
         isLoading: false,
@@ -229,16 +222,14 @@ export default class CardContainerLogic extends React.Component<
       },
     }
 
-    SynapseClient.getQueryTableResults(initQueryRequest, this.props.token)
+    SynapseClient.getQueryTableResults(initQueryRequest)
       .then((data: QueryResultBundle) => {
         const queryRequestWithoutCount = cloneDeep(initQueryRequest)
         queryRequestWithoutCount.partMask =
           SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
           SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
           SynapseConstants.BUNDLE_MASK_QUERY_RESULTS
-        const hasMoreData =
-          data.queryResult.queryResults.rows.length ===
-          limit
+        const hasMoreData = data.queryResult.queryResults.rows.length === limit
         const newState = {
           hasMoreData,
           data,
@@ -258,12 +249,11 @@ export default class CardContainerLogic extends React.Component<
    */
   public render() {
     // only forward the necessary props
-    const { sql, searchParams, token, ...rest } = this.props
+    const { sql, searchParams, ...rest } = this.props
     return (
       <CardContainer
         {...rest}
         data={this.state.data}
-        token={token}
         getLastQueryRequest={this.getLastQueryRequest}
         getNextPageOfData={this.getNextPageOfData}
         hasMoreData={this.state.hasMoreData}

--- a/src/lib/containers/EntityIdList.tsx
+++ b/src/lib/containers/EntityIdList.tsx
@@ -1,21 +1,18 @@
 import React, { useEffect, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
-import {
-  getEntityHeadersByIds
-} from '../utils/SynapseClient'
+import { getEntityHeadersByIds } from '../utils/SynapseClient'
 
 export type EntityIdListProps = {
-  entityIdList: string[],
-  token: string | undefined
+  entityIdList: string[]
 }
 
 const EntityIdList: React.FC<EntityIdListProps> = props => {
-  const { entityIdList, token } = props
-  const [entityNameList, setEntityNameList] = useState<string>("")
+  const { entityIdList } = props
+  const [entityNameList, setEntityNameList] = useState<string>('')
   const { ref, inView } = useInView()
-  let mounted:boolean = true
+  let mounted: boolean = true
 
-  useEffect( () => {
+  useEffect(() => {
     if (mounted && inView) {
       getEntityTypes()
     }
@@ -27,19 +24,17 @@ const EntityIdList: React.FC<EntityIdListProps> = props => {
   const getEntityTypes = async () => {
     if (!entityIdList.length) return
 
-    getEntityHeadersByIds(entityIdList, token).then((entity) =>{
-      const list = entity.results.map(el => el.name).join(", ")
-      setEntityNameList(list)
-    }).catch(e => {
-      console.log("EntityIdList: Error getting entity header names", e)
-    })
+    getEntityHeadersByIds(entityIdList)
+      .then(entity => {
+        const list = entity.results.map(el => el.name).join(', ')
+        setEntityNameList(list)
+      })
+      .catch(e => {
+        console.log('EntityIdList: Error getting entity header names', e)
+      })
   }
 
-  return (
-    <span ref={ref}>
-      {entityNameList}
-    </span>
-  )
+  return <span ref={ref}>{entityNameList}</span>
 }
 
 export default EntityIdList

--- a/src/lib/containers/ErrorBanner.tsx
+++ b/src/lib/containers/ErrorBanner.tsx
@@ -1,9 +1,8 @@
-import * as React from 'react'
-import { SynapseClientError } from '../utils/SynapseClient'
+import React from 'react'
+import { isSignedIn, SynapseClientError } from '../utils/SynapseClient'
 import SignInButton from './SignInButton'
 import { Alert } from 'react-bootstrap'
 type ErrorProps = {
-  token?: string
   error?: string | Error | SynapseClientError | null
 }
 
@@ -25,13 +24,11 @@ function isString(error: string | Error | SynapseClientError): error is string {
   return typeof error === 'string'
 }
 
-export const ClientError = (props: {
-  error: SynapseClientError
-  token?: string
-}) => {
-  const { error, token } = props
-  const loginError = (error.status === 403 || error.status === 401) && !token
-  const accessDenied = error.status === 403 && token
+export const ClientError = (props: { error: SynapseClientError }) => {
+  const { error } = props
+  const loginError =
+    (error.status === 403 || error.status === 401) && !isSignedIn()
+  const accessDenied = error.status === 403 && isSignedIn()
 
   return (
     <>
@@ -50,7 +47,7 @@ export const ClientError = (props: {
 }
 
 export const ErrorBanner = (props: ErrorProps) => {
-  const { error, token } = props
+  const { error } = props
 
   if (!error) {
     return <></>
@@ -75,9 +72,7 @@ export const ErrorBanner = (props: ErrorProps) => {
         transition={false}
       >
         <p>
-          {synapseClientError && (
-            <ClientError error={synapseClientError} token={token} />
-          )}
+          {synapseClientError && <ClientError error={synapseClientError} />}
           {jsError && jsError.message}
           {stringError && stringError}
         </p>

--- a/src/lib/containers/ExternalFileHandleLink.tsx
+++ b/src/lib/containers/ExternalFileHandleLink.tsx
@@ -16,12 +16,11 @@ library.add(faExternalLinkAlt)
 
 export type ExternalFileHandleLinkProps = {
   synId: string
-  token?: string
   className?: string
 }
 
 export const ExternalFileHandleLink = (props: ExternalFileHandleLinkProps) => {
-  const { synId, token, className } = props
+  const { synId, className } = props
   const [data, setData] = useState<
     | { fileEntity: FileEntity; externalFileHandle: ExternalFileHandle }
     | undefined
@@ -29,10 +28,7 @@ export const ExternalFileHandleLink = (props: ExternalFileHandleLinkProps) => {
   useEffect(() => {
     const getEntity = async () => {
       try {
-        const fileEntity = await SynapseClient.getEntity<FileEntity>(
-          token,
-          synId,
-        )
+        const fileEntity = await SynapseClient.getEntity<FileEntity>(synId)
         assertIsFileEntity(fileEntity)
         const batchFileRequest: BatchFileRequest = {
           requestedFiles: [
@@ -46,7 +42,7 @@ export const ExternalFileHandleLink = (props: ExternalFileHandleLinkProps) => {
           includePreSignedURLs: false,
           includePreviewPreSignedURLs: false,
         }
-        const file = await SynapseClient.getFiles(batchFileRequest, token)
+        const file = await SynapseClient.getFiles(batchFileRequest)
         const externalFileHandle = file.requestedFiles[0].fileHandle
         assertIsExternalFileHandle(externalFileHandle)
         setData({
@@ -58,7 +54,7 @@ export const ExternalFileHandleLink = (props: ExternalFileHandleLinkProps) => {
       }
     }
     getEntity()
-  }, [synId, token])
+  }, [synId])
 
   const externalFileHandle = data?.externalFileHandle
   const fileEntity = data?.fileEntity
@@ -68,6 +64,7 @@ export const ExternalFileHandleLink = (props: ExternalFileHandleLinkProps) => {
       href={externalFileHandle.externalURL}
       className={className}
       target="_blank"
+      rel="noopener noreferrer"
     >
       <span>
         {fileEntity?.name}

--- a/src/lib/containers/Facets.tsx
+++ b/src/lib/containers/Facets.tsx
@@ -301,7 +301,6 @@ class Facets extends React.Component<QueryWrapperChildProps, FacetsState> {
         {!showBarChart && (
           <TotalQueryResults
             lastQueryRequest={this.props.getLastQueryRequest!()}
-            token={this.props.token}
             unitDescription={unitDescription!}
             frontText={'Displaying'}
             isLoading={isLoading!}

--- a/src/lib/containers/FileContentDownloadUploadDemo.tsx
+++ b/src/lib/containers/FileContentDownloadUploadDemo.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import {
   getEntity,
+  isSignedIn,
   updateEntity,
   uploadFile,
 } from '../utils/SynapseClient'
 import { Entity, FileEntity, FileUploadComplete } from '../utils/synapseTypes/'
 
 type FileContentDownloadUploadDemoState = {
-  token?: string
   error?: any
   isLoading?: boolean
   fileContent?: string
@@ -15,7 +15,6 @@ type FileContentDownloadUploadDemoState = {
 }
 
 export type FileContentDownloadUploadDemoProps = {
-  token?: string
   targetEntityId: string
 }
 
@@ -26,17 +25,16 @@ export default class FileContentDownloadUploadDemo extends React.Component<
   constructor(props: FileContentDownloadUploadDemoProps) {
     super(props)
     this.state = {
-      token: '',
       isLoading: false,
     }
   }
 
   public componentDidMount() {
-    const { token, targetEntityId } = this.props
+    const { targetEntityId } = this.props
     // must be logged in to download content
-    if (token) {
+    if (isSignedIn()) {
       this.setState({ isLoading: true })
-      getEntity(token, targetEntityId)
+      getEntity(targetEntityId)
         .then((entity: Entity) => {
           // if file entity
           if (
@@ -59,18 +57,18 @@ export default class FileContentDownloadUploadDemo extends React.Component<
 
   updateFileContent = (event: React.MouseEvent<HTMLButtonElement>) => {
     // create a new FileHandle, and update the FileEntity
-    if (this.props.token && this.state.targetEntity && this.state.fileContent) {
+    if (isSignedIn() && this.state.targetEntity && this.state.fileContent) {
       this.setState({ isLoading: true })
       const newFileContent = new Blob([this.state.fileContent], {
         type: 'text/plain',
       })
-      uploadFile(this.props.token, this.state.targetEntity.name, newFileContent)
+      uploadFile(this.state.targetEntity.name, newFileContent)
         .then((fileUploadComplete: FileUploadComplete) => {
           // now update the entity!
           if (this.state.targetEntity) {
             this.state.targetEntity.dataFileHandleId =
               fileUploadComplete.fileHandleId
-            updateEntity(this.state.targetEntity, this.props.token)
+            updateEntity(this.state.targetEntity)
               .then((entity: Entity) => {
                 const fileEntity = entity as FileEntity
                 // updated the target entity, force it to get the updated entity

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -9,7 +9,12 @@ import {
 } from './CardContainerLogic'
 import { unCamelCase } from '../utils/functions/unCamelCase'
 import MarkdownSynapse from './MarkdownSynapse'
-import { SelectColumn, ColumnModel, ColumnType, EntityColumnType } from '../utils/synapseTypes'
+import {
+  SelectColumn,
+  ColumnModel,
+  ColumnType,
+  EntityColumnType,
+} from '../utils/synapseTypes'
 import { SynapseConstants } from '../utils'
 import { FileHandleLink } from './widgets/FileHandleLink'
 import IconList from './IconList'
@@ -52,12 +57,11 @@ export type GenericCardProps = {
   selectColumns?: SelectColumn[]
   columnModels?: ColumnModel[]
   facetAliases?: {}
-  iconOptions?: IconOptions  
+  iconOptions?: IconOptions
   isHeader?: boolean
   isAlignToLeftNav?: boolean
   schema: any
   data: any
-  token?: string
   tableEntityConcreteType: string | undefined
   tableId: string | undefined
   columnIconOptions?: {}
@@ -106,8 +110,7 @@ export const getValueOrMultiValue = ({
   const selectedColumnOrUndefined =
     selectColumns?.find(el => el.name === columnName) ||
     columnModels?.find(el => el.name === columnName)
-  const isMultiValue =
-    selectedColumnOrUndefined?.columnType.endsWith('_LIST')
+  const isMultiValue = selectedColumnOrUndefined?.columnType.endsWith('_LIST')
 
   if (isMultiValue) {
     let val: any = value
@@ -118,7 +121,7 @@ export const getValueOrMultiValue = ({
       return {
         strList,
         str: val,
-        columnModelType: selectedColumnOrUndefined?.columnType
+        columnModelType: selectedColumnOrUndefined?.columnType,
       }
     } catch (e) {
       console.error(
@@ -172,20 +175,18 @@ export const renderLabel = (args: {
   }
   // PORTALS-1913: special rendering for user ID lists
   if (columnModelType === 'USERID_LIST' && strList) {
-      return strList.map((val:string, index:number) => {
-        return (
-          <span key={val}>
-            <UserCard ownerId={val} size={SMALL_USER_CARD}/>
-            {/* \u00a0 is a nbsp; */}
-            {index < strList.length - 1 && ',\u00a0\u00a0'}
-          </span>
-        )
+    return strList.map((val: string, index: number) => {
+      return (
+        <span key={val}>
+          <UserCard ownerId={val} size={SMALL_USER_CARD} />
+          {/* \u00a0 is a nbsp; */}
+          {index < strList.length - 1 && ',\u00a0\u00a0'}
+        </span>
+      )
     })
   }
   if (columnModelType === 'USERID' && str) {
-      return (
-        <UserCard ownerId={str} size={SMALL_USER_CARD}/>
-      )
+    return <UserCard ownerId={str} size={SMALL_USER_CARD} />
   }
 
   if (!labelLink) {
@@ -241,7 +242,7 @@ export const renderLabel = (args: {
 
 type ValueOrMultiValue = {
   str: string
-  strList?: string[],
+  strList?: string[]
   columnModelType?: ColumnType | EntityColumnType
 }
 
@@ -360,7 +361,7 @@ export default class GenericCard extends React.Component<
       schema,
       data,
       genericCardSchema,
-      secondaryLabelLimit,      
+      secondaryLabelLimit,
       selectColumns,
       columnModels,
       iconOptions,
@@ -374,7 +375,6 @@ export default class GenericCard extends React.Component<
       tableId,
       tableEntityConcreteType,
       columnIconOptions,
-      token,
     } = this.props
     // GenericCard inherits properties from CommonCardProps so that the properties have the same name
     // and type, but theres one nuance which is that we can't override if one specific property will be
@@ -438,32 +438,45 @@ export default class GenericCard extends React.Component<
 
     const showFooter = values.length > 0
 
-    const style: React.CSSProperties = {      
+    const style: React.CSSProperties = {
       // undefined, take default value from class
       marginTop: isHeader ? '0px' : undefined,
       marginBottom: isHeader ? '0px' : undefined,
       paddingBottom: showFooter || imageFileHandleIdValue ? undefined : '15px',
-    }    
-    const icon:JSX.Element = <>
-        {imageFileHandleIdValue && <div className="SRC-imageThumbnail" style={{padding: genericCardSchemaDefined.thumbnailRequiresPadding ? '21px' : undefined}}>
-          <ImageFileHandle 
-            token={token}
-            fileHandleId={imageFileHandleIdValue}
-            tableEntityConcreteType={tableEntityConcreteType}
-            rowId={data![schema.id]}
-            tableId={tableId}
-          /></div>}
-        {!imageFileHandleIdValue && <div className="SRC-cardThumbnail">
-          <Icon iconOptions={iconOptions} value={iconValue} type={type} />          
-        </div>}
+    }
+    const icon: JSX.Element = (
+      <>
+        {imageFileHandleIdValue && (
+          <div
+            className="SRC-imageThumbnail"
+            style={{
+              padding: genericCardSchemaDefined.thumbnailRequiresPadding
+                ? '21px'
+                : undefined,
+            }}
+          >
+            <ImageFileHandle
+              fileHandleId={imageFileHandleIdValue}
+              tableEntityConcreteType={tableEntityConcreteType}
+              rowId={data![schema.id]}
+              tableId={tableId}
+            />
+          </div>
+        )}
+        {!imageFileHandleIdValue && (
+          <div className="SRC-cardThumbnail">
+            <Icon iconOptions={iconOptions} value={iconValue} type={type} />
+          </div>
+        )}
       </>
+    )
 
     if (isHeader) {
       return (
         <HeaderCard
           descriptionConfig={descriptionConfig}
           title={title}
-          subTitle={subTitle}          
+          subTitle={subTitle}
           description={description}
           type={type}
           icon={icon}
@@ -489,8 +502,9 @@ export default class GenericCard extends React.Component<
       genericCardSchemaDefined.description,
       facetAliases,
     )
-    
-    let ctaHref: string | undefined = undefined, ctaTarget: string | undefined = undefined
+
+    let ctaHref: string | undefined = undefined,
+      ctaTarget: string | undefined = undefined
     if (ctaLinkConfig) {
       const ctaLinkValue: string = data[schema[ctaLinkConfig.link]] || ''
       const { href: newCtaHref, target: newCtaTarget } = this.getLinkParams(
@@ -530,7 +544,6 @@ export default class GenericCard extends React.Component<
                 {!titleLinkConfig &&
                 titleColumnType === ColumnType.FILEHANDLEID ? (
                   <FileHandleLink
-                    token={token}
                     fileHandleId={linkValue}
                     tableEntityConcreteType={tableEntityConcreteType}
                     showDownloadIcon={type !== SynapseConstants.EXPERIMENTAL}
@@ -574,13 +587,10 @@ export default class GenericCard extends React.Component<
                 hasClickedShowMore,
                 descriptionSubTitle,
                 descriptionConfig,
-                this.props.token,
               )}
             {ctaLinkConfig && ctaHref && ctaTarget && (
               <div className="SRC-portalCardCTALink bootstrap-4-backport">
-                <a target={ctaTarget}
-                  rel="noopener noreferrer"
-                  href={ctaHref}>
+                <a target={ctaTarget} rel="noopener noreferrer" href={ctaHref}>
                   {ctaLinkConfig.text}
                 </a>
               </div>
@@ -605,11 +615,10 @@ export default class GenericCard extends React.Component<
     hasClickedShowMore: boolean,
     descriptionSubTitle: any,
     descriptionConfig?: DescriptionConfig,
-    token?: string,
   ): React.ReactNode {
     let content: JSX.Element | string = description
     if (descriptionConfig?.isMarkdown) {
-      content = <MarkdownSynapse token={token} markdown={content} />
+      content = <MarkdownSynapse markdown={content} />
     }
     const show =
       hasClickedShowMore || descriptionConfig?.showFullDescriptionByDefault

--- a/src/lib/containers/Login.tsx
+++ b/src/lib/containers/Login.tsx
@@ -20,7 +20,7 @@ type State = {
 type Props = {
   googleRedirectUrl?: string
   redirectUrl?: string // will redirect here after a successful login. if unset, reload the current page url.
-  sessionCallback: Function // Callback is invoked after login
+  sessionCallback: () => void // Callback is invoked after login
 }
 
 /**
@@ -161,7 +161,7 @@ class Login extends React.Component<Props, State> {
           or
         </div>
         <Form onSubmit={this.handleLogin}>
-          <label htmlFor={"exampleEmail"}>Username or Email Address</label>
+          <label htmlFor={'exampleEmail'}>Username or Email Address</label>
           <Form.Control
             required
             autoComplete="username"
@@ -173,7 +173,7 @@ class Login extends React.Component<Props, State> {
             value={this.state.username}
             onChange={this.handleChange}
           />
-          <label htmlFor={"examplePassword"}>Password</label>
+          <label htmlFor={'examplePassword'}>Password</label>
           <Form.Control
             required
             autoComplete="password"
@@ -203,7 +203,7 @@ class Login extends React.Component<Props, State> {
             Log in
           </Button>
         </Form>
-        <div className={"SRC-center-text"}>
+        <div className={'SRC-center-text'}>
           <a
             href={`${getEndpoint(
               BackendDestinationEnum.PORTAL_ENDPOINT,

--- a/src/lib/containers/LoginPage.tsx
+++ b/src/lib/containers/LoginPage.tsx
@@ -4,26 +4,27 @@ import Login from './Login'
 export type LoginPageProps = {
   googleRedirectUrl?: string
   redirectUrl?: string // will redirect here after a successful login. if unset, reload the current page url.
-  sessionCallback: Function // Callback is invoked after login
+  sessionCallback: () => void // Callback is invoked after login
 }
 
-const LoginPage: React.FunctionComponent<LoginPageProps> = (props) => {
+const LoginPage: React.FunctionComponent<LoginPageProps> = props => {
   const { googleRedirectUrl, redirectUrl, sessionCallback } = props
-  const thisClass = "login-panel-wrapper"
+  const thisClass = 'login-panel-wrapper'
 
   return (
-    <div className={"login-panel-wrapper-bg"}>
-      <div
-        id={thisClass}
-        className={thisClass}
-      >
-        <div className={"login-panel panel-left"}>
-          <div className={"panel-logo"}>
+    <div className={'login-panel-wrapper-bg'}>
+      <div id={thisClass} className={thisClass}>
+        <div className={'login-panel panel-left'}>
+          <div className={'panel-logo'}>
             <img
               alt={'Synapse logo'}
-              src={"https://s3.amazonaws.com/static.synapse.org/images/synapse-logo-blue.svg"}
+              src={
+                'https://s3.amazonaws.com/static.synapse.org/images/synapse-logo-blue.svg'
+              }
             />
-            <p className={"panel-tagline"}>Organize. Get credit. Collaborate.</p>
+            <p className={'panel-tagline'}>
+              Organize. Get credit. Collaborate.
+            </p>
           </div>
           <Login
             googleRedirectUrl={googleRedirectUrl}
@@ -31,10 +32,12 @@ const LoginPage: React.FunctionComponent<LoginPageProps> = (props) => {
             sessionCallback={sessionCallback}
           />
         </div>
-        <div className={"login-panel panel-right"} >
-          <div className={"panel-tagline"}>
-            <strong>Organize</strong> your digital research assets.<br />
-            <strong>Get credit</strong> for your research.<br />
+        <div className={'login-panel panel-right'}>
+          <div className={'panel-tagline'}>
+            <strong>Organize</strong> your digital research assets.
+            <br />
+            <strong>Get credit</strong> for your research.
+            <br />
             <strong>Collaborate</strong> with your colleagues and the public.
           </div>
         </div>

--- a/src/lib/containers/Logout.tsx
+++ b/src/lib/containers/Logout.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Button } from 'react-bootstrap'
 
 export type LogoutProps = {
-  callback: Function
+  callback: () => void
 }
 
 export default function Logout(props: LogoutProps) {

--- a/src/lib/containers/MarkdownSynapse.tsx
+++ b/src/lib/containers/MarkdownSynapse.tsx
@@ -38,7 +38,6 @@ declare var sanitizeHtml: any
 declare var markdownitMath: any
 
 export type MarkdownSynapseProps = {
-  token?: string
   ownerId?: string
   wikiId?: string
   markdown?: string
@@ -295,13 +294,12 @@ export default class MarkdownSynapse extends React.Component<
    * Get wiki page markdown and file attachment handles
    */
   public async getWikiPageMarkdown() {
-    const { ownerId, wikiId, token, objectType } = this.props
+    const { ownerId, wikiId, objectType } = this.props
     if (!ownerId && !wikiId) {
       return
     }
     try {
       const wikiPage = await SynapseClient.getEntityWiki(
-        token,
         ownerId,
         wikiId,
         objectType,
@@ -326,7 +324,7 @@ export default class MarkdownSynapse extends React.Component<
     }
   }
   public async getWikiAttachments(wikiId: string) {
-    const { token, ownerId, objectType } = this.props
+    const { ownerId, objectType } = this.props
     if (!ownerId) {
       console.error(
         'Cannot get wiki attachments without ownerId on Markdown Component',
@@ -334,7 +332,6 @@ export default class MarkdownSynapse extends React.Component<
       return undefined
     }
     return await SynapseClient.getWikiAttachmentsFromEntity(
-      token,
       ownerId,
       wikiId,
       objectType,
@@ -580,8 +577,7 @@ export default class MarkdownSynapse extends React.Component<
     if (alignLowerCase === 'right') {
       buttonClasses += 'floatright '
     }
-    const buttonVariant =
-      highlight === 'true' ? 'secondary' : 'light-secondary'
+    const buttonVariant = highlight === 'true' ? 'secondary' : 'light-secondary'
     if (alignLowerCase === 'center') {
       return (
         <div
@@ -615,7 +611,6 @@ export default class MarkdownSynapse extends React.Component<
     return (
       <SynapsePlot
         key={widgetparamsMapped.reactKey}
-        token={this.props.token}
         ownerId={this.props.ownerId}
         wikiId={this.props.wikiId || this.state.data.id}
         widgetparamsMapped={widgetparamsMapped}
@@ -624,9 +619,7 @@ export default class MarkdownSynapse extends React.Component<
   }
 
   public renderVideo(widgetparamsMapped: any) {
-    const { token } = this.props
-
-    return <SynapseVideo token={token} params={widgetparamsMapped} />
+    return <SynapseVideo params={widgetparamsMapped} />
   }
 
   public renderSynapseImage(widgetparamsMapped: any) {
@@ -642,7 +635,6 @@ export default class MarkdownSynapse extends React.Component<
         <SynapseImage
           params={widgetparamsMapped}
           key={reactKey}
-          token={this.props.token}
           fileName={widgetparamsMapped.fileName}
           wikiId={this.props.wikiId || this.state.data.id}
           fileResults={this.state.fileHandles.list}
@@ -656,7 +648,6 @@ export default class MarkdownSynapse extends React.Component<
         <SynapseImage
           params={widgetparamsMapped}
           key={reactKey}
-          token={this.props.token}
           synapseId={widgetparamsMapped.synapseId}
         />
       )
@@ -710,8 +701,7 @@ export default class MarkdownSynapse extends React.Component<
 
   // on component update find and re-render the math/widget items accordingly
   public async componentDidUpdate(prevProps: MarkdownSynapseProps) {
-    let shouldUpdate = this.props.token !== prevProps.token
-    shouldUpdate = shouldUpdate || this.props.ownerId !== prevProps.ownerId
+    let shouldUpdate = this.props.ownerId !== prevProps.ownerId
     shouldUpdate = shouldUpdate || this.props.wikiId !== prevProps.wikiId
 
     // we have to carefully update the component so it doesn't encounter an infinite loop
@@ -722,11 +712,11 @@ export default class MarkdownSynapse extends React.Component<
   }
 
   public render() {
-    const { renderInline, token } = this.props
+    const { renderInline } = this.props
     const { isLoading, error } = this.state
 
     if (error) {
-      return <ErrorBanner token={token} error={error} />
+      return <ErrorBanner error={error} />
     }
     const bookmarks = this.addBookmarks()
     const content = (

--- a/src/lib/containers/ModalDownload.tsx
+++ b/src/lib/containers/ModalDownload.tsx
@@ -31,9 +31,8 @@ export type ModalDownloadState = {
 
 export type ModalDownloadProps = {
   onClose: (...args: any[]) => void
-  token?: string
   includeEntityEtag?: boolean
-  queryBundleRequest?: QueryBundleRequest  // either the query bundle request needs to be provided, or getLastQueryRequest
+  queryBundleRequest?: QueryBundleRequest // either the query bundle request needs to be provided, or getLastQueryRequest
   getLastQueryRequest?: () => QueryBundleRequest
   offset?: number
   limit?: number
@@ -71,7 +70,7 @@ export default class ModalDownload extends React.Component<
     const { formData } = event
     const fileType = formData['File Type']
     const contents = formData.Contents as string[]
-    const { token, queryBundleRequest, getLastQueryRequest } = this.props
+    const { queryBundleRequest, getLastQueryRequest } = this.props
     const separator = fileType === csvOption ? ',' : '\t'
     const writeHeader = contents.includes(writeHeaderOption)
     const includeRowIdAndRowVersion = contents.includes(
@@ -89,7 +88,7 @@ export default class ModalDownload extends React.Component<
       includeRowIdAndRowVersion,
       csvTableDescriptor: { separator },
     }
-    SynapseClient.getDownloadFromTableRequest(downloadFromTableRequest, token)
+    SynapseClient.getDownloadFromTableRequest(downloadFromTableRequest)
       .then(data => {
         this.setState({
           isLoading: false,
@@ -104,14 +103,11 @@ export default class ModalDownload extends React.Component<
 
   onDownload = () => {
     const { data } = this.state
-    const { token } = this.props
     // data will always be defined if calling this function
-    SynapseClient.getFileHandleByIdURL(data!.resultsFileHandleId, token).then(
-      url => {
-        window.location.href = url
-        this.props.onClose()
-      },
-    )
+    SynapseClient.getFileHandleByIdURL(data!.resultsFileHandleId).then(url => {
+      window.location.href = url
+      this.props.onClose()
+    })
   }
 
   handleChange = (event: IChangeEvent) => {

--- a/src/lib/containers/QueryCount.tsx
+++ b/src/lib/containers/QueryCount.tsx
@@ -11,7 +11,6 @@ export type QueryCountProps = {
   selectedFacets?: FacetColumnValuesRequest[]
   parens?: boolean
   name: string
-  token?: string
 }
 
 const QueryCount: React.FunctionComponent<QueryCountProps> = ({
@@ -19,12 +18,14 @@ const QueryCount: React.FunctionComponent<QueryCountProps> = ({
   selectedFacets,
   parens,
   name,
-  token,
 }) => {
   const [storedSqlQueryCount, setStoredSqlQueryCount] = useState<{}>({})
   // maps sql string to true/false, true if already made a request for this sql's query count
   // false or undefined if not
-  const [isCalculatingQueryCountForSql, setIsCalculatingQueryCountForSql] = useState<{}>({})
+  const [
+    isCalculatingQueryCountForSql,
+    setIsCalculatingQueryCountForSql,
+  ] = useState<{}>({})
   let mounted = true
 
   useEffect(() => {
@@ -32,14 +33,15 @@ const QueryCount: React.FunctionComponent<QueryCountProps> = ({
       if (mounted) {
         const entityId = parseEntityIdFromSqlStatement(sql)
         if (
-          isCalculatingQueryCountForSql[`${sql}-${token}`] ||
-          storedSqlQueryCount[`${sql}-${token}`]
+          isCalculatingQueryCountForSql[`${sql}`] ||
+          storedSqlQueryCount[`${sql}`]
         ) {
           // its either in progress or its already been calculated
           return
         }
         const request: QueryBundleRequest = {
-          concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+          concreteType:
+            'org.sagebionetworks.repo.model.table.QueryBundleRequest',
           query: {
             sql,
             selectedFacets,
@@ -48,15 +50,15 @@ const QueryCount: React.FunctionComponent<QueryCountProps> = ({
           partMask: SynapseConstants.BUNDLE_MASK_QUERY_COUNT,
         }
         const newIsCalculatingQueryCountForSql = {
-          ...isCalculatingQueryCountForSql,  
+          ...isCalculatingQueryCountForSql,
         }
-        newIsCalculatingQueryCountForSql[`${sql}-${token}`] = true
+        newIsCalculatingQueryCountForSql[`${sql}`] = true
         setIsCalculatingQueryCountForSql(newIsCalculatingQueryCountForSql)
-        SynapseClient.getQueryTableResults(request, token).then(data => {
+        SynapseClient.getQueryTableResults(request).then(data => {
           const newStoredSqlQueryCount = {
-            ...storedSqlQueryCount
+            ...storedSqlQueryCount,
           }
-          newStoredSqlQueryCount[`${sql}-${token}`] = data!.queryCount
+          newStoredSqlQueryCount[`${sql}`] = data!.queryCount
           setStoredSqlQueryCount(newStoredSqlQueryCount)
         })
       }
@@ -67,10 +69,9 @@ const QueryCount: React.FunctionComponent<QueryCountProps> = ({
     return () => {
       mounted = false
     }
+  }, [sql, selectedFacets])
 
-  }, [sql, selectedFacets, token])
-
-  const count = storedSqlQueryCount[`${sql}-${token}`]
+  const count = storedSqlQueryCount[`${sql}`]
   const localCount = count?.toLocaleString()
   /* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString#Using_toLocaleString */
   return (

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -16,7 +16,6 @@ export type QueryWrapperProps = {
   visibleColumnCount?: number
   initQueryRequest: QueryBundleRequest
   rgbIndex?: number
-  token?: string
   facet?: string
   unitDescription?: string
   facetAliases?: {}
@@ -74,7 +73,7 @@ export type QueryWrapperState = {
   in SRC won't generate type errors.
  */
 export type LockedFacet = {
-  facet?: string,
+  facet?: string
   value?: string
 }
 
@@ -88,7 +87,6 @@ export type FacetSelection = {
 export type QueryWrapperChildProps = {
   isAllFilterSelectedForFacet?: {}
   isLoading?: boolean
-  token?: string
   entityId?: string
   isLoadingNewData?: boolean
   executeQueryRequest?: (param: QueryBundleRequest) => void
@@ -112,7 +110,7 @@ export type QueryWrapperChildProps = {
   topLevelControlsState?: TopLevelControlsState
   isColumnSelected?: string[]
   selectedRowIndices?: number[]
-  error?: SynapseClientError | undefined,
+  error?: SynapseClientError | undefined
   lockedFacet?: LockedFacet
 }
 export const QUERY_FILTERS_EXPANDED_CSS: string = 'isShowingFacetFilters'
@@ -153,7 +151,7 @@ export default class QueryWrapper extends React.Component<
       isAllFilterSelectedForFacet: {},
       loadNowStarted: false,
       lastQueryRequest: cloneDeep(this.props.initQueryRequest!),
-      topLevelControlsState : {
+      topLevelControlsState: {
         showColumnFilter: true,
         showFacetFilter: true,
         showFacetVisualization,
@@ -197,9 +195,6 @@ export default class QueryWrapper extends React.Component<
     const { loadNow = true } = this.props
     if (loadNow && !this.state.loadNowStarted) {
       this.executeInitialQueryRequest()
-    } else if (loadNow && this.props.token !== prevProps.token) {
-      // if loadNow is true and they've logged in with a token that is not undefined, null, or an empty string when it was before
-      this.executeQueryRequest(this.getLastQueryRequest())
     } else if (
       prevProps.initQueryRequest.query.sql !==
       this.props.initQueryRequest!.query.sql
@@ -258,7 +253,6 @@ export default class QueryWrapper extends React.Component<
     }
     return SynapseClient.getQueryTableResults(
       clonedQueryRequest,
-      this.props.token,
       this.updateParentState,
     )
       .then((data: QueryResultBundle) => {
@@ -293,11 +287,7 @@ export default class QueryWrapper extends React.Component<
       isLoading: true,
     })
 
-    await getNextPageOfData(
-      queryRequest,
-      this.state.data!,
-      this.props.token,
-    ).then(newState => {
+    await getNextPageOfData(queryRequest, this.state.data!).then(newState => {
       this.setState({
         ...newState,
         isLoading: false,
@@ -323,15 +313,11 @@ export default class QueryWrapper extends React.Component<
       loadNowStarted: true,
       lastQueryRequest,
     })
-    SynapseClient.getQueryTableResults(
-      initQueryRequest,
-      this.props.token,
-      this.updateParentState,
-    )
+    SynapseClient.getQueryTableResults(initQueryRequest, this.updateParentState)
       .then((data: QueryResultBundle) => {
         const hasMoreData =
           data.queryResult.queryResults.rows.length ===
-          initQueryRequest.query.limit ?? DEFAULT_PAGE_SIZE
+            initQueryRequest.query.limit ?? DEFAULT_PAGE_SIZE
         const isAllFilterSelectedForFacet = cloneDeep(
           this.state.isAllFilterSelectedForFacet,
         )
@@ -398,14 +384,18 @@ export default class QueryWrapper extends React.Component<
    * this is to remove the facet from the charts, search and filter.
    * @return data: QueryResultBundle
    */
-  public removeLockedFacetData (){
+  public removeLockedFacetData() {
     const lockedFacet = this.props.lockedFacet?.facet
-    if (lockedFacet && this.state.data) {  // for details page, return data without the "locked" facet
+    if (lockedFacet && this.state.data) {
+      // for details page, return data without the "locked" facet
       const data = cloneDeep(this.state.data)
-      const facets = data.facets?.filter( item => item.columnName.toLowerCase() !== lockedFacet.toLowerCase())
+      const facets = data.facets?.filter(
+        item => item.columnName.toLowerCase() !== lockedFacet.toLowerCase(),
+      )
       data.facets = facets
       return data
-    } else {  // for other pages, just return the data
+    } else {
+      // for other pages, just return the data
       return this.state.data
     }
   }

--- a/src/lib/containers/Search.tsx
+++ b/src/lib/containers/Search.tsx
@@ -332,7 +332,6 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
           style={totalQueryResultsStyle}
           isLoading={isLoading!}
           frontText={'Displaying'}
-          token={this.props.token}
           lastQueryRequest={getLastQueryRequest!()}
           unitDescription={usedUnitDescription}
         />

--- a/src/lib/containers/StatisticsPlot.tsx
+++ b/src/lib/containers/StatisticsPlot.tsx
@@ -26,7 +26,6 @@ const months = [
 
 export type StatisticsPlotProps = {
   request: ProjectFilesStatisticsRequest
-  token?: string
   title?: string
   xtitle?: string
   ytitle?: string
@@ -61,8 +60,8 @@ class StatisticsPlot extends React.Component<
    * @returns data corresponding to plotly widget
    */
   fetchPlotlyData = async () => {
-    const { request, token } = this.props
-    return SynapseClient.getProjectStatistics(request, token)
+    const { request } = this.props
+    return SynapseClient.getProjectStatistics(request)
       .then((data: ProjectFilesStatisticsResponse) => {
         this.setState({
           isLoaded: true,

--- a/src/lib/containers/TotalQueryResults.tsx
+++ b/src/lib/containers/TotalQueryResults.tsx
@@ -25,7 +25,11 @@ import {
 } from './widgets/query-filter/QueryFilter'
 import { RadioValuesEnum } from './widgets/query-filter/RangeFacetFilter'
 import { useState, FunctionComponent } from 'react'
-import { QueryWrapperChildProps, QUERY_FILTERS_COLLAPSED_CSS, QUERY_FILTERS_EXPANDED_CSS } from './QueryWrapper'
+import {
+  QueryWrapperChildProps,
+  QUERY_FILTERS_COLLAPSED_CSS,
+  QUERY_FILTERS_EXPANDED_CSS,
+} from './QueryWrapper'
 import { ColumnSingleValueFilterOperator } from '../utils/synapseTypes/Table/QueryFilter'
 import { Button } from 'react-bootstrap'
 
@@ -33,7 +37,6 @@ export type TotalQueryResultsProps = {
   isLoading: boolean
   style?: React.CSSProperties
   lastQueryRequest: QueryBundleRequest
-  token: string | undefined
   unitDescription: string
   frontText: string
   applyChanges?: Function
@@ -48,7 +51,6 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
   unitDescription,
   frontText,
   lastQueryRequest,
-  token,
   isLoading: parentLoading,
   executeQueryRequest,
   getInitQueryRequest,
@@ -156,7 +158,7 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
         SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS
       if (parentLoading || total === undefined) {
         setIsLoading(true)
-        SynapseClient.getQueryTableResults(cloneLastQueryRequest, token)
+        SynapseClient.getQueryTableResults(cloneLastQueryRequest)
           .then(data => {
             setTotal(data.queryCount!)
             const rangeFacetsWithSelections = getRangeFacetsWithSelections(
@@ -187,7 +189,7 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
       }
     }
     calculateTotal()
-  }, [parentLoading, token, lastQueryRequest])
+  }, [parentLoading, lastQueryRequest])
 
   const removeFacetSelection = ({
     facet,
@@ -263,7 +265,11 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
   }
   return (
     <div
-      className={`TotalQueryResults ${showNotch ? 'notch-down' : ''} ${showFacetFilter ? QUERY_FILTERS_EXPANDED_CSS : QUERY_FILTERS_COLLAPSED_CSS}`}
+      className={`TotalQueryResults ${showNotch ? 'notch-down' : ''} ${
+        showFacetFilter
+          ? QUERY_FILTERS_EXPANDED_CSS
+          : QUERY_FILTERS_COLLAPSED_CSS
+      }`}
       style={style}
     >
       <span className="SRC-boldText SRC-text-title SRC-centerContent">
@@ -286,7 +292,11 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
         ))}
       </div>
       {facetsWithSelection.length > 0 && (
-        <Button onClick={clearAll} variant="light" className="TotalQueryResults__clearall">
+        <Button
+          onClick={clearAll}
+          variant="light"
+          className="TotalQueryResults__clearall"
+        >
           Clear All
         </Button>
       )}

--- a/src/lib/containers/Uploader.tsx
+++ b/src/lib/containers/Uploader.tsx
@@ -14,7 +14,6 @@ import {
 } from '../utils/synapseTypes/'
 
 type UploaderState = {
-  token?: string
   error?: any
   totalFilesToUploadCount: number
   filesUploadedCount: number
@@ -23,7 +22,6 @@ type UploaderState = {
 }
 
 export type UploaderProps = {
-  token?: string
   parentContainerId: string
 }
 
@@ -36,7 +34,6 @@ export default class Uploader extends React.Component<
   constructor(props: UploaderProps) {
     super(props)
     this.state = {
-      token: '',
       isUploading: false,
       filesUploadedCount: 0,
       totalFilesToUploadCount: 0,
@@ -94,10 +91,10 @@ export default class Uploader extends React.Component<
         entityName: file.name,
         parentId: this.props.parentContainerId,
       }
-      lookupChildEntity(entityLookupRequest, this.props.token)
+      lookupChildEntity(entityLookupRequest)
         .then((entityId: EntityId) => {
           // ok, found an entity of the same name.
-          getEntity<FileEntity>(this.props.token, entityId.id).then(
+          getEntity<FileEntity>(entityId.id).then(
             (existingEntity: FileEntity) => {
               if (
                 existingEntity.concreteType ===
@@ -122,12 +119,12 @@ export default class Uploader extends React.Component<
   }
 
   updateEntityFile = (fileEntity: FileEntity, file: File) => {
-    uploadFile(this.props.token, file.name, file)
+    uploadFile(file.name, file)
       .then((fileUploadComplete: FileUploadComplete) => {
         const isCreate = fileEntity.dataFileHandleId === ''
         fileEntity.dataFileHandleId = fileUploadComplete.fileHandleId
         const createOrUpdate = isCreate ? createEntity : updateEntity
-        createOrUpdate(fileEntity, this.props.token).then(() => {
+        createOrUpdate(fileEntity).then(() => {
           this.finishedProcessingOneFile()
         })
       })

--- a/src/lib/containers/UpsetPlot.tsx
+++ b/src/lib/containers/UpsetPlot.tsx
@@ -25,7 +25,6 @@ export type UpsetPlotProps = {
   height?: number
   summaryLinkText?: string // text for home page link below chart
   summaryLink?: string // url for home page link below chart
-  token?: string
 }
 
 export type UpsetPlotData = {
@@ -45,7 +44,6 @@ const UpsetPlot: React.FunctionComponent<UpsetPlotProps> = ({
   height = 700,
   summaryLinkText,
   summaryLink,
-  token,
 }) => {
   const [isLoading, setIsLoading] = useState<boolean>()
   const [data, setData] = useState<UpsetPlotData>()
@@ -75,7 +73,6 @@ const UpsetPlot: React.FunctionComponent<UpsetPlotProps> = ({
         }
         const { queryResult } = await SynapseClient.getFullQueryTableResults(
           queryRequest,
-          token,
         )
         // transform query data into plot data, and store.
         // collect all values for each key
@@ -136,7 +133,7 @@ const UpsetPlot: React.FunctionComponent<UpsetPlotProps> = ({
     return () => {
       isCancelled = true
     }
-  }, [sql, token])
+  }, [sql])
 
   return (
     <>
@@ -180,7 +177,7 @@ const UpsetPlot: React.FunctionComponent<UpsetPlotProps> = ({
           )}
         </SizeMe>
       )}
-      <ErrorBanner error={error} token={token} />
+      <ErrorBanner error={error} />
     </>
   )
 }

--- a/src/lib/containers/UserCard.tsx
+++ b/src/lib/containers/UserCard.tsx
@@ -37,8 +37,6 @@ export type UserCardProps = {
   /** The link to point to on the user name, defaults to https://www.synapse.org/#!Profile:${userProfile.ownerId} */
   link?: string
   openLinkInNewTab?: boolean
-  /** Authentication token used to retrieve data */
-  token?: string
   /** Disables the `@username` link for the small user card (if `showCardOnHover` is false). For the medium user card, disables linking the user's name to their profile (or other specified destination) */
   disableLink?: boolean
   isCertified?: boolean
@@ -58,7 +56,6 @@ export const UserCard: React.FunctionComponent<UserCardProps> = (
     size,
     ownerId,
     alias,
-    token,
     ...rest
   } = props
   const [userProfile, setUserProfile] = useState(initialProfile)
@@ -73,17 +70,15 @@ export const UserCard: React.FunctionComponent<UserCardProps> = (
       setIsLoading(false)
     } else if (alias) {
       // Before we can get the profile, we must get the principal ID using the alias
-      getPrincipalAliasRequest(token, alias, 'USER_NAME').then(
-        (aliasData: any) => {
-          setPrincipalId(aliasData.principalId)
-        },
-      )
+      getPrincipalAliasRequest(alias, 'USER_NAME').then((aliasData: any) => {
+        setPrincipalId(aliasData.principalId)
+      })
     }
-  }, [userProfile, alias, token])
+  }, [userProfile, alias])
 
   useEffect(() => {
     if (!userProfile && principalId) {
-      getUserProfileWithProfilePic(principalId, token)
+      getUserProfileWithProfilePic(principalId)
         .then(data => {
           setUserProfile(data.userProfile)
           setPresignedUrl(data.preSignedURL)
@@ -93,7 +88,7 @@ export const UserCard: React.FunctionComponent<UserCardProps> = (
           console.warn('failed to get user bundle ', err)
         })
     }
-  }, [userProfile, principalId, token])
+  }, [userProfile, principalId])
 
   function getCard(
     cardSize: UserCardSize,

--- a/src/lib/containers/UserCardListRotate.tsx
+++ b/src/lib/containers/UserCardListRotate.tsx
@@ -18,7 +18,6 @@ const DEFAULT_DISPLAY_COUNT = 3
 export type UserCardListRotateProps = {
   sql: string
   count: number
-  token?: string
   useQueryResultUserData?: boolean
   size?: UserCardSize
   summaryLink?: string
@@ -64,7 +63,6 @@ export const getDisplayIds = (
 const UserCardListRotate: React.FunctionComponent<UserCardListRotateProps> = ({
   sql,
   count,
-  token,
   useQueryResultUserData = false,
   size = LARGE_USER_CARD,
   summaryLink,
@@ -96,7 +94,6 @@ const UserCardListRotate: React.FunctionComponent<UserCardListRotateProps> = ({
 
       const queryResultBundle = await SynapseClient.getFullQueryTableResults(
         request,
-        token,
       )
       const { queryResult } = queryResultBundle
       if (queryResult.queryResults.rows) {
@@ -124,7 +121,7 @@ const UserCardListRotate: React.FunctionComponent<UserCardListRotateProps> = ({
     return () => {
       mounted = false
     }
-  }, [sql, selectedFacets, count, token])
+  }, [sql, selectedFacets, count])
 
   return (
     <div className="UserCardListRotate bootstrap-4-backport">

--- a/src/lib/containers/UserCardMedium.tsx
+++ b/src/lib/containers/UserCardMedium.tsx
@@ -50,7 +50,7 @@ export default class UserCardMedium extends React.Component<
     this.state = {
       showModal: false,
       isContextMenuOpen: false,
-      ORCIDHref: undefined
+      ORCIDHref: undefined,
     }
   }
 
@@ -89,16 +89,11 @@ export default class UserCardMedium extends React.Component<
     // PORTALS-1893: Add ORCID to medium/large card
     const { ORCIDHref } = this.state
     if (!ORCIDHref) {
-      const {
-        userProfile
-      } = this.props
-      const {
-        ownerId
-      } = userProfile
+      const { userProfile } = this.props
+      const { ownerId } = userProfile
       const bundle: UserBundle = await SynapseClient.getUserBundle(
         ownerId,
         SynapseConstants.USER_BUNDLE_MASK_ORCID,
-        undefined,
       )
       this.setState({ ORCIDHref: bundle.ORCID })
     }
@@ -257,15 +252,21 @@ export default class UserCardMedium extends React.Component<
             </p>
           )}
           {this.state.ORCIDHref && (
-              <a
+            <a
               href={this.state.ORCIDHref}
-              target='_blank'
-              rel='noopener noreferrer'
+              target="_blank"
+              rel="noopener noreferrer"
               tabIndex={0}
             >
-              <p className={isLarge
-                ? 'SRC-whiteText'
-                : 'SRC-primary-text-color SRC-primary-color-hover'}>View ORCID</p>
+              <p
+                className={
+                  isLarge
+                    ? 'SRC-whiteText'
+                    : 'SRC-primary-text-color SRC-primary-color-hover'
+                }
+              >
+                View ORCID
+              </p>
             </a>
           )}
         </div>

--- a/src/lib/containers/access_requirement_list/ACTAccessRequirement.tsx
+++ b/src/lib/containers/access_requirement_list/ACTAccessRequirement.tsx
@@ -6,7 +6,6 @@ import { AccessRequirementProps } from './AccessRequirementProps'
 
 export default function ACTAccessRequirementComponent({
   accessRequirement,
-  token,
   user,
   onHide,
   accessRequirementStatus,
@@ -18,7 +17,6 @@ export default function ACTAccessRequirementComponent({
     const getACTAccessData = async () => {
       try {
         const wikipageRequirement = await SynapseClient.getWikiPageKeyForAccessRequirement(
-          token,
           accessRequirement.id,
         )
         setWikiPage(wikipageRequirement)
@@ -28,13 +26,12 @@ export default function ACTAccessRequirementComponent({
     }
 
     getACTAccessData()
-  }, [token, accessRequirement])
+  }, [accessRequirement])
 
   return (
     <AcceptedRequirements
       accessRequirement={accessRequirement}
       accessRequirementStatus={accessRequirementStatus}
-      token={token}
       user={user}
       wikiPage={wikiPage}
       onHide={onHide}

--- a/src/lib/containers/access_requirement_list/AcceptedRequirements.tsx
+++ b/src/lib/containers/access_requirement_list/AcceptedRequirements.tsx
@@ -16,10 +16,10 @@ import {
 import { SynapseClient } from '../../utils'
 import AccessApprovalCheckMark from './AccessApprovalCheckMark'
 import { SUPPORTED_ACCESS_REQUIREMENTS } from './AccessRequirementList'
+import { isSignedIn } from '../../utils/SynapseClient'
 
 export type AcceptedRequirementsProps = {
   user: UserProfile | undefined
-  token: string | undefined
   wikiPage: WikiPageKey | undefined
   entityId: string
   accessRequirement:
@@ -34,7 +34,6 @@ export type AcceptedRequirementsProps = {
 
 export default function AcceptedRequirements({
   user,
-  token,
   wikiPage,
   accessRequirement,
   accessRequirementStatus,
@@ -95,7 +94,7 @@ export default function AcceptedRequirements({
           state: ApprovalState.APPROVED,
         }
 
-        SynapseClient.postAccessApproval(token, accessApprovalRequest)
+        SynapseClient.postAccessApproval(accessApprovalRequest)
           .then(_ => {
             setIsApproved(true)
           })
@@ -126,7 +125,6 @@ export default function AcceptedRequirements({
     markdown = (
       <div className="AcceptRequirementsMarkdown">
         <MarkdownSynapse
-          token={token}
           wikiId={wikiPage?.wikiPageId}
           ownerId={wikiPage?.ownerObjectId}
           objectType={wikiPage?.ownerObjectType}
@@ -135,17 +133,16 @@ export default function AcceptedRequirements({
     )
   } else if (isActOrTermsOfUse) {
     markdown = (
-      <MarkdownSynapse
-        markdown={isTermsOfUse ? termsOfUse : actContactInfo}
-        token={token}
-      />
+      <MarkdownSynapse markdown={isTermsOfUse ? termsOfUse : actContactInfo} />
     )
   }
 
   const isManagedActAr =
     accessRequirement.concreteType ===
-    SUPPORTED_ACCESS_REQUIREMENTS.ManagedACTAccessRequirement  
-  const approvedText = isManagedActAr ? "Your data access request has been approved." : "You have accepted the terms of use."
+    SUPPORTED_ACCESS_REQUIREMENTS.ManagedACTAccessRequirement
+  const approvedText = isManagedActAr
+    ? 'Your data access request has been approved.'
+    : 'You have accepted the terms of use.'
   return (
     <>
       <div className="requirement-container">
@@ -183,7 +180,7 @@ export default function AcceptedRequirements({
           )}
         </div>
       </div>
-      {token && showButton && (
+      {isSignedIn() && showButton && (
         <div className={`button-container ${isApproved ? `hide` : `default`}`}>
           <div className="accept-button-container">
             <button className="accept-button" onClick={onAcceptClicked}>

--- a/src/lib/containers/access_requirement_list/AccessRequirementProps.ts
+++ b/src/lib/containers/access_requirement_list/AccessRequirementProps.ts
@@ -5,7 +5,6 @@ export type AccessRequirementProps<T extends AccessRequirement> = {
   entityId: string
   accessRequirement: T
   accessRequirementStatus: AccessRequirementStatus
-  token: string | undefined
   user: UserProfile | undefined
   onHide?: Function
 }

--- a/src/lib/containers/access_requirement_list/ManagedACTAccessRequirement.tsx
+++ b/src/lib/containers/access_requirement_list/ManagedACTAccessRequirement.tsx
@@ -9,7 +9,6 @@ import { AccessRequirementProps } from './AccessRequirementProps'
 
 export default function ManagedACTAccessRequirementComponent({
   accessRequirement,
-  token,
   user,
   onHide,
   accessRequirementStatus,
@@ -21,7 +20,6 @@ export default function ManagedACTAccessRequirementComponent({
     const getManagedACTAccessData = async () => {
       try {
         const wikipageRequirement = await SynapseClient.getWikiPageKeyForAccessRequirement(
-          token,
           accessRequirement.id,
         )
         setWikiPage(wikipageRequirement)
@@ -31,14 +29,13 @@ export default function ManagedACTAccessRequirementComponent({
     }
 
     getManagedACTAccessData()
-  }, [token, accessRequirement])
+  }, [accessRequirement])
 
   return (
     <AcceptedRequirements
       accessRequirement={accessRequirement}
       accessRequirementStatus={accessRequirementStatus}
       entityId={entityId}
-      token={token}
       user={user}
       wikiPage={wikiPage}
       onHide={onHide}

--- a/src/lib/containers/access_requirement_list/SelfSignAccessRequirement.tsx
+++ b/src/lib/containers/access_requirement_list/SelfSignAccessRequirement.tsx
@@ -12,7 +12,6 @@ import { AccessRequirementProps } from './AccessRequirementProps'
 
 export default function SelfSignAccessRequirementComponent({
   accessRequirement,
-  token,
   user,
   onHide,
   accessRequirementStatus,
@@ -29,7 +28,6 @@ export default function SelfSignAccessRequirementComponent({
       try {
         setIsLoading(true)
         const wikiPageRequirment = await SynapseClient.getWikiPageKeyForAccessRequirement(
-          token,
           accessRequirement.id,
         )
 
@@ -43,7 +41,6 @@ export default function SelfSignAccessRequirementComponent({
           const bundle = await SynapseClient.getUserBundle(
             user.ownerId,
             certificationOrVerification,
-            token,
           )
           setUserBundle(bundle)
         }
@@ -55,7 +52,7 @@ export default function SelfSignAccessRequirementComponent({
     }
 
     getSelfSignAccessData()
-  }, [accessRequirement, token, user])
+  }, [accessRequirement, user])
 
   return (
     <>
@@ -111,7 +108,6 @@ export default function SelfSignAccessRequirementComponent({
       )}
       <AcceptedRequirements
         user={user}
-        token={token}
         wikiPage={wikiPage}
         accessRequirement={accessRequirement}
         accessRequirementStatus={accessRequirementStatus}

--- a/src/lib/containers/access_requirement_list/TermsOfUseAccessRequirement.tsx
+++ b/src/lib/containers/access_requirement_list/TermsOfUseAccessRequirement.tsx
@@ -10,7 +10,6 @@ import { AccessRequirementProps } from './AccessRequirementProps'
 
 export default function TermsOfUseAccessRequirementComponent({
   accessRequirement,
-  token,
   user,
   onHide,
   accessRequirementStatus,
@@ -25,7 +24,6 @@ export default function TermsOfUseAccessRequirementComponent({
 
       try {
         const wikiPageRequirement = await SynapseClient.getWikiPageKeyForAccessRequirement(
-          token,
           accessRequirement.id,
         )
         setWikiPage(wikiPageRequirement)
@@ -37,14 +35,13 @@ export default function TermsOfUseAccessRequirementComponent({
     }
 
     getTermsOfUseData()
-  }, [token, accessRequirement])
+  }, [accessRequirement])
 
   return (
     <>
       {isLoading && <span className="spinner" />}
       <AcceptedRequirements
         user={user}
-        token={token}
         wikiPage={wikiPage}
         accessRequirement={accessRequirement}
         accessRequirementStatus={accessRequirementStatus}

--- a/src/lib/containers/download_list/CreatePackage.tsx
+++ b/src/lib/containers/download_list/CreatePackage.tsx
@@ -24,7 +24,6 @@ library.add(faDownload)
 library.add(faFolder)
 
 export type CreatePackageProps = {
-  token?: string
   children?: JSX.Element
   updateDownloadList: Function
 }
@@ -51,7 +50,7 @@ export const CreatePackage = (props: CreatePackageProps) => {
   const [bulkFileDownloadResponse, setBulkFileDownloadResponse] = useState<
     BulkFileDownloadResponse | undefined
   >(undefined)
-  const { token, children, updateDownloadList } = props
+  const { children, updateDownloadList } = props
 
   const createPackageHandler = async (event: React.SyntheticEvent) => {
     event.preventDefault()
@@ -67,10 +66,7 @@ export const CreatePackage = (props: CreatePackageProps) => {
     setIsLoading(true)
     try {
       const fileNameWithZipExtension = `${fileName}.zip`
-      const downloadOrder = await getDownloadOrder(
-        fileNameWithZipExtension,
-        token,
-      )
+      const downloadOrder = await getDownloadOrder(fileNameWithZipExtension)
       const bulkFileDownloadRequest: BulkFileDownloadRequest = {
         concreteType:
           'org.sagebionetworks.repo.model.file.BulkFileDownloadRequest',
@@ -80,7 +76,6 @@ export const CreatePackage = (props: CreatePackageProps) => {
       }
       const currentBulkFileDownloadResponse: BulkFileDownloadResponse = await getBulkFiles(
         bulkFileDownloadRequest,
-        token,
       )
       setBulkFileDownloadResponse(currentBulkFileDownloadResponse)
     } catch (err) {
@@ -105,7 +100,7 @@ export const CreatePackage = (props: CreatePackageProps) => {
         className: 'SRC-primary-background-color SRC-whiteText',
         variant: undefined,
       })
-      const url = await getFileHandleByIdURL(resultZipFileHandleId, token)
+      const url = await getFileHandleByIdURL(resultZipFileHandleId)
       window.location.href = url
       updateDownloadList()
       setBulkFileDownloadResponse(undefined)

--- a/src/lib/containers/download_list/DownloadDetails.tsx
+++ b/src/lib/containers/download_list/DownloadDetails.tsx
@@ -7,6 +7,7 @@ import { calculateFriendlyFileSize } from '../../utils/functions/calculateFriend
 import ReactTooltip from 'react-tooltip'
 import moment from 'moment'
 import { TOOLTIP_DELAY_SHOW } from '../table/SynapseTableConstants'
+import { isSignedIn } from '../../utils/SynapseClient'
 
 library.add(faFile)
 library.add(faDatabase)
@@ -15,7 +16,6 @@ library.add(faClock)
 export type DownloadDetailsProps = {
   numFiles: number
   numBytes: number
-  token: string | undefined
 }
 
 type State = {
@@ -29,18 +29,18 @@ export default function DownloadDetails(props: DownloadDetailsProps) {
     downloadSpeed: 0,
   })
   const { isLoading, downloadSpeed } = state
-  const { token, numFiles, numBytes } = props
+  const { numFiles, numBytes } = props
 
   useEffect(() => {
-    if (token) {
-      testDownloadSpeed(token).then(speed => {
+    if (isSignedIn()) {
+      testDownloadSpeed().then(speed => {
         setState({
           isLoading: false,
           downloadSpeed: speed,
         })
       })
     }
-  }, [token])
+  }, [])
 
   const timeEstimateInSeconds =
     isLoading || downloadSpeed === 0 ? 0 : numBytes / downloadSpeed

--- a/src/lib/containers/download_list/ShowDownload.tsx
+++ b/src/lib/containers/download_list/ShowDownload.tsx
@@ -9,15 +9,15 @@ import { DOWNLOAD_LIST_CHANGE_EVENT } from '../../utils/functions/dispatchDownlo
 import DownloadListTable from './DownloadListTable'
 import ReactTooltip from 'react-tooltip'
 import { TOOLTIP_DELAY_SHOW } from '../table/SynapseTableConstants'
+import { isSignedIn } from '../../utils/SynapseClient'
 
 library.add(faDownload)
 
 export type ShowDownloadProps = {
-  token?: string
   to?: string
 }
 
-function ShowDownload({ token, to }: ShowDownloadProps & RouteComponentProps) {
+function ShowDownload({ to }: ShowDownloadProps & RouteComponentProps) {
   const [downloadList, setDownloadList] = useState<DownloadList | undefined>(
     undefined,
   )
@@ -25,7 +25,7 @@ function ShowDownload({ token, to }: ShowDownloadProps & RouteComponentProps) {
   const idForToolTip = 'SHOW_DOWNLOAD_TOOLTIP'
   const tooltipText = 'Click to view items in your download list.'
   useEffect(() => {
-    if (!token) {
+    if (!isSignedIn()) {
       return
     }
     const updateDownloadList = async (
@@ -35,7 +35,7 @@ function ShowDownload({ token, to }: ShowDownloadProps & RouteComponentProps) {
         setDownloadList(event.detail)
       } else {
         // for initialization
-        SynapseClient.getDownloadList(token).then((downloadList) => {
+        SynapseClient.getDownloadList().then(downloadList => {
           setDownloadList(downloadList)
         })
       }
@@ -48,9 +48,9 @@ function ShowDownload({ token, to }: ShowDownloadProps & RouteComponentProps) {
         updateDownloadList,
       )
     }
-  }, [token])
+  }, [])
 
-  if (!token) {
+  if (!isSignedIn()) {
     return <></>
   }
   const size = downloadList?.filesToDownload.length ?? 0
@@ -92,7 +92,6 @@ function ShowDownload({ token, to }: ShowDownloadProps & RouteComponentProps) {
       </button>
       {showDownloadModal && (
         <DownloadListTable
-          token={token}
           renderAsModal={true}
           onHide={() => setShowDownloadModal(false)}
         />

--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -61,7 +61,6 @@ const queryClient = new QueryClient({
 })
 
 export type EntityFinderProps = {
-  sessionToken: string
   /** Whether or not it is possible to select multiple entities */
   selectMultiple: boolean
   /** Callback invoked when the selection changes */
@@ -87,7 +86,6 @@ export type EntityFinderProps = {
 }
 
 export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
-  sessionToken,
   initialScope,
   projectId,
   initialContainer,
@@ -206,7 +204,6 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                 : undefined,
             },
           ],
-          sessionToken,
         )
           .then(response => {
             setSearchByIdResults(response.results)
@@ -216,7 +213,7 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
     } else {
       setSearchByIdResults([])
     }
-  }, [sessionToken, searchTerms, handleError])
+  }, [searchTerms, handleError])
 
   const mainPanelClass = searchActive
     ? 'MainPanelSearch'
@@ -300,7 +297,6 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
             {/* We have a separate Details component for search in order to preserve state in the other component between searches */}
             {searchActive && (
               <EntityDetailsList
-                sessionToken={sessionToken}
                 configuration={
                   searchByIdResults && searchByIdResults.length > 0
                     ? {
@@ -329,7 +325,6 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                 {treeOnly ? (
                   <div>
                     <TreeView
-                      sessionToken={sessionToken}
                       toggleSelection={toggleSelection}
                       showDropdown={true}
                       visibleTypes={selectableAndVisibleTypesInTree}
@@ -356,7 +351,6 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                             flex={0.18}
                           >
                             <TreeView
-                              sessionToken={sessionToken}
                               selectedEntities={selectedEntities}
                               setDetailsViewConfiguration={
                                 setConfigFromTreeView
@@ -374,7 +368,6 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                           <ReflexSplitter></ReflexSplitter>
                           <ReflexElement className="DetailsViewReflexElement">
                             <EntityDetailsList
-                              sessionToken={sessionToken}
                               configuration={configFromTreeView}
                               showVersionSelection={showVersionSelection}
                               selected={selectedEntities}
@@ -398,7 +391,6 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
 
           {selectedEntities.length > 0 && (
             <SelectionPane
-              sessionToken={sessionToken}
               title={selectedCopy}
               selectedEntities={selectedEntities}
               toggleSelection={toggleSelection}

--- a/src/lib/containers/entity_finder/SelectionPane.tsx
+++ b/src/lib/containers/entity_finder/SelectionPane.tsx
@@ -7,14 +7,12 @@ import { EntityTypeIcon } from '../EntityIcon'
 import { BUNDLE_REQUEST_OBJECT } from './EntityFinderUtils'
 
 export type SelectionPaneProps = {
-  sessionToken: string
   title: string
   selectedEntities: Reference[]
   toggleSelection: (entity: Reference) => void
 }
 
 export const SelectionPane: React.FC<SelectionPaneProps> = ({
-  sessionToken,
   title,
   selectedEntities,
   toggleSelection,
@@ -30,7 +28,6 @@ export const SelectionPane: React.FC<SelectionPaneProps> = ({
             }`}
           >
             <EntityPathDisplay
-              sessionToken={sessionToken}
               entity={e}
               toggleSelection={toggleSelection}
             ></EntityPathDisplay>
@@ -42,14 +39,12 @@ export const SelectionPane: React.FC<SelectionPaneProps> = ({
 }
 
 const EntityPathDisplay: React.FunctionComponent<{
-  sessionToken: string
   entity: Reference
   toggleSelection: (entity: Reference) => void
-}> = ({ sessionToken, entity, toggleSelection }) => {
+}> = ({ entity, toggleSelection }) => {
   const ENTITY_PATH_TOOLTIP_ID = `EntityPathDisplayReactTooltip_${entity.targetId}`
 
   const { data: bundle } = useGetEntityBundle(
-    sessionToken,
     entity.targetId,
     BUNDLE_REQUEST_OBJECT,
     entity.targetVersionNumber,

--- a/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
+++ b/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
@@ -40,7 +40,6 @@ export type EntityDetailsListDataConfiguration = {
  * We collect them into this type to simplify passing them through to the view.
  */
 export type EntityDetailsListSharedProps = {
-  sessionToken: string
   showVersionSelection: boolean
   selectColumnType: 'checkbox' | 'none'
   visibleTypes: EntityType[]

--- a/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
@@ -11,7 +11,6 @@ type EntityChildrenDetailsProps = EntityDetailsListSharedProps & {
 }
 
 export const EntityChildrenDetails: React.FunctionComponent<EntityChildrenDetailsProps> = ({
-  sessionToken,
   parentContainerId,
   visibleTypes: includeTypes,
   showVersionSelection,
@@ -32,7 +31,7 @@ export const EntityChildrenDetails: React.FunctionComponent<EntityChildrenDetail
     fetchNextPage,
     isError,
     error,
-  } = useGetEntityChildrenInfinite(sessionToken, {
+  } = useGetEntityChildrenInfinite({
     parentId: parentContainerId,
     includeTypes: includeTypes,
     sortBy: sortBy,
@@ -47,7 +46,6 @@ export const EntityChildrenDetails: React.FunctionComponent<EntityChildrenDetail
 
   return (
     <DetailsView
-      sessionToken={sessionToken}
       entities={
         data
           ? ([] as EntityHeader[]).concat.apply(

--- a/src/lib/containers/entity_finder/details/configurations/FavoritesDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/FavoritesDetails.tsx
@@ -8,7 +8,6 @@ import { DetailsView } from '../view/DetailsView'
 type FavoritesDetailsProps = EntityDetailsListSharedProps
 
 export const FavoritesDetails: React.FunctionComponent<FavoritesDetailsProps> = ({
-  sessionToken,
   showVersionSelection,
   selectColumnType,
   selected,
@@ -16,9 +15,7 @@ export const FavoritesDetails: React.FunctionComponent<FavoritesDetailsProps> = 
   selectableTypes,
   toggleSelection,
 }) => {
-  const { data, status, isFetching, isError, error } = useGetFavorites(
-    sessionToken,
-  )
+  const { data, status, isFetching, isError, error } = useGetFavorites()
   const handleError = useErrorHandler()
 
   useEffect(() => {
@@ -29,7 +26,6 @@ export const FavoritesDetails: React.FunctionComponent<FavoritesDetailsProps> = 
 
   return (
     <DetailsView
-      sessionToken={sessionToken}
       entities={data ? data.results : []}
       queryStatus={status}
       queryIsFetching={isFetching}

--- a/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
@@ -12,7 +12,6 @@ type ProjectListDetailsProps = EntityDetailsListSharedProps & {
 }
 
 export const ProjectListDetails: React.FunctionComponent<ProjectListDetailsProps> = ({
-  sessionToken,
   projectsParams,
   showVersionSelection,
   selectColumnType,
@@ -29,7 +28,7 @@ export const ProjectListDetails: React.FunctionComponent<ProjectListDetailsProps
     fetchNextPage,
     isError,
     error,
-  } = useGetProjectsInfinite(sessionToken, projectsParams)
+  } = useGetProjectsInfinite(projectsParams)
   const handleError = useErrorHandler()
 
   useEffect(() => {
@@ -40,7 +39,6 @@ export const ProjectListDetails: React.FunctionComponent<ProjectListDetailsProps
 
   return (
     <DetailsView
-      sessionToken={sessionToken}
       entities={
         data
           ? ([] as ProjectHeader[]).concat.apply(

--- a/src/lib/containers/entity_finder/details/configurations/SearchDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/SearchDetails.tsx
@@ -11,7 +11,6 @@ type SearchDetailsProps = EntityDetailsListSharedProps & {
 }
 
 export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
-  sessionToken,
   searchQuery,
   showVersionSelection,
   selectColumnType,
@@ -28,7 +27,7 @@ export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
     fetchNextPage,
     error,
     isError,
-  } = useSearchInfinite(searchQuery, sessionToken, {
+  } = useSearchInfinite(searchQuery, {
     enabled: !!searchQuery.queryTerm,
   })
   const handleError = useErrorHandler()
@@ -42,7 +41,6 @@ export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
   if (searchQuery.queryTerm) {
     return (
       <DetailsView
-        sessionToken={sessionToken}
         entities={
           data
             ? ([] as Hit[]).concat.apply(
@@ -78,7 +76,6 @@ export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
   } else {
     return (
       <DetailsView
-        sessionToken={sessionToken}
         entities={[]}
         queryStatus={'success'}
         queryIsFetching={false}

--- a/src/lib/containers/entity_finder/details/view/DetailsView.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsView.tsx
@@ -43,7 +43,6 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
   queryIsFetching,
   hasNextPage,
   fetchNextPage,
-  sessionToken,
   showVersionSelection,
   selectColumnType,
   selected,
@@ -168,7 +167,6 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
             return (
               <DetailsViewRow
                 key={entity.id}
-                sessionToken={sessionToken}
                 entityHeader={entity}
                 appearance={determineRowAppearance(entity)}
                 selectedVersion={

--- a/src/lib/containers/entity_finder/details/view/DetailsViewRow.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsViewRow.tsx
@@ -33,7 +33,6 @@ export type DetailsViewRowAppearance =
   | 'hidden'
 
 export type DetailsViewRowProps = {
-  sessionToken: string
   entityHeader: EntityHeader | ProjectHeader | Hit
   appearance: DetailsViewRowAppearance
   showVersionColumn: boolean
@@ -43,7 +42,6 @@ export type DetailsViewRowProps = {
 }
 
 export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
-  sessionToken,
   entityHeader,
   appearance,
   showVersionColumn,
@@ -70,7 +68,6 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
   )
 
   const { data: bundle, isError, error } = useGetEntityBundle(
-    sessionToken,
     entityHeader.id,
     BUNDLE_REQUEST_OBJECT,
     undefined,
@@ -84,7 +81,6 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
 
   const { data: modifiedByUserProfile } = useGetUserProfileWithProfilePic(
     bundle?.entity?.modifiedBy ?? '273950',
-    sessionToken,
     {
       enabled: !!bundle,
       staleTime: 60 * 1000, // 60 seconds
@@ -99,7 +95,7 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
 
   useEffect(() => {
     if (isSelected && versions === undefined) {
-      SynapseClient.getEntityVersions(sessionToken, entityHeader.id).then(
+      SynapseClient.getEntityVersions(entityHeader.id).then(
         response => {
           setVersions(response.results)
         },
@@ -108,7 +104,7 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
         },
       )
     }
-  }, [isSelected, versions, sessionToken, entityHeader.id, handleError])
+  }, [isSelected, versions, entityHeader.id, handleError])
 
   return (
     <tr

--- a/src/lib/containers/entity_finder/tree/TreeNode.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeNode.tsx
@@ -28,7 +28,6 @@ export enum NodeAppearance {
 }
 
 export type TreeNodeProps = {
-  sessionToken: string
   entityHeader?: EntityHeader | ProjectHeader
   selected: Reference[]
   setSelectedId: (entityId: string) => void
@@ -42,7 +41,6 @@ export type TreeNodeProps = {
 }
 
 export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
-  sessionToken,
   entityHeader,
   selected,
   setSelectedId,
@@ -88,7 +86,6 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
     hasNextPage,
     isSuccess,
   } = useGetEntityChildrenInfinite(
-    sessionToken,
     {
       parentId: nodeId,
       includeTypes: visibleTypes,
@@ -102,7 +99,6 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
   )
 
   const { data: bundle } = useGetEntityBundle(
-    sessionToken,
     nodeId,
     BUNDLE_REQUEST_OBJECT,
     undefined,
@@ -200,7 +196,6 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
             return (
               <TreeNode
                 key={child.id}
-                sessionToken={sessionToken}
                 entityHeader={child}
                 selected={selected}
                 setSelectedId={setSelectedId}

--- a/src/lib/containers/entity_finder/tree/TreeView.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeView.tsx
@@ -51,7 +51,6 @@ function getScopeOptionNodeName(scope: FinderScope): string {
 }
 // if the first item is selected (matching the dropdown), then output a configuration. otherwise, output a synId
 export type TreeViewProps = {
-  sessionToken: string
   initialScope?: FinderScope
   /** To show the current project, projectId must be defined */
   projectId?: string
@@ -77,7 +76,6 @@ export type TreeViewProps = {
  * The tree view currently can only be used to drive a DetailsView using the `setDetailsViewConfiguration` property.
  */
 export const TreeView: React.FunctionComponent<TreeViewProps> = ({
-  sessionToken,
   initialScope = FinderScope.CURRENT_PROJECT,
   projectId,
   initialContainer = null,
@@ -144,7 +142,6 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
     hasNextPage: hasNextPageProjects,
     isLoading: isLoadingProjects,
   } = useGetProjectsInfinite(
-    sessionToken,
     scope === FinderScope.CREATED_BY_ME ? { filter: 'CREATED' } : {},
     {
       enabled: useProjectData,
@@ -154,15 +151,9 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
   const {
     data: currentContainerBundle,
     isSuccess: isSuccessBundle,
-  } = useGetEntityBundle(
-    sessionToken,
-    currentContainer!,
-    BUNDLE_REQUEST_OBJECT,
-    undefined,
-    {
-      enabled: !!currentContainer && currentContainer !== 'root',
-    },
-  )
+  } = useGetEntityBundle(currentContainer!, BUNDLE_REQUEST_OBJECT, undefined, {
+    enabled: !!currentContainer && currentContainer !== 'root',
+  })
 
   const { ref, inView } = useInView({ rootMargin: '500px' })
 
@@ -202,7 +193,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
         // See the useGetProjectsInfinite hook
         break
       case FinderScope.FAVORITES: {
-        SynapseClient.getUserFavorites(sessionToken).then(({ results }) => {
+        SynapseClient.getUserFavorites().then(({ results }) => {
           // TODO: https://sagebionetworks.jira.com/browse/PLFM-6652
           results = results.filter(result =>
             visibleTypes.includes(convertToEntityType(result.type)),
@@ -215,7 +206,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
       case FinderScope.CURRENT_PROJECT:
         if (projectId) {
           if (initialContainer?.match(SYNAPSE_ENTITY_ID_REGEX)) {
-            SynapseClient.getEntityPath(sessionToken, initialContainer)
+            SynapseClient.getEntityPath(initialContainer)
               .then(path => {
                 if (!path.path.map(entity => entity.id).includes(projectId)) {
                   handleError(
@@ -230,7 +221,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
               })
               .catch(e => handleError(e))
           } else {
-            SynapseClient.getEntityHeader(projectId, sessionToken)
+            SynapseClient.getEntityHeader(projectId)
               .then(header => {
                 setTopLevelEntities([header])
                 setIsLoading(false)
@@ -249,7 +240,6 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
         handleError(new Error('No scope selected'))
     }
   }, [
-    sessionToken,
     scope,
     initialContainer,
     handleError,
@@ -414,7 +404,6 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
           {showScopeAsRootNode ? (
             <TreeNode
               level={0}
-              sessionToken={sessionToken}
               selected={selected}
               setSelectedId={setSelectedId}
               visibleTypes={visibleTypes}
@@ -428,7 +417,6 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
               <TreeNode
                 key={entity.id}
                 level={0}
-                sessionToken={sessionToken}
                 selected={selected}
                 setSelectedId={setSelectedId}
                 visibleTypes={visibleTypes}

--- a/src/lib/containers/evaluation_queues/CreatedOnByUserDiv.tsx
+++ b/src/lib/containers/evaluation_queues/CreatedOnByUserDiv.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 export type CreatedOnByUserDivProps = {
   userId: string
   date: Date
-  sessionToken: string
   utc: boolean
 }
 
@@ -15,7 +14,6 @@ const dateFormatOptionUTC = { timeZone: 'UTC', timeZoneName: 'short' }
 export const CreatedOnByUserDiv: React.FunctionComponent<CreatedOnByUserDivProps> = ({
   userId,
   date,
-  sessionToken,
   utc,
 }) => {
   return (
@@ -30,11 +28,7 @@ export const CreatedOnByUserDiv: React.FunctionComponent<CreatedOnByUserDivProps
           .replace(',', '')}{' '}
         by{' '}
       </span>
-      <UserCard
-        token={sessionToken}
-        size={SynapseConstants.SMALL_USER_CARD}
-        ownerId={userId}
-      />
+      <UserCard size={SynapseConstants.SMALL_USER_CARD} ownerId={userId} />
     </div>
   )
 }

--- a/src/lib/containers/evaluation_queues/EvaluationCard.tsx
+++ b/src/lib/containers/evaluation_queues/EvaluationCard.tsx
@@ -22,8 +22,6 @@ export type ExistingEvaluation = RequiredProperties<
 export type EvaluationCardProps = {
   /** properties of the Evaluation to show*/
   evaluation: ExistingEvaluation
-  /** session token to make authenticated API calls */
-  sessionToken: string
   /** If true, dates for start/end are displayed in UTC instead of local time*/
   utc: boolean
   /** Callback when the Edit option in the dropdown is clicked*/
@@ -47,7 +45,6 @@ export type EvaluationCardProps = {
  */
 export const EvaluationCard: React.FunctionComponent<EvaluationCardProps> = ({
   evaluation,
-  sessionToken,
   utc,
   onEdit,
   onModifyAccess,
@@ -61,18 +58,16 @@ export const EvaluationCard: React.FunctionComponent<EvaluationCardProps> = ({
     //clear error
     setError(undefined)
 
-    getEvaluationPermissions(evaluation.id, sessionToken)
+    getEvaluationPermissions(evaluation.id)
       .then(retrievedPermissions => {
         setPermissions(retrievedPermissions)
       })
       .catch(error => setError(error))
-  }, [evaluation, sessionToken])
+  }, [evaluation])
 
   const onDelete = () => {
     setError(undefined)
-    deleteEvaluation(evaluation.id, sessionToken)
-      .then(onDeleteSuccess)
-      .catch(setError)
+    deleteEvaluation(evaluation.id).then(onDeleteSuccess).catch(setError)
   }
 
   return (
@@ -108,7 +103,6 @@ export const EvaluationCard: React.FunctionComponent<EvaluationCardProps> = ({
               <CreatedOnByUserDiv
                 userId={evaluation.ownerId}
                 date={new Date(evaluation.createdOn)}
-                sessionToken={sessionToken}
                 utc={utc}
               />
               {permissions?.canSubmit && (

--- a/src/lib/containers/evaluation_queues/EvaluationEditor.tsx
+++ b/src/lib/containers/evaluation_queues/EvaluationEditor.tsx
@@ -15,8 +15,6 @@ import { CreatedOnByUserDiv } from './CreatedOnByUserDiv'
 import WarningModal from '../synapse_form_wrapper/WarningModal'
 
 export type EvaluationEditorProps = {
-  /** session token to make authenticated API calls */
-  readonly sessionToken: string
   /** Use if UPDATING an existing Evaluation. Id of the evaluation to edit */
   readonly evaluationId?: string
   /** Use if CREATING a new Evaluation. Id of the Entity that will be associated with the Evaluation */
@@ -33,7 +31,6 @@ export type EvaluationEditorProps = {
  * Edits basic properties of an Evaluation
  */
 export const EvaluationEditor: React.FunctionComponent<EvaluationEditorProps> = ({
-  sessionToken,
   evaluationId,
   entityId,
   utc,
@@ -82,13 +79,13 @@ export const EvaluationEditor: React.FunctionComponent<EvaluationEditorProps> = 
     if (evaluationId) {
       //clear error
       setError(undefined)
-      getEvaluation(evaluationId, sessionToken)
+      getEvaluation(evaluationId)
         .then(retrievedEvaluation => {
           setEvaluation(retrievedEvaluation)
         })
         .catch(error => setError(error))
     }
-  }, [evaluationId, sessionToken])
+  }, [evaluationId])
 
   const onSave = () => {
     // clear out error
@@ -103,8 +100,8 @@ export const EvaluationEditor: React.FunctionComponent<EvaluationEditorProps> = 
     }
 
     const promise = newOrUpdatedEvaluation.id
-      ? updateEvaluation(newOrUpdatedEvaluation, sessionToken)
-      : createEvaluation(newOrUpdatedEvaluation, sessionToken)
+      ? updateEvaluation(newOrUpdatedEvaluation)
+      : createEvaluation(newOrUpdatedEvaluation)
 
     promise
       .then(evaluation => {
@@ -121,7 +118,7 @@ export const EvaluationEditor: React.FunctionComponent<EvaluationEditorProps> = 
   const onDelete = evaluation?.id
     ? () => {
         setError(undefined)
-        deleteEvaluation(evaluation.id!, sessionToken)
+        deleteEvaluation(evaluation.id!)
           .then(onDeleteSuccess)
           .catch(error => setError(error))
       }
@@ -182,11 +179,10 @@ export const EvaluationEditor: React.FunctionComponent<EvaluationEditorProps> = 
             <CreatedOnByUserDiv
               userId={evaluation.ownerId!}
               date={new Date(evaluation.createdOn)}
-              sessionToken={sessionToken}
               utc={utc}
             />
           )}
-          {error && <ErrorBanner error={error} token={sessionToken} />}
+          {error && <ErrorBanner error={error}/>}
           {showSaveSuccess && (
             <Alert
               className="save-success-alert"

--- a/src/lib/containers/evaluation_queues/EvaluationEditorPage.tsx
+++ b/src/lib/containers/evaluation_queues/EvaluationEditorPage.tsx
@@ -4,8 +4,6 @@ import { EvaluationRoundEditorList } from './EvaluationRoundEditorList'
 import { Alert, Button } from 'react-bootstrap'
 
 export type EvaluationEditorPageProps = {
-  /** session token to make authenticated API calls */
-  readonly sessionToken: string
   /** Use if UPDATING an existing Evaluation. Id of the evaluation to edit */
   readonly evaluationId?: string
   /** Use if CREATING a new Evaluation. Id of the Entity that will be associated with the Evaluation */
@@ -20,7 +18,6 @@ export type EvaluationEditorPageProps = {
  * Combined editor that allows editing an Evaluation's data and also it's associated rounds (once the Evaluation exists on Synapse)
  */
 export const EvaluationEditorPage: React.FunctionComponent<EvaluationEditorPageProps> = ({
-  sessionToken,
   evaluationId,
   entityId,
   utc,
@@ -32,7 +29,6 @@ export const EvaluationEditorPage: React.FunctionComponent<EvaluationEditorPageP
   return (
     <div className="bootstrap-4-backport">
       <EvaluationEditor
-        sessionToken={sessionToken}
         evaluationId={savedEvaluationId}
         //do not use entityId if we already have the evaluation Id
         entityId={savedEvaluationId ? undefined : entityId}
@@ -44,7 +40,6 @@ export const EvaluationEditorPage: React.FunctionComponent<EvaluationEditorPageP
       <div className="mt-4">
         {savedEvaluationId ? (
           <EvaluationRoundEditorList
-            sessionToken={sessionToken}
             evaluationId={savedEvaluationId}
             utc={utc}
           />

--- a/src/lib/containers/evaluation_queues/EvaluationRoundEditor.tsx
+++ b/src/lib/containers/evaluation_queues/EvaluationRoundEditor.tsx
@@ -32,7 +32,6 @@ import { ErrorBanner } from '../ErrorBanner'
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 
 export type EvaluationRoundEditorProps = {
-  sessionToken: string
   evaluationRoundInput: EvaluationRoundInput
   //If true, dates for start/end are displayed in UTC instead of local time
   utc: boolean
@@ -123,7 +122,6 @@ const convertInputsToEvaluationRound = (
 }
 
 export const EvaluationRoundEditor: React.FunctionComponent<EvaluationRoundEditorProps> = ({
-  sessionToken,
   evaluationRoundInput,
   onSave,
   onDelete,
@@ -191,8 +189,8 @@ export const EvaluationRoundEditor: React.FunctionComponent<EvaluationRoundEdito
     }
     if (evaluationRound) {
       const promise = evaluationRound.id
-        ? updateEvaluationRound(evaluationRound, sessionToken)
-        : createEvaluationRound(evaluationRound, sessionToken)
+        ? updateEvaluationRound(evaluationRound)
+        : createEvaluationRound(evaluationRound)
 
       promise
         .then(createdOrUpdatedRound => {
@@ -214,7 +212,6 @@ export const EvaluationRoundEditor: React.FunctionComponent<EvaluationRoundEdito
       deleteEvaluationRound(
         evaluationRoundInput.evaluationId,
         evaluationRoundInput.id,
-        sessionToken,
       )
         .then(() => onDelete())
         .catch(error => setError(error))
@@ -335,7 +332,7 @@ export const EvaluationRoundEditor: React.FunctionComponent<EvaluationRoundEdito
             {error && (
               <Row className="my-3">
                 <Col>
-                  <ErrorBanner error={error} token={sessionToken} />
+                  <ErrorBanner error={error} />
                 </Col>
               </Row>
             )}

--- a/src/lib/containers/evaluation_queues/EvaluationRoundEditorList.tsx
+++ b/src/lib/containers/evaluation_queues/EvaluationRoundEditorList.tsx
@@ -15,8 +15,6 @@ import { EvaluationRoundListResponse } from '../../utils/synapseTypes/Evaluation
 import { ErrorBanner } from '../ErrorBanner'
 
 export type EvaluationRoundEditorListProps = {
-  /** session token to make authenticated API calls */
-  sessionToken: string
   /** id of the Evaluation containing EvaluationRounds to edit*/
   evaluationId: string
   /** If true, dates for start/end are displayed in UTC instead of local time*/
@@ -25,18 +23,13 @@ export type EvaluationRoundEditorListProps = {
 
 const fetchEvaluationList = (
   evaluationId: string,
-  sessionToken: string,
   setListCallback: (items: EvaluationRoundInput[]) => void,
   errorHandleCallback: (error: string | SynapseClientError | undefined) => void,
 ): void => {
   const allEvaluationRoundInputList: EvaluationRoundInput[] = []
 
   const getEvaluationRounds = (nextPageToken?: string) => {
-    getEvaluationRoundsList(
-      evaluationId,
-      { nextPageToken: nextPageToken },
-      sessionToken,
-    )
+    getEvaluationRoundsList(evaluationId, { nextPageToken: nextPageToken })
       .then((response: EvaluationRoundListResponse) => {
         const convertedToInput: EvaluationRoundInput[] = response.page.map(
           evaluationRound => convertEvaluationRoundToInput(evaluationRound),
@@ -65,7 +58,6 @@ const fetchEvaluationList = (
  * Edits EvaluationsRounds for an Evaluation.
  */
 export const EvaluationRoundEditorList: React.FunctionComponent<EvaluationRoundEditorListProps> = ({
-  sessionToken,
   evaluationId,
   utc,
 }: EvaluationRoundEditorListProps) => {
@@ -82,21 +74,16 @@ export const EvaluationRoundEditorList: React.FunctionComponent<EvaluationRoundE
   //run only once
   useEffect(
     () => {
-      fetchEvaluationList(
-        evaluationId,
-        sessionToken,
-        setEvaluationRoundInputList,
-        setError,
-      )
+      fetchEvaluationList(evaluationId, setEvaluationRoundInputList, setError)
     },
     // we explicitly dont want to list setEvaluationRoundInputList nor setError as a dependency
     // if we do, the fetchEvaluationList will re-fetch from the backend on every new render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [sessionToken, evaluationId],
+    [evaluationId],
   )
 
   if (error) {
-    return <ErrorBanner error={error} token={sessionToken} />
+    return <ErrorBanner error={error} />
   }
 
   return (
@@ -105,7 +92,6 @@ export const EvaluationRoundEditorList: React.FunctionComponent<EvaluationRoundE
         {evaluationRoundInputList.map((evaluationRoundInput, index) => {
           return (
             <EvaluationRoundEditor
-              sessionToken={sessionToken}
               key={evaluationRoundInput.reactListKey}
               evaluationRoundInput={evaluationRoundInput}
               onSave={handleEvaluationRoundInputListChange(index)}

--- a/src/lib/containers/home_page/featured-data/FacetPlotsCard.tsx
+++ b/src/lib/containers/home_page/featured-data/FacetPlotsCard.tsx
@@ -60,7 +60,6 @@ const FacetPlotsCard: React.FunctionComponent<FacetPlotsCardProps> = ({
   data,
   isLoading,
   facetAliases,
-  token,
 }: FacetPlotsCardProps): JSX.Element => {
   const [facetPlotDataArray, setFacetPlotDataArray] = useState<GraphData[]>([])
   const [facetDataArray, setFacetDataArray] = useState<FacetColumnResult[]>([])
@@ -87,7 +86,6 @@ const FacetPlotsCard: React.FunctionComponent<FacetPlotsCardProps> = ({
             getColumnType(item),
             index + 1, //individual plot rgbIndex
             'PIE',
-            token,
           )
           return plotData
         }),

--- a/src/lib/containers/home_page/featured-data/QueryPerFacetPlotsCard.tsx
+++ b/src/lib/containers/home_page/featured-data/QueryPerFacetPlotsCard.tsx
@@ -7,7 +7,6 @@ import { ErrorBanner } from '../../ErrorBanner'
 import FacetPlotsCard from './FacetPlotsCard'
 
 export type QueryPerFacetPlotsCardProps = {
-  token?: string
   title?: string
   description?: string
   rgbIndex?: number
@@ -57,7 +56,6 @@ const QueryPerFacetPlotsCard: React.FunctionComponent<QueryPerFacetPlotsCardProp
     selectFacetColumnName,
     selectFacetColumnValue,
     detailsPagePath,
-    token,
     ...rest
   } = props
   const initQueryRequest: QueryBundleRequest = getQueryRequest(
@@ -67,7 +65,7 @@ const QueryPerFacetPlotsCard: React.FunctionComponent<QueryPerFacetPlotsCardProp
   )
   return (
     <div className="QueryPerFacetPlotsCard">
-      <QueryWrapper {...rest} token={token} initQueryRequest={initQueryRequest}>
+      <QueryWrapper {...rest} initQueryRequest={initQueryRequest}>
         <ErrorBanner />
         <FacetPlotsCard
           title={title}

--- a/src/lib/containers/home_page/featured-data/SingleQueryFacetPlotsCards.tsx
+++ b/src/lib/containers/home_page/featured-data/SingleQueryFacetPlotsCards.tsx
@@ -7,7 +7,6 @@ import { ErrorBanner } from '../../ErrorBanner'
 import FacetPlotsCard from './FacetPlotsCard'
 
 export type SingleQueryFacetPlotsCardsProps = {
-  token?: string
   rgbIndex?: number
   facetsToPlot?: string[]
   facetAliases?: {}
@@ -31,15 +30,19 @@ export function getQueryRequest(sql: string): QueryBundleRequest {
   }
 }
 const SingleQueryFacetPlotsCards: React.FunctionComponent<SingleQueryFacetPlotsCardsProps> = props => {
-  const { sql, facetsToPlot, rgbIndex, token, ...rest } = props
+  const { sql, facetsToPlot, rgbIndex, ...rest } = props
   const initQueryRequest: QueryBundleRequest = getQueryRequest(sql!)
   return (
     <div className="SingleQueryFacetPlotsCards">
-      <QueryWrapper {...rest} token={token} initQueryRequest={initQueryRequest}>
+      <QueryWrapper {...rest} initQueryRequest={initQueryRequest}>
         <ErrorBanner />
         {facetsToPlot?.map(facetName => {
           return (
-            <FacetPlotsCard key={`FacetPlotCard-${facetName}`} facetsToPlot={[facetName]} rgbIndex={rgbIndex} />
+            <FacetPlotsCard
+              key={`FacetPlotCard-${facetName}`}
+              facetsToPlot={[facetName]}
+              rgbIndex={rgbIndex}
+            />
           )
         })}
       </QueryWrapper>

--- a/src/lib/containers/home_page/goals/Goals.Desktop.tsx
+++ b/src/lib/containers/home_page/goals/Goals.Desktop.tsx
@@ -9,7 +9,6 @@ export default function GoalsDesktop({
   summary,
   countSql,
   title,
-  token,
 }: GoalsDataProps) {
   return (
     <div className="Goals__Card bootstrap-4-backport">
@@ -21,7 +20,7 @@ export default function GoalsDesktop({
           <span className="Goals__Card__header__title"> {title} </span>
           {countSql && (
             <span className="Goals__Card__header__count">
-              <QueryCount parens={false} sql={countSql} token={token} name="" />
+              <QueryCount parens={false} sql={countSql} name="" />
             </span>
           )}
         </p>

--- a/src/lib/containers/home_page/goals/Goals.Mobile.tsx
+++ b/src/lib/containers/home_page/goals/Goals.Mobile.tsx
@@ -9,13 +9,12 @@ export default function GoalsMobile({
   summary,
   countSql,
   title,
-  token,
 }: GoalsDataProps) {
   const titleElement = (
     <div className="Goals__Mobile__Header">
       {countSql && (
         <span className="Goals__Mobile__Header__Count">
-          <QueryCount parens={false} sql={countSql} token={token} name="" />
+          <QueryCount parens={false} sql={countSql} name="" />
         </span>
       )}
       <span className="Goals__Mobile__Header__Title"> {title} </span>

--- a/src/lib/containers/home_page/goals/Goals.tsx
+++ b/src/lib/containers/home_page/goals/Goals.tsx
@@ -17,7 +17,6 @@ import { withQueryClientProvider } from '../../../utils/hooks/SynapseAPI/QueryCl
 
 export type GoalsProps = {
   entityId: string
-  token?: string
 }
 
 export type GoalsDataProps = {
@@ -26,7 +25,6 @@ export type GoalsDataProps = {
   summary: string
   link: string
   asset: string
-  token?: string
 }
 
 enum ExpectedColumns {
@@ -40,7 +38,7 @@ enum ExpectedColumns {
 
 export const Goals: React.FC<GoalsProps> = withQueryClientProvider(
   (props: GoalsProps) => {
-    const { entityId, token } = props
+    const { entityId } = props
     const [assets, setAssets] = useState<string[] | undefined>()
     const [error, setError] = useState<
       string | SynapseClientError | undefined
@@ -58,7 +56,6 @@ export const Goals: React.FC<GoalsProps> = withQueryClientProvider(
     }
     const { data: queryResultBundle } = useGetQueryResultBundle(
       queryBundleRequest,
-      token,
     )
 
     useEffect(() => {
@@ -91,7 +88,7 @@ export const Goals: React.FC<GoalsProps> = withQueryClientProvider(
             includePreviewPreSignedURLs: false,
             requestedFiles: fileHandleAssociationList,
           }
-          const files = await getFiles(batchFileRequest, token)
+          const files = await getFiles(batchFileRequest)
           setError(undefined)
           setAssets(
             files.requestedFiles
@@ -104,7 +101,7 @@ export const Goals: React.FC<GoalsProps> = withQueryClientProvider(
         }
       }
       getData()
-    }, [entityId, token, queryResultBundle])
+    }, [entityId, queryResultBundle])
 
     const tableIdColumnIndex = getFieldIndex(
       ExpectedColumns.TABLEID,
@@ -130,7 +127,7 @@ export const Goals: React.FC<GoalsProps> = withQueryClientProvider(
 
     return (
       <div className={`Goals${showDesktop ? '__Desktop' : ''}`}>
-        {error && <ErrorBanner error={error} token={token} />}
+        {error && <ErrorBanner error={error} />}
         {queryResultBundle?.queryResult.queryResults.rows.map((el, index) => {
           const values = el.values
           const tableId =
@@ -153,7 +150,6 @@ export const Goals: React.FC<GoalsProps> = withQueryClientProvider(
             summary,
             link,
             asset,
-            token,
           }
           return showDesktop ? (
             <GoalsDesktop {...goalsDataProps} />

--- a/src/lib/containers/home_page/project_view_carousel/ProjectViewCarousel.tsx
+++ b/src/lib/containers/home_page/project_view_carousel/ProjectViewCarousel.tsx
@@ -9,7 +9,6 @@ import { ErrorBanner } from '../../ErrorBanner'
 import { withQueryClientProvider } from '../../../utils/hooks/SynapseAPI/QueryClientProviderWrapper'
 
 export type ProjectViewCarouselProps = {
-  token?: string
   entityId: string
 }
 
@@ -35,7 +34,7 @@ enum ExpectedColumns {
  * be an attachment on the project's root wiki page.
  */
 export const ProjectViewCarousel: React.FunctionComponent<ProjectViewCarouselProps> = withQueryClientProvider(
-  ({ token, entityId }) => {
+  ({ entityId }) => {
     const queryBundleRequest: QueryBundleRequest = {
       concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
       entityId,
@@ -53,7 +52,7 @@ export const ProjectViewCarousel: React.FunctionComponent<ProjectViewCarouselPro
       data: queryResultBundle,
       error: queryError,
       isLoading,
-    } = useGetQueryResultBundle(queryBundleRequest, token)
+    } = useGetQueryResultBundle(queryBundleRequest)
 
     useEffect(() => {
       const getData = async () => {
@@ -102,12 +101,10 @@ export const ProjectViewCarousel: React.FunctionComponent<ProjectViewCarouselPro
             try {
               if (project.imageFileName) {
                 const wikiPageKey = await SynapseClient.getWikiPageKeyForEntity(
-                  token,
                   project.entityId,
                 )
 
                 project.imageUrl = await SynapseClient.getPresignedUrlForWikiAttachment(
-                  token,
                   project.entityId,
                   wikiPageKey.wikiPageId,
                   project.imageFileName!,
@@ -127,7 +124,7 @@ export const ProjectViewCarousel: React.FunctionComponent<ProjectViewCarouselPro
         }
       }
       getData()
-    }, [entityId, token, queryResultBundle, queryError])
+    }, [entityId, queryResultBundle, queryError])
 
     return error ? (
       <ErrorBanner error={error}></ErrorBanner>

--- a/src/lib/containers/home_page/resources/Resources.Desktop.tsx
+++ b/src/lib/containers/home_page/resources/Resources.Desktop.tsx
@@ -4,13 +4,9 @@ import MarkdownSynapse from '../../MarkdownSynapse'
 
 export type ResourcesDesktopProps = {
   data: Data
-  token?: string
 }
 
-export default function ResourcesDesktop({
-  data,
-  token,
-}: ResourcesDesktopProps) {
+export default function ResourcesDesktop({ data }: ResourcesDesktopProps) {
   const [index, setIndex] = useState(0)
   return (
     <div className="control-container">
@@ -37,11 +33,7 @@ export default function ResourcesDesktop({
           const { ownerId, wikiId } = el
           return (
             <span key={ownerId} className={index === curIndex ? '' : 'hide'}>
-              <MarkdownSynapse
-                token={token}
-                ownerId={ownerId}
-                wikiId={wikiId}
-              />
+              <MarkdownSynapse ownerId={ownerId} wikiId={wikiId} />
             </span>
           )
         })}

--- a/src/lib/containers/home_page/resources/Resources.Mobile.tsx
+++ b/src/lib/containers/home_page/resources/Resources.Mobile.tsx
@@ -5,18 +5,17 @@ import ExpandableContent from '../ExpandableContent'
 
 export type ResourcesMobileProps = {
   data: Data
-  token?: string
 }
 
-export default function ResourcesMobile({ data, token }: ResourcesMobileProps) {
+export default function ResourcesMobile({ data }: ResourcesMobileProps) {
   return (
     <div className="Resources_Mobile">
       {data.map(({ name, ownerId, wikiId }) => {
         let title = <> {name} </>
-        let markdown = (
-          <MarkdownSynapse token={token} ownerId={ownerId} wikiId={wikiId} />
+        let markdown = <MarkdownSynapse ownerId={ownerId} wikiId={wikiId} />
+        return (
+          <ExpandableContent key={wikiId} title={title} content={markdown} />
         )
-        return <ExpandableContent title={title} content={markdown} />
       })}
     </div>
   )

--- a/src/lib/containers/home_page/resources/Resources.tsx
+++ b/src/lib/containers/home_page/resources/Resources.tsx
@@ -11,7 +11,6 @@ import { withQueryClientProvider } from '../../../utils/hooks/SynapseAPI/QueryCl
 
 export type ResourcesProps = {
   entityId: string
-  token?: string
 }
 
 enum ExpectedColumns {
@@ -27,7 +26,7 @@ export type Data = {
 
 export const Resources: React.FC<ResourcesProps> = withQueryClientProvider(
   (props: ResourcesProps) => {
-    const { entityId, token } = props
+    const { entityId } = props
     const showDesktop = useShowDesktop()
 
     const queryBundleRequest: QueryBundleRequest = {
@@ -42,7 +41,6 @@ export const Resources: React.FC<ResourcesProps> = withQueryClientProvider(
     }
     const { data: queryResultBundle, error } = useGetQueryResultBundle(
       queryBundleRequest,
-      token,
     )
 
     const nameIndex = getFieldIndex(ExpectedColumns.NAME, queryResultBundle)
@@ -63,11 +61,11 @@ export const Resources: React.FC<ResourcesProps> = withQueryClientProvider(
       }) ?? []
     return (
       <div className="Resources">
-        <ErrorBanner error={error} token={token} />
+        <ErrorBanner error={error} />
         {showDesktop ? (
-          <ResourcesDesktop data={data} token={token} />
+          <ResourcesDesktop data={data} />
         ) : (
-          <ResourcesMobile data={data} token={token} />
+          <ResourcesMobile data={data}/>
         )}
       </div>
     )

--- a/src/lib/containers/personal_access_token/AccessTokenCard.tsx
+++ b/src/lib/containers/personal_access_token/AccessTokenCard.tsx
@@ -15,13 +15,11 @@ import WarningModal from '../synapse_form_wrapper/WarningModal'
 
 export type AccessTokenCardProps = {
   accessToken: AccessTokenRecord
-  token?: string
   onDelete: (...args: any[]) => void
 }
 
 export const AccessTokenCard: React.FunctionComponent<AccessTokenCardProps> = ({
   accessToken,
-  token,
   onDelete,
 }: AccessTokenCardProps) => {
   const [showModal, setShowModal] = useState(false)
@@ -58,7 +56,7 @@ export const AccessTokenCard: React.FunctionComponent<AccessTokenCardProps> = ({
         confirmButtonText={'Delete Token'}
         onCancel={() => setShowModal(false)}
         onConfirm={(id: string) => {
-          SynapseClient.deletePersonalAccessToken(id, token)
+          SynapseClient.deletePersonalAccessToken(id)
             .then(() => {
               onDelete()
               setShowModal(false)
@@ -69,7 +67,7 @@ export const AccessTokenCard: React.FunctionComponent<AccessTokenCardProps> = ({
         }}
         confirmButtonVariant="danger"
         show={showModal}
-        onConfirmCallbackArgs={[accessToken.id, token]}
+        onConfirmCallbackArgs={[accessToken.id]}
       ></WarningModal>
 
       <div className="SRC-cardContent">
@@ -117,7 +115,7 @@ export const AccessTokenCard: React.FunctionComponent<AccessTokenCardProps> = ({
           onClick={() => {
             if (isExpired) {
               // token no longer works, no need for warning/confirmation
-              SynapseClient.deletePersonalAccessToken(accessToken.id, token)
+              SynapseClient.deletePersonalAccessToken(accessToken.id)
                 .then(() => {
                   onDelete()
                 })

--- a/src/lib/containers/personal_access_token/AccessTokenPage.tsx
+++ b/src/lib/containers/personal_access_token/AccessTokenPage.tsx
@@ -24,13 +24,11 @@ const ErrorFallback: React.FunctionComponent<FallbackProps> = ({
 export type AccessTokenPageProps = {
   title: string
   body: string | JSX.Element
-  token: string
 }
 
 export const AccessTokenPage: React.FunctionComponent<AccessTokenPageProps> = ({
   title,
   body,
-  token,
 }: AccessTokenPageProps) => {
   const [isLoading, setIsLoading] = useState(false)
 
@@ -61,7 +59,7 @@ export const AccessTokenPage: React.FunctionComponent<AccessTokenPageProps> = ({
     if (loadNextPage) {
       setLoadNextPage(false)
       setIsLoading(true)
-      SynapseClient.getPersonalAccessTokenRecords(token, nextPageToken)
+      SynapseClient.getPersonalAccessTokenRecords(nextPageToken)
         .then(response => {
           setIsLoading(false)
           appendTokenRecords(...response.results)
@@ -77,7 +75,7 @@ export const AccessTokenPage: React.FunctionComponent<AccessTokenPageProps> = ({
           setShowErrorMessage(true)
         })
     }
-  }, [loadNextPage, token, nextPageToken])
+  }, [loadNextPage, nextPageToken])
 
   return (
     <div className="PersonalAccessTokenPage bootstrap-4-backport">
@@ -98,7 +96,6 @@ export const AccessTokenPage: React.FunctionComponent<AccessTokenPageProps> = ({
       <ErrorBoundary FallbackComponent={ErrorFallback}>
         {showCreateTokenModal && (
           <CreateAccessTokenModal
-            token={token}
             onClose={() => setShowCreateTokenModal(false)}
             onCreate={rerenderList}
           ></CreateAccessTokenModal>
@@ -116,7 +113,6 @@ export const AccessTokenPage: React.FunctionComponent<AccessTokenPageProps> = ({
                 <AccessTokenCard
                   key={accessToken.id}
                   accessToken={accessToken}
-                  token={token}
                   onDelete={rerenderList}
                 />
               )

--- a/src/lib/containers/personal_access_token/CreateAccessTokenModal.tsx
+++ b/src/lib/containers/personal_access_token/CreateAccessTokenModal.tsx
@@ -21,13 +21,11 @@ const INVALID_INPUT_MSG =
 export type CreateAccessTokenModalProps = {
   onClose: (...args: any[]) => void
   onCreate: (...args: any[]) => void
-  token: string
 }
 
 export const CreateAccessTokenModal: React.FunctionComponent<CreateAccessTokenModalProps> = ({
   onClose,
   onCreate,
-  token,
 }: CreateAccessTokenModalProps) => {
   const [tokenName, setTokenName] = React.useState('')
   const [viewAccess, setViewAccess] = React.useState(true)
@@ -66,10 +64,7 @@ export const CreateAccessTokenModal: React.FunctionComponent<CreateAccessTokenMo
 
         setIsLoading(true)
 
-        const response = await SynapseClient.createPersonalAccessToken(
-          request,
-          token,
-        )
+        const response = await SynapseClient.createPersonalAccessToken(request)
 
         setIsLoading(false)
         setCreatedToken(response.token)

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -28,7 +28,6 @@ type OwnProps = {
   tableConfiguration?: SynapseTableProps
   cardConfiguration?: CardConfiguration
   searchConfiguration?: SearchV2Props
-  token?: string
   rgbIndex?: number
   facetsToPlot?: string[]
   facetsToFilter?: string[]
@@ -110,11 +109,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
         />
         <QueryFilter {...rest} />
         <QueryFilterToggleButton />
-        <FacetNav
-          facetsToPlot={facetsToPlot}
-          showNotch={false}
-          token={props.token}
-        />
+        <FacetNav facetsToPlot={facetsToPlot} showNotch={false} />
         <FilterAndView
           facetsToFilter={facetsToFilter}
           tableConfiguration={tableConfiguration}

--- a/src/lib/containers/query_wrapper_plot_nav/TopLevelControls.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/TopLevelControls.tsx
@@ -14,7 +14,6 @@ export type TopLevelControlsProps = {
   name: string
   entityId: string
   sql: string
-  token?: string
   hideDownload?: boolean
   showColumnSelection?: boolean
   customControls?: CustomControl[]
@@ -66,7 +65,6 @@ const TopLevelControls = (
   props: QueryWrapperChildProps & TopLevelControlsProps,
 ) => {
   const {
-    token,
     name,
     sql,
     updateParentState,
@@ -102,11 +100,11 @@ const TopLevelControls = (
 
   useEffect(() => {
     const getIsFileView = async () => {
-      const entityData = await SynapseClient.getEntity(token, entityId)
+      const entityData = await SynapseClient.getEntity(entityId)
       setIsFileView(entityData.concreteType.includes('EntityView'))
     }
     getIsFileView()
-  }, [entityId, token])
+  }, [entityId])
 
   const refresh = () => {
     executeQueryRequest!(getLastQueryRequest!())
@@ -133,7 +131,7 @@ const TopLevelControls = (
     <div className={`TopLevelControls ${showFacetFilter ? QUERY_FILTERS_EXPANDED_CSS : QUERY_FILTERS_COLLAPSED_CSS}`}>
       <h3>        
         <div className="QueryWrapperPlotNav__querycount">
-          <QueryCount token={token} name={name} sql={sql} parens={true} />
+          <QueryCount name={name} sql={sql} parens={true} />
         </div>
         <div className="QueryWrapperPlotNav__actions">
           {customControls &&
@@ -168,7 +166,6 @@ const TopLevelControls = (
                   onDownloadFiles={() =>
                     setControlState(key)
                   }
-                  token={token}
                   queryResultBundle={data}
                   queryBundleRequest={getLastQueryRequest!()}
                   isFileView={isFileView && !hideDownload}

--- a/src/lib/containers/synapse_table_functions/renderTableCell.tsx
+++ b/src/lib/containers/synapse_table_functions/renderTableCell.tsx
@@ -11,7 +11,8 @@ import { MarkdownLink, CardLink } from '../CardContainerLogic'
 import { renderLabel } from '../GenericCard'
 import {
   SelectColumn,
-  ColumnModel, FileHandleAssociateType,
+  ColumnModel,
+  FileHandleAssociateType,
 } from '../../utils/synapseTypes'
 import { NOT_SET_DISPLAY_VALUE } from '../table/SynapseTableConstants'
 import DirectDownload from '../DirectDownload'
@@ -38,7 +39,6 @@ export const renderTableCell = ({
   selectColumns,
   columnModels,
   tableEntityId,
-  token,
 }: {
   entityColumnIndicies: number[]
   userColumnIndicies: number[]
@@ -59,16 +59,14 @@ export const renderTableCell = ({
   selectColumns: SelectColumn[] | undefined
   columnModels: ColumnModel[] | undefined
   tableEntityId?: string
-  token: string | undefined
 }): React.ReactNode => {
-  const isShortString = (
-    s: string,
-    maxCharCount = 20,
-  ): boolean => {
-    return (!s || s.length <= maxCharCount)
+  const isShortString = (s: string, maxCharCount = 20): boolean => {
+    return !s || s.length <= maxCharCount
   }
   if (!columnValue) {
-    return <p className="SRC-center-text SRC-inactive"> {NOT_SET_DISPLAY_VALUE}</p>
+    return (
+      <p className="SRC-center-text SRC-inactive"> {NOT_SET_DISPLAY_VALUE}</p>
+    )
   }
   if (columnLinkConfig) {
     return renderLabel({
@@ -93,60 +91,69 @@ export const renderTableCell = ({
   }
   if (dateListColumnIndicies.includes(colIndex)) {
     const jsonData: number[] = JSON.parse(columnValue)
-    return <p>{jsonData.map((val: number, index: number) => {
-      return (
-        <span key={index} className={isBold}>
-          {new Date(val).toLocaleString()}
-          {index !== jsonData.length - 1 ? ', ' : ''}
-        </span>
-      )
-    })} </p>
+    return (
+      <p>
+        {jsonData.map((val: number, index: number) => {
+          return (
+            <span key={index} className={isBold}>
+              {new Date(val).toLocaleString()}
+              {index !== jsonData.length - 1 ? ', ' : ''}
+            </span>
+          )
+        })}{' '}
+      </p>
+    )
   }
   if (booleanListColumnIndicies.includes(colIndex)) {
     const jsonData: boolean[] = JSON.parse(columnValue)
-    return <p>{jsonData.map((val: boolean, index: number) => {
-      return (
-        <span key={index} className={isBold}>
-          {val ? 'true' : 'false'}
-          {index !== jsonData.length - 1 ? ', ' : ''}
-        </span>
-      )
-    })}</p>
+    return (
+      <p>
+        {jsonData.map((val: boolean, index: number) => {
+          return (
+            <span key={index} className={isBold}>
+              {val ? 'true' : 'false'}
+              {index !== jsonData.length - 1 ? ', ' : ''}
+            </span>
+          )
+        })}
+      </p>
+    )
   }
 
   // If it's a file from a table view
-  if (fileHandleIdColumnIndicies.includes(colIndex)){
-    return <>
-      <DirectDownload
-        associatedObjectId={tableEntityId!}
-        associatedObjectType={FileHandleAssociateType.TableEntity}
-        fileHandleId={columnValue}
-        displayFileName={true}
-      />
-    </>
+  if (fileHandleIdColumnIndicies.includes(colIndex)) {
+    return (
+      <>
+        <DirectDownload
+          associatedObjectId={tableEntityId!}
+          associatedObjectType={FileHandleAssociateType.TableEntity}
+          fileHandleId={columnValue}
+          displayFileName={true}
+        />
+      </>
+    )
   }
 
   // If it's a list of entity ids
-  if (entityIdListColumnIndicies.includes(colIndex)){
+  if (entityIdListColumnIndicies.includes(colIndex)) {
     const jsonData: string[] = JSON.parse(columnValue)
-    return(
-      <EntityIdList
-        entityIdList={jsonData}
-        token={token}
-      />
-    )
+    return <EntityIdList entityIdList={jsonData} />
   }
 
   if (otherListColumnIndicies.includes(colIndex)) {
     const jsonData: string[] = JSON.parse(columnValue)
-    return <p>{jsonData.map((val: string, index: number) => {
-      return (
-        <span key={val} className={isBold}>
-          {val}
-          {index !== jsonData.length - 1 ? ', ' : ''}
-        </span>
-      )
-    })}</p>
+    return (
+      <p>
+        {jsonData.map((val: string, index: number) => {
+          return (
+            <span key={val} className={isBold}>
+              {val}
+              {index !== jsonData.length - 1 ? ', ' : ''}
+            </span>
+          )
+        })}
+      </p>
+    )
   }
   if (dateColumnIndicies.includes(colIndex)) {
     return (

--- a/src/lib/containers/table/table-top/DownloadOptions.tsx
+++ b/src/lib/containers/table/table-top/DownloadOptions.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../../utils/synapseTypes'
 import ProgrammaticOptions from './ProgrammaticOptions'
 import ModalDownload from '../../../containers/ModalDownload'
+import { isSignedIn } from '../../../utils/SynapseClient'
 
 export const DOWNLOAD_OPTIONS_CONTAINER_CLASS = 'SRC-download-options-container'
 
@@ -16,7 +17,6 @@ type DownloadOptionsProps = {
   isUnauthenticated?: boolean
   isFileView?: boolean
   darkTheme?: boolean
-  token: string | undefined
   queryResultBundle?: QueryResultBundle
   queryBundleRequest: QueryBundleRequest
 }
@@ -34,7 +34,6 @@ export const DownloadOptions: React.FunctionComponent<DownloadOptionsProps> = pr
     onDownloadFiles,
     queryResultBundle,
     queryBundleRequest,
-    token,
     darkTheme = true,
   } = props
 
@@ -46,7 +45,7 @@ export const DownloadOptions: React.FunctionComponent<DownloadOptionsProps> = pr
           tooltipText={'Download Options'}
           size="lg"
           darkTheme={darkTheme}
-          icon={"download"}
+          icon={'download'}
         ></ElementWithTooltip>
         <Dropdown.Menu
           className="SRC-primary-color-hover-dropdown"
@@ -62,7 +61,7 @@ export const DownloadOptions: React.FunctionComponent<DownloadOptionsProps> = pr
           {props.isFileView && (
             <Dropdown.Item
               onClick={() =>
-                props.token ? onDownloadFiles() : setShowLoginModal(true)
+                isSignedIn() ? onDownloadFiles() : setShowLoginModal(true)
               }
             >
               {DOWNLOAD_FILES_MENU_TEXT}
@@ -88,7 +87,6 @@ export const DownloadOptions: React.FunctionComponent<DownloadOptionsProps> = pr
           <ModalDownload
             onClose={() => setShowExportMetadata(false)}
             queryBundleRequest={queryBundleRequest}
-            token={token}
           />
         )
       }

--- a/src/lib/containers/widgets/FileHandleLink.tsx
+++ b/src/lib/containers/widgets/FileHandleLink.tsx
@@ -2,9 +2,9 @@ import { FileHandleAssociateType } from '../../utils/synapseTypes'
 import React from 'react'
 import { SynapseConstants, SynapseClient } from '../../utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { isSignedIn } from '../../utils/SynapseClient'
 
 type FileHandleLinkProps = {
-  token: string | undefined
   fileHandleId: string
   redirect?: boolean
   showDownloadIcon: boolean
@@ -15,7 +15,6 @@ type FileHandleLinkProps = {
 }
 export const FileHandleLink = (props: FileHandleLinkProps) => {
   const {
-    token,
     fileHandleId,
     showDownloadIcon,
     tableEntityConcreteType,
@@ -38,19 +37,19 @@ export const FileHandleLink = (props: FileHandleLinkProps) => {
     <button
       // @ts-ignore
       onClick={() => {
-        if (token && fileAssociateId) {
+        if (isSignedIn() && fileAssociateId) {
           SynapseClient.getActualFileHandleByIdURL(
             fileHandleId,
-            token,
             fileAssociateType,
             fileAssociateId,
             redirect,
-          ).then(url => {
-            window.open(url, '_blank')
-          })
-          .catch(err => {
-            console.error('Error on retrieving file handle url ', err)
-          })
+          )
+            .then(url => {
+              window.open(url, '_blank')
+            })
+            .catch(err => {
+              console.error('Error on retrieving file handle url ', err)
+            })
         }
       }}
       className={`SRC-primary-text-color ${SynapseConstants.SRC_SIGN_IN_CLASS}`}

--- a/src/lib/containers/widgets/ImageFileHandle.tsx
+++ b/src/lib/containers/widgets/ImageFileHandle.tsx
@@ -4,27 +4,20 @@ import { SynapseClient } from '../../utils'
 import { useInView } from 'react-intersection-observer'
 
 type ImageFileHandleProps = {
-  token: string | undefined
   fileHandleId: string
   tableEntityConcreteType: string | undefined
   rowId: string | undefined
-  tableId: string | undefined  
+  tableId: string | undefined
 }
 export const ImageFileHandle = (props: ImageFileHandleProps) => {
-  const {
-    token,
-    fileHandleId,
-    tableEntityConcreteType,
-    rowId,
-    tableId,    
-  } = props
+  const { fileHandleId, tableEntityConcreteType, rowId, tableId } = props
 
   const [url, setUrl] = useState<string>()
   const { ref, inView } = useInView({
     triggerOnce: true,
     rootMargin: '500px 0px',
   })
-  
+
   useEffect(() => {
     const getData = async () => {
       const isFileView = tableEntityConcreteType?.includes('EntityView')
@@ -35,31 +28,27 @@ export const ImageFileHandle = (props: ImageFileHandleProps) => {
       if (fileAssociateId && inView) {
         SynapseClient.getActualFileHandleByIdURL(
           fileHandleId,
-          token,
           fileAssociateType,
           fileAssociateId,
           false,
-        ).then(url => {
-          setUrl(url)
-        })
-        .catch(err => {
-          console.error('Error on retrieving file handle url ', err)
-        })
+        )
+          .then(url => {
+            setUrl(url)
+          })
+          .catch(err => {
+            console.error('Error on retrieving file handle url ', err)
+          })
       }
     }
 
     getData()
-  }, [inView, fileHandleId, rowId, tableId, tableEntityConcreteType, token])
+  }, [inView, fileHandleId, rowId, tableId, tableEntityConcreteType])
 
   return (
     <span ref={ref}>
-      {url && <img
-        src={url}
-        alt=''
-        className='ImageFileHandle'
-        loading="lazy"
-      >
-      </img>}
+      {url && (
+        <img src={url} alt="" className="ImageFileHandle" loading="lazy"></img>
+      )}
     </span>
   )
 }

--- a/src/lib/containers/widgets/SynapseImage.tsx
+++ b/src/lib/containers/widgets/SynapseImage.tsx
@@ -12,7 +12,6 @@ import {
 type SynapseImageProps = {
   wikiId?: string
   synapseId?: string
-  token?: string
   fileName?: string
   fileResults?: FileHandle[]
   params: {
@@ -43,9 +42,9 @@ class SynapseImage extends React.Component<
   }
 
   public getEntity() {
-    const { token, synapseId } = this.props
+    const { synapseId } = this.props
     if (synapseId) {
-      getEntity<FileEntity>(token, synapseId).then(
+      getEntity<FileEntity>(synapseId).then(
         // https://docs.synapse.org/rest/org/sagebionetworks/repo/model/FileEntity.html
         (data: FileEntity) => {
           const fileHandleAssociationList = [
@@ -73,7 +72,7 @@ class SynapseImage extends React.Component<
       includePreviewPreSignedURLs: false,
       requestedFiles: fileHandleAssociationList,
     }
-    getFiles(request, this.props.token)
+    getFiles(request)
       .then((data: BatchFileResult) => {
         const { preSignedURL } = data.requestedFiles.filter(
           el => el.fileHandleId === id,
@@ -113,7 +112,7 @@ class SynapseImage extends React.Component<
     if (params.scale && params.scale !== '100') {
       scale = `${Number(params.scale)}%`
     }
-    
+
     const alignLowerCase = align.toLowerCase()
     let className = ''
     if (alignLowerCase === 'left') {

--- a/src/lib/containers/widgets/SynapsePlot.tsx
+++ b/src/lib/containers/widgets/SynapsePlot.tsx
@@ -11,7 +11,6 @@ import { parseEntityIdFromSqlStatement } from '../../utils/functions/sqlFunction
 const Plot = createPlotlyComponent(Plotly)
 
 export type SynapsePlotProps = {
-  token?: string
   ownerId?: string
   wikiId?: string
   widgetparamsMapped?: any
@@ -42,7 +41,6 @@ class SynapsePlot extends React.Component<SynapsePlotProps, SynapsePlotState> {
    * @returns data corresponding to plotly widget
    */
   public fetchPlotlyData() {
-    const { token } = this.props
     const { query } = this.props.widgetparamsMapped
     const queryRequest: QueryBundleRequest = {
       concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
@@ -53,7 +51,7 @@ class SynapsePlot extends React.Component<SynapsePlotProps, SynapsePlotState> {
       },
     }
 
-    getFullQueryTableResults(queryRequest, token)
+    getFullQueryTableResults(queryRequest)
       .then((data: QueryResultBundle) => {
         this.setState({
           isLoaded: true,

--- a/src/lib/containers/widgets/SynapseVideo.tsx
+++ b/src/lib/containers/widgets/SynapseVideo.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useEffect, useState } from 'react'
-import { getEntity, getFiles } from '../../utils/SynapseClient'
+import { getEntity, getFiles, isSignedIn } from '../../utils/SynapseClient'
 import {
   FileEntity,
   FileHandleAssociateType,
@@ -12,10 +12,9 @@ import { SynapseConstants } from '../../utils/'
 
 export type Props = {
   params: any
-  token?: string
 }
 
-export default function SynapseVideo({ params, token }: Props) {
+export default function SynapseVideo({ params }: Props) {
   const [video, setVideo] = useState<string>()
   const [videoUrl, setVideoUrl] = useState<string>()
 
@@ -31,7 +30,7 @@ export default function SynapseVideo({ params, token }: Props) {
         const videoKey =
           params.oggSynapseId || params.mp4SynapseId || params.webmSynapseId
 
-        getEntity<FileEntity>(token, videoKey).then((data: FileEntity) => {
+        getEntity<FileEntity>(videoKey).then((data: FileEntity) => {
           const fileHandleAssociationList: FileHandleAssociation[] = [
             {
               associateObjectId: videoKey,
@@ -55,7 +54,7 @@ export default function SynapseVideo({ params, token }: Props) {
         requestedFiles: fileHandleAssociationList,
       }
 
-      getFiles(request, token)
+      getFiles(request)
         .then((data: BatchFileResult) => {
           const { preSignedURL } = data.requestedFiles.filter(
             el => el.fileHandleId === id,
@@ -67,7 +66,7 @@ export default function SynapseVideo({ params, token }: Props) {
         })
     }
     getVideo()
-  }, [video, params, token, videoHeight, videoWidth])
+  }, [video, params, videoHeight, videoWidth])
 
   const RenderVideo = () => {
     return (
@@ -94,7 +93,7 @@ export default function SynapseVideo({ params, token }: Props) {
   }
   return (
     <div>
-      {token ? (
+      {isSignedIn() ? (
         <RenderVideo />
       ) : (
         <p>

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -59,7 +59,6 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
   isLoadingNewData,
   isLoading,
   executeQueryRequest,
-  token,
   asyncJobStatus,
   topLevelControlsState,
   facetsToPlot,
@@ -213,7 +212,6 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
           executeQueryRequest={executeQueryRequest!}
           lastQueryRequest={getLastQueryRequest?.()!}
           getInitQueryRequest={getInitQueryRequest}
-          token={token}
           unitDescription={
             hasSelectedFacets ? 'Results Filtered By' : 'Results'
           }
@@ -257,7 +255,6 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
                   }
                   facetAliases={facetAliases}
                   lastQueryRequest={lastQueryRequest}
-                  token={token}
                 ></FacetNavPanel>
               </div>
             ))}
@@ -303,7 +300,6 @@ const FacetNav: React.FunctionComponent<FacetNavProps> = ({
                     )
                   }
                   facetAliases={facetAliases}
-                  token={token}
                 />
               </div>
             ))}

--- a/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
@@ -95,7 +95,6 @@ export async function extractPlotDataArray(
   columnType: ColumnType | undefined,
   index: number,
   plotType: PlotType,
-  sessionToken?: string,
   facetAliases?: {},
 ) {
   const { colorPalette } = getColorPalette(
@@ -106,7 +105,6 @@ export async function extractPlotDataArray(
   const getLabels = async (
     facetValues: FacetColumnResultValueCount[],
     columnType?: ColumnType,
-    sessionToken?: string,
   ) => {
     const map = new Map<string, string>()
     map.set(
@@ -119,18 +117,12 @@ export async function extractPlotDataArray(
       .filter(val => val !== SynapseConstants.VALUE_NOT_SET)
     if (columnType === ColumnType.ENTITYID) {
       // TODO: Pagination
-      const response = await SynapseClient.getEntityHeadersByIds(
-        filteredValues,
-        sessionToken,
-      )
+      const response = await SynapseClient.getEntityHeadersByIds(filteredValues)
       for (const header of response.results) {
         map.set(header.id, header.name)
       }
     } else if (columnType === ColumnType.USERID) {
-      const response = await SynapseClient.getGroupHeadersBatch(
-        filteredValues,
-        sessionToken,
-      )
+      const response = await SynapseClient.getGroupHeadersBatch(filteredValues)
       for (const header of response.children) {
         map.set(header.ownerId, header.userName)
       }
@@ -156,11 +148,7 @@ export async function extractPlotDataArray(
     return label
   }
 
-  const labels = await getLabels(
-    facetToPlot.facetValues,
-    columnType,
-    sessionToken,
-  )
+  const labels = await getLabels(facetToPlot.facetValues, columnType)
   const text = labels.map(el => el.truncatedLabel)
 
   const anyFacetsSelected = facetToPlot.facetValues.some(
@@ -340,7 +328,6 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
   data,
   isLoading,
   facetAliases,
-  token,
   lastQueryRequest,
 }: FacetNavPanelProps): JSX.Element => {
   const [plotData, setPlotData] = useState<GraphData>()
@@ -364,7 +351,6 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
         getColumnType(),
         index,
         'PIE',
-        token
       ).then(plotData => setPlotData(plotData))
     }
   }, [facetToPlot, data, index, getColumnType])
@@ -380,7 +366,6 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
         getColumnType(),
         index,
         'BAR',
-        token,
       ).then(plotData => setPlotData(plotData))
     } else {
       extractPlotDataArray(
@@ -388,7 +373,6 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
         getColumnType(),
         index,
         'PIE',
-        token,
       ).then(plotData => setPlotData(plotData))
     }
     setPlotType(plotType)
@@ -441,7 +425,6 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = ({
                   el => el.name === facetToPlot.columnName,
                 )!
               }
-              token={token}
               facetAliases={facetAliases}
               onChange={(facetNamesMap: {}) => {
                 applyMultipleChangesToValuesColumn(

--- a/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
@@ -22,7 +22,6 @@ library.add(faArrowLeft)
 export type EnumFacetFilterProps = {
   facetValues: FacetColumnResultValueCount[]
   columnModel: ColumnModel
-  token?: string
   onChange: Function
   onClear: Function
   facetAliases: {} | undefined
@@ -79,7 +78,6 @@ function formatFacetValuesForDisplay(
 /************* QUERY ENUM CONMPONENT  *************/
 
 export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
-  token,
   facetValues,
   columnModel,
   onClear,
@@ -113,7 +111,6 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
       : []
   const userProfiles = useGetInfoFromIds<UserProfile>({
     ids: userIds,
-    token,
     type: 'USER_PROFILE',
   })
 
@@ -123,7 +120,6 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
       : []
   const entityHeaders = useGetInfoFromIds<EntityHeader>({
     ids: entityIds,
-    token,
     type: 'ENTITY_HEADER',
   })
 
@@ -332,7 +328,7 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
           tooltipText="Filter by specific facet"
           key="facetFilterTooltip"
           darkTheme={true}
-          icon={"filter"}
+          icon={'filter'}
         />
         <Dropdown.Menu>{content}</Dropdown.Menu>
       </Dropdown>

--- a/src/lib/containers/widgets/query-filter/QueryFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/QueryFilter.tsx
@@ -16,14 +16,17 @@ import {
   QueryBundleRequest,
   QueryResultBundle,
 } from '../../../utils/synapseTypes'
-import { QueryWrapperChildProps, QUERY_FILTERS_COLLAPSED_CSS, QUERY_FILTERS_EXPANDED_CSS } from '../../QueryWrapper'
+import {
+  QueryWrapperChildProps,
+  QUERY_FILTERS_COLLAPSED_CSS,
+  QUERY_FILTERS_EXPANDED_CSS,
+} from '../../QueryWrapper'
 
 export type QueryFilterProps = {
   isLoading?: boolean
   data?: QueryResultBundle
   getLastQueryRequest?: Function
   executeQueryRequest?: Function
-  token?: string
   facetAliases?: {}
   facetsToFilter?: string[]
 }
@@ -139,12 +142,13 @@ export const applyChangesToRangeColumn = (
   onChangeFn(result)
 }
 
-export const QueryFilter: React.FunctionComponent<QueryWrapperChildProps & QueryFilterProps> = ({
+export const QueryFilter: React.FunctionComponent<
+  QueryWrapperChildProps & QueryFilterProps
+> = ({
   data,
   isLoading = false,
   getLastQueryRequest,
   executeQueryRequest,
-  token,
   facetAliases,
   facetsToFilter,
   topLevelControlsState,
@@ -156,7 +160,7 @@ export const QueryFilter: React.FunctionComponent<QueryWrapperChildProps & Query
   const columnModels = data.columnModels
   let facets = data.facets as FacetColumnResult[]
   if (facetsToFilter) {
-    facets = facets.filter( facet => {
+    facets = facets.filter(facet => {
       return facetsToFilter.includes(facet.columnName)
     })
   }
@@ -170,7 +174,13 @@ export const QueryFilter: React.FunctionComponent<QueryWrapperChildProps & Query
   }
 
   return (
-    <div className={`QueryFilter ${showFacetFilter ? QUERY_FILTERS_EXPANDED_CSS : QUERY_FILTERS_COLLAPSED_CSS}`}>
+    <div
+      className={`QueryFilter ${
+        showFacetFilter
+          ? QUERY_FILTERS_EXPANDED_CSS
+          : QUERY_FILTERS_COLLAPSED_CSS
+      }`}
+    >
       <h4 className="QueryFilter__title">Filter Data By</h4>
       {isLoading && <div>Loading...</div>}
       {!isLoading &&
@@ -189,7 +199,6 @@ export const QueryFilter: React.FunctionComponent<QueryWrapperChildProps & Query
                   collapsed={shouldStartCollapsed}
                   facetValues={(facet as FacetColumnResultValues).facetValues}
                   columnModel={columnModel!}
-                  token={token}
                   facetAliases={facetAliases}
                   onChange={(facetNamesMap: {}) =>
                     applyMultipleChangesToValuesColumn(

--- a/src/lib/containers/widgets/themes-plot/ThemesPlot.tsx
+++ b/src/lib/containers/widgets/themes-plot/ThemesPlot.tsx
@@ -24,7 +24,6 @@ import BarPlot from './BarPlot'
 import loadingScreen from '../../LoadingScreen'
 
 export type ThemesPlotProps = {
-  token?: string
   onPointClick: ({ facetValue, type, event }: ClickCallbackParams) => void
   dotPlot: PlotProps
   topBarPlot: PlotProps
@@ -105,10 +104,14 @@ const barLayoutConfig: Partial<PlotlyTyped.Layout> = {
   },
 }
 
-function fetchData(
-  token: string,
-  { xField, yField, groupField, entityId, whereClause, infoField }: PlotProps,
-): Promise<RowSet> {
+function fetchData({
+  xField,
+  yField,
+  groupField,
+  entityId,
+  whereClause,
+  infoField,
+}: PlotProps): Promise<RowSet> {
   const sql = `SELECT ${xField} as "x", ${yField} as "y", ${
     infoField ? infoField + ' as "info", ' : ''
   }   ${groupField} as "group" FROM ${entityId} ${
@@ -124,7 +127,7 @@ function fetchData(
     },
   }
 
-  return getFullQueryTableResults(queryRequest, token).then(
+  return getFullQueryTableResults(queryRequest).then(
     (data: QueryResultBundle) => {
       return data.queryResult.queryResults
     },
@@ -199,7 +202,6 @@ const getTooltip = (data: GraphItem[], filter: string) => {
 }
 
 const ThemesPlot: FunctionComponent<ThemesPlotProps> = ({
-  token,
   dotPlot,
   topBarPlot,
   sideBarPlot,
@@ -213,9 +215,9 @@ const ThemesPlot: FunctionComponent<ThemesPlotProps> = ({
   const [sideBarPlotData, setSideBarQueryData] = useState<GraphItem[]>([])
 
   useEffect(() => {
-    const dotPlotData = fetchData(token!, dotPlot)
-    const topBarPlotData = fetchData(token!, topBarPlot)
-    const sideBarPlotData = fetchData(token!, sideBarPlot)
+    const dotPlotData = fetchData(dotPlot)
+    const topBarPlotData = fetchData(topBarPlot)
+    const sideBarPlotData = fetchData(sideBarPlot)
     Promise.all([dotPlotData, topBarPlotData, sideBarPlotData])
       .then(result => {
         setDotPlotQueryData(resultToJson(result[0].headers, result[0].rows))
@@ -227,7 +229,7 @@ const ThemesPlot: FunctionComponent<ThemesPlotProps> = ({
         throw err
       })
     return () => {}
-  }, [token, dotPlot, topBarPlot, sideBarPlot])
+  }, [dotPlot, topBarPlot, sideBarPlot])
   let yLabelsForDotPlot: string[] = []
   let xLabelsForTopBarPlot: string[] = []
   let xMaxForDotPlot = 0
@@ -252,9 +254,7 @@ const ThemesPlot: FunctionComponent<ThemesPlotProps> = ({
 
   return (
     <>
-      {!isLoaded && (
-        loadingScreen
-      )}
+      {!isLoaded && loadingScreen}
 
       {isLoaded && (
         <div className="ThemesPlot">

--- a/src/lib/utils/functions/getUserData.ts
+++ b/src/lib/utils/functions/getUserData.ts
@@ -5,11 +5,8 @@ import { UserProfile, FileHandleAssociateType } from '../synapseTypes/'
   Utility functions for UserCards
 */
 
-function getUserProfileWithProfilePicAttached(
-  principalIds: string[],
-  token?: string,
-) {
-  return SynapseClient.getUserProfiles(principalIds).then((data) => {
+function getUserProfileWithProfilePicAttached(principalIds: string[]) {
+  return SynapseClient.getUserProfiles(principalIds).then(data => {
     // people will either have a profile pic file handle id
     // or they won't. Have to break this down into two groups.
     const withProfilePic = data.list.filter((value: any) => {
@@ -18,7 +15,7 @@ function getUserProfileWithProfilePicAttached(
     if (withProfilePic.length === 0) {
       return data
     }
-    const fileHandleAssociationList = withProfilePic.map((value) => {
+    const fileHandleAssociationList = withProfilePic.map(value => {
       return {
         associateObjectId: value.ownerId,
         associateObjectType: 'UserProfileAttachment',
@@ -31,13 +28,13 @@ function getUserProfileWithProfilePicAttached(
       includePreviewPreSignedURLs: false,
       requestedFiles: fileHandleAssociationList,
     }
-    return SynapseClient.getFiles(request, token)
-      .then((fileHandleList) => {
+    return SynapseClient.getFiles(request)
+      .then(fileHandleList => {
         // we retrieve all the persons with profile pic file handles
         // so we next loop through them, find the original person in the data.list
         // and add a field with their pre-signed url
-        fileHandleList.requestedFiles.forEach((fileHandle) => {
-          const matchingPersonIndex = data.list.findIndex((el) => {
+        fileHandleList.requestedFiles.forEach(fileHandle => {
+          const matchingPersonIndex = data.list.findIndex(el => {
             return fileHandle.fileHandleId === el.profilePicureFileHandleId
           })
           data.list[matchingPersonIndex].clientPreSignedURL =
@@ -45,7 +42,7 @@ function getUserProfileWithProfilePicAttached(
         })
         return Promise.resolve(data)
       })
-      .catch((err) => {
+      .catch(err => {
         throw Error(`Err on getting user data ${err}`)
       })
   })
@@ -57,9 +54,8 @@ export type UserProfileAndImg = {
 }
 function getUserProfileWithProfilePic(
   ownerId: string,
-  token?: string,
 ): Promise<UserProfileAndImg> {
-  return SynapseClient.getUserProfileById(token, ownerId).then(
+  return SynapseClient.getUserProfileById(ownerId).then(
     (userProfile: UserProfile) => {
       // people will either have a profile pic file handle id
       // or they won't. Have to break this down into two groups.
@@ -82,8 +78,8 @@ function getUserProfileWithProfilePic(
         requestedFiles: fileHandleAssociationList,
       }
 
-      return SynapseClient.getFiles(request, token)
-        .then((fileHandleList) => {
+      return SynapseClient.getFiles(request)
+        .then(fileHandleList => {
           // we retrieve all the persons with profile pic file handles
           // so we next loop through them, find the original person in the data.list
           // and add a field with their pre-signed url
@@ -93,7 +89,7 @@ function getUserProfileWithProfilePic(
             preSignedURL: firstElement.preSignedURL,
           })
         })
-        .catch((err) => {
+        .catch(err => {
           console.log({ err })
         })
     },

--- a/src/lib/utils/functions/testDownloadSpeed.ts
+++ b/src/lib/utils/functions/testDownloadSpeed.ts
@@ -18,9 +18,8 @@ const TEST_FILE_ENTITY_ID: string = 'syn12600511'
  * Return the estimated download speed (bytes/second).  Result is cached.
  * Result is crude estimate since it's a single test file (small sample, only ~2MB), but is a valid test (since it's a Synapse file on s3).
  * The intent is to let the user know if the package download will take many hours to download.
- * @param sessionToken
  */
-export const testDownloadSpeed = (sessionToken: string): Promise<number> => {
+export const testDownloadSpeed = (): Promise<number> => {
   return new Promise((resolve, reject) => {
     // check cache
     const cachedSpeedExpireTime = localStorage.getItem(
@@ -41,7 +40,7 @@ export const testDownloadSpeed = (sessionToken: string): Promise<number> => {
      * 2.  Get the file handle and presigned URL associated to the latest version of the test File Entity
      * 3.  Start the timer and fetch the file content using that presigned URL
      */
-    getEntity(sessionToken, TEST_FILE_ENTITY_ID)
+    getEntity(TEST_FILE_ENTITY_ID)
       .then((entity: Entity) => {
         const fileEntity: FileEntity = entity as FileEntity
         const fileHandleAssociationList: FileHandleAssociation[] = [
@@ -57,7 +56,7 @@ export const testDownloadSpeed = (sessionToken: string): Promise<number> => {
           includePreviewPreSignedURLs: false,
           requestedFiles: fileHandleAssociationList,
         }
-        getFiles(request, sessionToken).then((data: BatchFileResult) => {
+        getFiles(request).then((data: BatchFileResult) => {
           const presignedUrl: string = data.requestedFiles[0].preSignedURL!
           // we know this file exists
           const fileHandle: FileHandle = data.requestedFiles[0].fileHandle!

--- a/src/lib/utils/hooks/SynapseAPI/useEntityBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useEntityBundle.ts
@@ -21,7 +21,6 @@ const ALL_FIELDS: EntityBundleRequest = {
 }
 
 export default function useGetEntityBundle(
-  sessionToken: string,
   entityId: string,
   bundleRequest: EntityBundleRequest = ALL_FIELDS,
   version?: number,
@@ -29,13 +28,7 @@ export default function useGetEntityBundle(
 ) {
   return useQuery<EntityBundle, SynapseClientError>(
     ['entitybundle', entityId, version, bundleRequest],
-    () =>
-      SynapseClient.getEntityBundleV2(
-        entityId,
-        bundleRequest,
-        version,
-        sessionToken,
-      ),
+    () => SynapseClient.getEntityBundleV2(entityId, bundleRequest, version),
     options,
   )
 }

--- a/src/lib/utils/hooks/SynapseAPI/useFavorites.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useFavorites.ts
@@ -4,7 +4,6 @@ import { SynapseClientError } from '../../SynapseClient'
 import { EntityHeader, PaginatedResults } from '../../synapseTypes'
 
 export function useGetFavorites(
-  sessionToken: string,
   options?: UseQueryOptions<
     PaginatedResults<EntityHeader>,
     SynapseClientError,
@@ -12,8 +11,8 @@ export function useGetFavorites(
   >,
 ) {
   return useQuery<PaginatedResults<EntityHeader>, SynapseClientError>(
-    ['favorites', sessionToken],
-    () => SynapseClient.getUserFavorites(sessionToken),
+    ['favorites'],
+    () => SynapseClient.getUserFavorites(),
     options,
   )
 }

--- a/src/lib/utils/hooks/SynapseAPI/useGetEntityChildren.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useGetEntityChildren.ts
@@ -12,7 +12,6 @@ import {
 } from '../../synapseTypes'
 
 export function useGetEntityChildren(
-  sessionToken: string,
   request: EntityChildrenRequest,
   options?: UseQueryOptions<
     EntityChildrenResponse,
@@ -21,14 +20,13 @@ export function useGetEntityChildren(
   >,
 ) {
   return useQuery<EntityChildrenResponse, SynapseClientError>(
-    ['entitychildren', sessionToken, request],
-    () => SynapseClient.getEntityChildren(request, sessionToken),
+    ['entitychildren', request],
+    () => SynapseClient.getEntityChildren(request),
     options,
   )
 }
 
 export function useGetEntityChildrenInfinite(
-  sessionToken: string,
   request: EntityChildrenRequest,
   options?: UseInfiniteQueryOptions<
     EntityChildrenResponse,
@@ -41,7 +39,6 @@ export function useGetEntityChildrenInfinite(
     async context => {
       return await SynapseClient.getEntityChildren(
         { ...request, nextPageToken: context.pageParam },
-        sessionToken,
       )
     },
     {

--- a/src/lib/utils/hooks/SynapseAPI/useGetEntityHeaders.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useGetEntityHeaders.ts
@@ -9,7 +9,6 @@ import {
 
 export function useGetEntityHeaders(
   references: ReferenceList,
-  sessionToken?: string,
   options?: UseQueryOptions<
     PaginatedResults<EntityHeader>,
     SynapseClientError,
@@ -17,8 +16,8 @@ export function useGetEntityHeaders(
   >,
 ) {
   return useQuery<PaginatedResults<EntityHeader>, SynapseClientError>(
-    ['entityHeaders', sessionToken, references],
-    () => SynapseClient.getEntityHeaders(references, sessionToken),
+    ['entityHeaders', references],
+    () => SynapseClient.getEntityHeaders(references),
     options,
   )
 }

--- a/src/lib/utils/hooks/SynapseAPI/useProjects.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useProjects.ts
@@ -2,7 +2,7 @@ import {
   useInfiniteQuery,
   UseInfiniteQueryOptions,
   useQuery,
-  UseQueryOptions
+  UseQueryOptions,
 } from 'react-query'
 import { SynapseClient } from '../..'
 import { SynapseClientError } from '../../SynapseClient'
@@ -10,7 +10,6 @@ import { ProjectHeaderList } from '../../synapseTypes'
 import { GetProjectsParameters } from '../../synapseTypes/GetProjectsParams'
 
 export function useGetProjects(
-  sessionToken: string,
   params?: GetProjectsParameters,
   options?: UseQueryOptions<
     ProjectHeaderList,
@@ -19,14 +18,13 @@ export function useGetProjects(
   >,
 ) {
   return useQuery<ProjectHeaderList, SynapseClientError>(
-    ['myProjects', sessionToken, params],
-    () => SynapseClient.getMyProjects(sessionToken, params),
+    ['myProjects', params],
+    () => SynapseClient.getMyProjects(params),
     options,
   )
 }
 
 export function useGetProjectsInfinite(
-  sessionToken: string,
   params: GetProjectsParameters,
   options?: UseInfiniteQueryOptions<
     ProjectHeaderList,
@@ -35,9 +33,9 @@ export function useGetProjectsInfinite(
   >,
 ) {
   return useInfiniteQuery<ProjectHeaderList, SynapseClientError>(
-    ['myProjects', sessionToken, params],
+    ['myProjects', params],
     async context => {
-      return await SynapseClient.getMyProjects(sessionToken, {
+      return await SynapseClient.getMyProjects({
         ...params,
         nextPageToken: context.pageParam,
       })

--- a/src/lib/utils/hooks/SynapseAPI/useSearch.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useSearch.ts
@@ -11,19 +11,17 @@ import { SearchQuery, SearchResults } from '../../synapseTypes/Search'
 
 export function useSearch(
   query: SearchQuery,
-  sessionToken?: string,
   options?: UseQueryOptions<SearchResults, SynapseClientError, SearchResults>,
 ) {
   return useQuery<SearchResults, SynapseClientError>(
-    ['search', sessionToken, query],
-    () => SynapseClient.searchEntities(query, sessionToken),
+    ['search', query],
+    () => SynapseClient.searchEntities(query),
     options,
   )
 }
 
 export function useSearchInfinite(
   query: Omit<SearchQuery, 'start'>,
-  sessionToken?: string,
   options?: UseInfiniteQueryOptions<
     SearchResults,
     SynapseClientError,
@@ -31,12 +29,12 @@ export function useSearchInfinite(
   >,
 ) {
   return useInfiniteQuery<SearchResults, SynapseClientError>(
-    ['search', sessionToken, query],
+    ['search', query],
     async (context: QueryFunctionContext) => {
-      return SynapseClient.searchEntities(
-        { ...query, start: context.pageParam },
-        sessionToken,
-      )
+      return SynapseClient.searchEntities({
+        ...query,
+        start: context.pageParam,
+      })
     },
     {
       ...options,

--- a/src/lib/utils/hooks/SynapseAPI/useUserBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useUserBundle.ts
@@ -7,7 +7,6 @@ import { SynapseClientError } from '../../SynapseClient'
 
 export function useGetUserProfileWithProfilePic(
   principalId: string,
-  sessionToken?: string,
   options?: UseQueryOptions<
     UserProfileAndImg,
     SynapseClientError,
@@ -15,8 +14,8 @@ export function useGetUserProfileWithProfilePic(
   >,
 ) {
   return useQuery<UserProfileAndImg, SynapseClientError>(
-    ['userprofile', principalId, sessionToken],
-    () => getUserProfileWithProfilePic(principalId, sessionToken),
+    ['userprofile', principalId],
+    () => getUserProfileWithProfilePic(principalId),
     options,
   )
 }

--- a/src/lib/utils/hooks/useGetInfoFromIds.ts
+++ b/src/lib/utils/hooks/useGetInfoFromIds.ts
@@ -10,7 +10,6 @@ import useDeepCompareEffect from 'use-deep-compare-effect'
 export type HookType = 'ENTITY_HEADER' | 'USER_PROFILE'
 export type UseGetInfoFromIdsProps = {
   ids: string[]
-  token: string | undefined
   type: HookType
 }
 
@@ -38,9 +37,8 @@ const entityHeaderTemplate: EntityHeader = {
 
 const getEntityHeaderItems = async (
   lookupList: ReferenceList,
-  token: string | undefined,
 ): Promise<EntityHeader[]> => {
-  const newData = await getEntityHeaders(lookupList, token)
+  const newData = await getEntityHeaders(lookupList)
   const notFound = lookupList.filter(
     item => newData.results.map(item => item.id).indexOf(item.targetId) === -1,
   )
@@ -55,9 +53,8 @@ const getEntityHeaderItems = async (
 
 const getUserProfileItems = async (
   lookupList: string[],
-  token: string | undefined,
 ): Promise<UserProfile[]> => {
-  const newData = await getUserProfileWithProfilePicAttached(lookupList, token)
+  const newData = await getUserProfileWithProfilePicAttached(lookupList)
   const notFound = lookupList.filter(
     item => newData.list.map(item => item.ownerId).indexOf(item) === -1,
   )
@@ -75,7 +72,7 @@ const getUserProfileItems = async (
 export default function useGetInfoFromIds<T extends EntityHeader | UserProfile>(
   props: UseGetInfoFromIdsProps,
 ) {
-  const { token, ids, type } = props
+  const { ids, type } = props
   const [data, setData] = useState<Array<T>>([])
 
   const idProp = (type: HookType) =>
@@ -137,11 +134,8 @@ export default function useGetInfoFromIds<T extends EntityHeader | UserProfile>(
           for (const newReferences of newReferencesChunks) {
             const newData =
               type === 'USER_PROFILE'
-                ? await getUserProfileItems(newReferences as string[], token)
-                : await getEntityHeaderItems(
-                    newReferences as ReferenceList,
-                    token,
-                  )
+                ? await getUserProfileItems(newReferences as string[])
+                : await getEntityHeaderItems(newReferences as ReferenceList)
             totalData.push(...(newData as T[]))
           }
           setData(oldData => oldData.concat(...(totalData as T[])))
@@ -152,6 +146,6 @@ export default function useGetInfoFromIds<T extends EntityHeader | UserProfile>(
       saveToSessionStorage(data, type)
     }
     getData()
-  }, [token, type, newValues])
+  }, [type, newValues])
   return data
 }

--- a/styleguide.setup.js
+++ b/styleguide.setup.js
@@ -19,7 +19,7 @@ global.sessionChangeHandler = async () => {
             }
           })
           
-          console.log('Session has successfully been changed' + sessionToken)
+          console.log('Session has successfully been changed: ' + sessionToken)
       })
       .catch((error) => {
         console.error(error)


### PR DESCRIPTION
Just testing some different patterns for handling authentication.

Here, instead of passing the session token around via props/context, we store it in-memory.

Pros
* Cleaner props interface for almost all components
* Cleaner interface for SynapseClient
* Components do not need to reason with changing auth states, the meaning of undefined token, just call `SynapseClient.isSignedIn()` (which just checks for the token in memory, so it is synchronous)

Cons
* Must hard-reload the page when the user logs in or logs out, since components no longer receive a prop update when the token changes.
* Authentication is handled per-tab (I think this is true for the current implementation as well)
  * e.g. if a user is signed in in tabs 1 and 2, then signs out of tab 1, they will still be signed into tab 2.

Todo
* Need a better way to instantiate the in-memory token value. Right now, it relies on the app calling `SynapseClient.getSessionTokenFromCookie` before attempting anything else.