### PR TITLE
Fix EntityFinder input customization

### DIFF
--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -261,6 +261,7 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                 className="SearchIcon"
               />
               <input
+                role="textbox"
                 ref={searchInputRef}
                 aria-hidden={!searchActive}
                 className="EntityFinder__Search__Input"

--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -9,7 +9,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { Button, FormControl } from 'react-bootstrap'
+import { Button } from 'react-bootstrap'
 import {
   ErrorBoundary,
   FallbackProps,
@@ -260,10 +260,9 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                 icon={faSearch}
                 className="SearchIcon"
               />
-              <FormControl
+              <input
                 ref={searchInputRef}
                 aria-hidden={!searchActive}
-                role="textbox"
                 className="EntityFinder__Search__Input"
                 type="search"
                 placeholder="Search by name, Wiki contents, or Synapse ID"

--- a/src/lib/style/components/entity_finder/_entity-finder.scss
+++ b/src/lib/style/components/entity_finder/_entity-finder.scss
@@ -75,6 +75,7 @@ $-splitter-width: 12px;
     }
 
     input.EntityFinder__Search__Input {
+      border: 1px solid SRC.$gray-dark;
       background-color: transparent;
       height: 100%;
       margin: 10px 0px;


### PR DESCRIPTION
#1019 slightly changed how bootstrap inputs look

This broke the visual styling of the customized entity finder input. This is easily fixed by not using bootstrap here