### PR TITLE
remove SRC-blacktext from header card heading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/containers/HeaderCard.tsx
+++ b/src/lib/containers/HeaderCard.tsx
@@ -74,7 +74,7 @@ const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
           <div className="SRC-type">{type}</div>
           <div>
             <h3
-              className="SRC-boldText SRC-blackText"
+              className="SRC-boldText"
               style={{ margin: 'none' }}
             >
               {href ? (


### PR DESCRIPTION
introduced in PORTALS-1853 about 3 months ago, but is not shown in NF because anchor color override