### PR TITLE
PORTALS-1924: Add Experimental Mode in Portals Footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.15.96",
+  "version": "1.15.97",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -37,6 +37,7 @@ import TermsAndConditions from './containers/TermsAndConditions'
 import PageProgress from './containers/PageProgress'
 import ProjectViewCarousel from './containers/home_page/project_view_carousel/ProjectViewCarousel'
 import EntityFinder from './containers/entity_finder/EntityFinder'
+import ExperimentalMode from './containers/ExperimentalMode'
 
 // we exclude this from main.scss because react doesn't like importing an svg
 // with a relative import.
@@ -84,6 +85,7 @@ const SynapseComponents = {
   PageProgress,
   ProjectViewCarousel,
   EntityFinder,
+  ExperimentalMode,
 }
 
 export { SynapseClient, SynapseConstants, SynapseComponents }


### PR DESCRIPTION
In this [PR](https://github.com/Sage-Bionetworks/Synapse-React-Client/pull/1023/files), I forgot to export the ExperimentalMode component in SRC. This PR is to add it back.