### PR TITLE
SWC-5589: recommend validating access token on app initialization.  s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -1192,7 +1192,7 @@ export const getAccessTokenFromCookie = async () => {
     return cookies.get(ACCESS_TOKEN_COOKIE_KEY)
   }
   return doGet<string>(
-    'Portal/sessioncookie',
+    'Portal/sessioncookie?validate=true',
     undefined,
     'include',
     BackendDestinationEnum.PORTAL_ENDPOINT,


### PR DESCRIPTION
…ervice calls seem to be failing in a different way when passing an invalid access token (resulting in a difficult to debug CORS error)