### PR TITLE
PORTALS-1924: Experimental mode bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.15.97",
+  "version": "1.15.98",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/containers/ExperimentalMode.tsx
+++ b/src/lib/containers/ExperimentalMode.tsx
@@ -27,7 +27,7 @@ const ExperimentalMode: React.FC = () => {
   }
 
   const deleteExperimentalModeCookie = () => {
-    cookies.remove(EXPERIMENTAL_MODE_COOKIE, { path: '/' })
+    cookies.remove(EXPERIMENTAL_MODE_COOKIE)
     setIsExperimentalModeOn(false)
   }
 


### PR DESCRIPTION
This is to fix the issue of not being able to delete the cookie if a path is specified. 