### PR TITLE
SWC-5620 pre-work

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
     "react-hooks/exhaustive-deps": "warn",
     "no-extra-semi": "off",
     "prefer-const": "warn",
+    "jest/expect-expect": "off",
     "@typescript-eslint/restrict-template-expressions": [
       "warn",
       { "allowBoolean": true }
@@ -36,7 +37,7 @@
     "@typescript-eslint/unbound-method": "warn",
     "@typescript-eslint/no-inferrable-types": "warn",
     "@typescript-eslint/ban-ts-comment": "warn",
-    "@typescript-eslint/no-floating-promises": "warn",
+    "@typescript-eslint/no-floating-promises": "off",
     "@typescript-eslint/no-unsafe-member-access": "warn",
     "@typescript-eslint/no-unsafe-call": "warn",
     "@typescript-eslint/no-unsafe-return": "warn",

--- a/src/__tests__/lib/utils/SynapseClient.test.tsx
+++ b/src/__tests__/lib/utils/SynapseClient.test.tsx
@@ -12,7 +12,7 @@ describe('it works at integration level testing', () => {
   it('Call to invalid rest endpoint results in error', async () => {
     try {
       await SynapseClient.doGet(
-        'repo/v1/invalid',
+        '/repo/v1/invalid',
         undefined,
         undefined,
         BackendDestinationEnum.REPO_ENDPOINT,

--- a/src/lib/containers/Login.tsx
+++ b/src/lib/containers/Login.tsx
@@ -20,7 +20,7 @@ type State = {
 type Props = {
   googleRedirectUrl?: string
   redirectUrl?: string // will redirect here after a successful login. if unset, reload the current page url.
-  sessionCallback: Function // Callback is invoked after login
+  sessionCallback: () => void // Callback is invoked after login
 }
 
 /**
@@ -161,7 +161,7 @@ class Login extends React.Component<Props, State> {
           or
         </div>
         <Form onSubmit={this.handleLogin}>
-          <label htmlFor={"exampleEmail"}>Username or Email Address</label>
+          <label htmlFor={'exampleEmail'}>Username or Email Address</label>
           <Form.Control
             required
             autoComplete="username"
@@ -173,7 +173,7 @@ class Login extends React.Component<Props, State> {
             value={this.state.username}
             onChange={this.handleChange}
           />
-          <label htmlFor={"examplePassword"}>Password</label>
+          <label htmlFor={'examplePassword'}>Password</label>
           <Form.Control
             required
             autoComplete="password"
@@ -203,7 +203,7 @@ class Login extends React.Component<Props, State> {
             Log in
           </Button>
         </Form>
-        <div className={"SRC-center-text"}>
+        <div className={'SRC-center-text'}>
           <a
             href={`${getEndpoint(
               BackendDestinationEnum.PORTAL_ENDPOINT,

--- a/src/lib/containers/LoginPage.tsx
+++ b/src/lib/containers/LoginPage.tsx
@@ -4,26 +4,27 @@ import Login from './Login'
 export type LoginPageProps = {
   googleRedirectUrl?: string
   redirectUrl?: string // will redirect here after a successful login. if unset, reload the current page url.
-  sessionCallback: Function // Callback is invoked after login
+  sessionCallback: () => void // Callback is invoked after login
 }
 
-const LoginPage: React.FunctionComponent<LoginPageProps> = (props) => {
+const LoginPage: React.FunctionComponent<LoginPageProps> = props => {
   const { googleRedirectUrl, redirectUrl, sessionCallback } = props
-  const thisClass = "login-panel-wrapper"
+  const thisClass = 'login-panel-wrapper'
 
   return (
-    <div className={"login-panel-wrapper-bg"}>
-      <div
-        id={thisClass}
-        className={thisClass}
-      >
-        <div className={"login-panel panel-left"}>
-          <div className={"panel-logo"}>
+    <div className={'login-panel-wrapper-bg'}>
+      <div id={thisClass} className={thisClass}>
+        <div className={'login-panel panel-left'}>
+          <div className={'panel-logo'}>
             <img
               alt={'Synapse logo'}
-              src={"https://s3.amazonaws.com/static.synapse.org/images/synapse-logo-blue.svg"}
+              src={
+                'https://s3.amazonaws.com/static.synapse.org/images/synapse-logo-blue.svg'
+              }
             />
-            <p className={"panel-tagline"}>Organize. Get credit. Collaborate.</p>
+            <p className={'panel-tagline'}>
+              Organize. Get credit. Collaborate.
+            </p>
           </div>
           <Login
             googleRedirectUrl={googleRedirectUrl}
@@ -31,10 +32,12 @@ const LoginPage: React.FunctionComponent<LoginPageProps> = (props) => {
             sessionCallback={sessionCallback}
           />
         </div>
-        <div className={"login-panel panel-right"} >
-          <div className={"panel-tagline"}>
-            <strong>Organize</strong> your digital research assets.<br />
-            <strong>Get credit</strong> for your research.<br />
+        <div className={'login-panel panel-right'}>
+          <div className={'panel-tagline'}>
+            <strong>Organize</strong> your digital research assets.
+            <br />
+            <strong>Get credit</strong> for your research.
+            <br />
             <strong>Collaborate</strong> with your colleagues and the public.
           </div>
         </div>

--- a/src/lib/containers/UserCard.tsx
+++ b/src/lib/containers/UserCard.tsx
@@ -2,12 +2,13 @@ import React, { useState, useEffect } from 'react'
 import { getPrincipalAliasRequest } from '../utils/SynapseClient'
 import { MenuAction } from './UserCardContextMenu'
 import { UserProfile } from '../utils/synapseTypes/'
-import { SynapseClient, SynapseConstants } from '../utils/'
+import { SynapseConstants } from '../utils/'
 import { UserCardSmall, UserCardSmallProps } from './UserCardSmall'
 import UserCardMedium, { UserCardMediumProps } from './UserCardMedium'
 import usePreFetchResource from '../utils/hooks/usePreFetchImage'
 import { Avatar, AvatarProps, AvatarSize } from './Avatar'
 import { useSynapseContext } from '../utils/SynapseContext'
+import { useGetUserProfileWithProfilePic } from '../utils/hooks/SynapseAPI/useUserBundle'
 
 export type UserCardSize =
   | 'AVATAR'
@@ -66,73 +67,36 @@ export const UserCard: React.FunctionComponent<UserCardProps> = (
   // We fetch the image right away in case it is an expiring presigned URL
   const imageURL = usePreFetchResource(preSignedURL)
 
+  const { data: profileAndImage } = useGetUserProfileWithProfilePic(
+    principalId!,
+    {
+      enabled: !!principalId,
+    },
+  )
+
+  useEffect(() => {
+    if (profileAndImage) {
+      if (!initialProfile) {
+        setUserProfile(profileAndImage.userProfile)
+      }
+      if (!initialPreSignedURL) {
+        setPresignedUrl(profileAndImage.preSignedURL)
+      }
+    }
+  }, [profileAndImage, initialPreSignedURL, initialProfile])
+
   useEffect(() => {
     if (userProfile) {
       setIsLoading(false)
     } else if (alias) {
       // Before we can get the profile, we must get the principal ID using the alias
       getPrincipalAliasRequest(accessToken, alias, 'USER_NAME').then(
-        (aliasData: any) => {
-          setPrincipalId(aliasData.principalId)
+        aliasData => {
+          setPrincipalId(aliasData.principalId.toString())
         },
       )
     }
   }, [userProfile, alias, accessToken])
-
-  useEffect(() => {
-    const getProfilePicture = (
-      profileOwnerId: string,
-      fileHandleId?: string,
-    ) => {
-      if (fileHandleId) {
-        const fha = {
-          associateObjectId: profileOwnerId,
-          associateObjectType: 'UserProfileAttachment',
-          fileHandleId: fileHandleId,
-        }
-        const request: any = {
-          includeFileHandles: false,
-          includePreSignedURLs: true,
-          includePreviewPreSignedURLs: false,
-          requestedFiles: [fha],
-        }
-        SynapseClient.getFiles(request, accessToken)
-          .then(fileHandleList => {
-            setPresignedUrl(fileHandleList.requestedFiles[0].preSignedURL!)
-            setIsLoading(false)
-          })
-          .catch(err => {
-            console.warn('failed to get user profile picture ', err)
-          })
-      } else {
-        setIsLoading(false)
-      }
-    }
-
-    if (!userProfile && principalId) {
-      const cachedProfileString = sessionStorage.getItem(
-        `${principalId}_USER_PROFILE`,
-      )
-      if (cachedProfileString) {
-        const cachedProfile = JSON.parse(cachedProfileString) as UserProfile
-        setUserProfile(cachedProfile)
-        getProfilePicture(principalId, cachedProfile.profilePicureFileHandleId)
-      } else {
-        SynapseClient.getUserProfileById(accessToken, principalId)
-          .then((profile: UserProfile) => {
-            sessionStorage.setItem(
-              `${principalId}_USER_PROFILE`,
-              JSON.stringify(profile),
-            )
-            setUserProfile(profile)
-            getProfilePicture(principalId, profile.profilePicureFileHandleId)
-          })
-          .catch(err => {
-            console.warn('failed to get user bundle ', err)
-          })
-      }
-    }
-  }, [userProfile, principalId, accessToken])
 
   function getCard(
     cardSize: UserCardSize,

--- a/src/lib/containers/UserCard.tsx
+++ b/src/lib/containers/UserCard.tsx
@@ -63,7 +63,9 @@ export const UserCard: React.FunctionComponent<UserCardProps> = (
   const [userProfile, setUserProfile] = useState(initialProfile)
   const [principalId, setPrincipalId] = useState(ownerId)
   const [isLoading, setIsLoading] = useState(true)
-  const [preSignedURL, setPresignedUrl] = useState(initialPreSignedURL ?? '')
+  const [preSignedURL, setPresignedUrl] = useState<string | undefined>(
+    initialPreSignedURL,
+  )
   // We fetch the image right away in case it is an expiring presigned URL
   const imageURL = usePreFetchResource(preSignedURL)
 

--- a/src/lib/containers/UserCardContextMenu.tsx
+++ b/src/lib/containers/UserCardContextMenu.tsx
@@ -25,10 +25,13 @@ const UserCardContextMenu: React.FC<UserCardContextMenuProps> = (
         {menuActions.map((menuAction, index) => {
           const callback = () => menuAction.callback!(userProfile)
           if (menuAction.field === SEPERATOR) {
-            return <hr className="SRC-break" key={menuAction.field + index} />
+            return (
+              <hr className="SRC-break" key={`${menuAction.field}_${index}`} />
+            )
           }
           return (
             <li
+              role="menuitem"
               key={menuAction.field}
               style={{ listStyle: 'none' }}
               className="SRC-menu-item SRC-table-dropdown-list SRC-primary-background-color-hover"

--- a/src/lib/containers/UserCardMedium.tsx
+++ b/src/lib/containers/UserCardMedium.tsx
@@ -5,7 +5,7 @@ import {
   faEllipsisV,
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import ReactTooltip from 'react-tooltip'
 import { SynapseClient, SynapseConstants } from '../utils'
 import IconCopy from '../assets/icons/IconCopy'
@@ -20,12 +20,6 @@ library.add(faCircle)
 library.add(faEllipsisV)
 library.add(faCopy)
 
-type UserCardState = {
-  showModal: boolean
-  isContextMenuOpen: boolean
-  ORCIDHref?: string
-}
-
 export type UserCardMediumProps = {
   userProfile: UserProfile
   menuActions?: MenuAction[]
@@ -39,306 +33,314 @@ export type UserCardMediumProps = {
   isValidated?: boolean
 }
 
-export default class UserCardMedium extends React.Component<
-  UserCardMediumProps,
-  UserCardState
-> {
-  public htmlDivRef = React.createRef<HTMLDivElement>()
+/**
+ * Function handles copying to clipboard the user's email address
+ *
+ * @param {string} value the email address of the user
+ * @returns
+ */
+const copyToClipboard = (
+  ref: React.MutableRefObject<HTMLElement | null>,
+  value: string,
+  onCopy: () => void,
+) => (event: React.SyntheticEvent) => {
+  event.preventDefault()
+  // https://hackernoon.com/copying-text-to-clipboard-with-javascript-df4d4988697f
+  // this copies the email to the clipoard
+  const el = document.createElement('textarea')
+  el.value = value
+  el.setAttribute('readonly', '')
+  el.style.position = 'absolute'
+  el.style.left = '-9999px'
+  ref.current!.appendChild(el)
+  el.select()
+  document.execCommand('copy')
+  ref.current!.removeChild(el)
+  onCopy()
+}
 
-  constructor(props: UserCardMediumProps) {
-    super(props)
-    this.state = {
-      showModal: false,
-      isContextMenuOpen: false,
-      ORCIDHref: undefined
-    }
-  }
+export const UserCardMedium: React.FC<UserCardMediumProps> = ({
+  userProfile,
+  menuActions,
+  isLarge = false,
+  imageURL,
+  hideEmail = false,
+  disableLink = false,
+  link,
+  openLinkInNewTab = false,
+  isValidated,
+  isCertified,
+}) => {
+  const [showModal, setShowModal] = useState(false)
+  const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
+  const [ORCIDHref, setORCIDHref] = useState<string | undefined>(undefined)
 
-  /**
-   * Function handles copying to clipboard the user's email address
-   *
-   * @param {string} value the email address of the user
-   * @returns
-   */
-  public copyToClipboard = (value: string) => (event: React.SyntheticEvent) => {
-    event.preventDefault()
-    // https://hackernoon.com/copying-text-to-clipboard-with-javascript-df4d4988697f
-    // this copies the email to the clipoard
-    const el = document.createElement('textarea')
-    el.value = value
-    el.setAttribute('readonly', '')
-    el.style.position = 'absolute'
-    el.style.left = '-9999px'
-    this.htmlDivRef.current!.appendChild(el)
-    el.select()
-    document.execCommand('copy')
-    this.htmlDivRef.current!.removeChild(el)
+  const copyToClipboardRef = useRef<HTMLParagraphElement>(null)
+
+  const onCopyToClipboard = () => {
     // show modal and hide after 4 seconds, the timing is per Material Design
-    this.setState({ showModal: true })
+    setShowModal(true)
     // hide after 4 seconds
     setTimeout(() => {
-      this.setState({ showModal: false })
+      setShowModal(false)
     }, 4000)
   }
 
-  public toggleContextMenu = (_event: any) => {
-    this.setState({ isContextMenuOpen: !this.state.isContextMenuOpen })
-  }
+  const {
+    displayName,
+    userName,
+    firstName,
+    lastName,
+    position,
+    company,
+  } = userProfile
 
-  public async updateOrcID() {
-    // PORTALS-1893: Add ORCID to medium/large card
-    const { ORCIDHref } = this.state
-    if (!ORCIDHref) {
-      const {
-        userProfile
-      } = this.props
-      const {
-        ownerId
-      } = userProfile
-      const bundle: UserBundle = await SynapseClient.getUserBundle(
-        ownerId,
-        SynapseConstants.USER_BUNDLE_MASK_ORCID,
-        undefined,
-      )
-      this.setState({ ORCIDHref: bundle.ORCID })
-    }
-  }
-
-  public componentDidMount() {
-    // SWC-4778: https://stackoverflow.com/questions/23821768/how-to-listen-for-click-events-that-are-outside-of-a-component
-    window.addEventListener('mouseup', this.pageClick, false)
-    this.updateOrcID()
-  }
-
-  public componentWillUnmount() {
-    window.removeEventListener('mouseup', this.pageClick, false)
-  }
-
-  public pageClick = (_event: any) => {
-    if (!this.state.isContextMenuOpen) {
-      return
-    }
-    // hide content menu (deferred, to allow menu action to process)
-    setTimeout(() => {
-      if (this.state.isContextMenuOpen) {
-        this.toggleContextMenu(_event)
+  useEffect(() => {
+    const pageClick = (_event: any) => {
+      if (!isContextMenuOpen) {
+        return
       }
-    }, 10)
+      // hide content menu (deferred, to allow menu action to process)
+      setTimeout(() => {
+        if (isContextMenuOpen) {
+          toggleContextMenu(_event)
+        }
+      }, 10)
+    }
+    // SWC-4778: https://stackoverflow.com/questions/23821768/how-to-listen-for-click-events-that-are-outside-of-a-component
+    window.addEventListener('mouseup', pageClick, false)
+    return () => {
+      window.removeEventListener('mouseup', pageClick, false)
+    }
+  }, [])
+
+  useEffect(() => {
+    async function updateOrcID() {
+      // PORTALS-1893: Add ORCID to medium/large card
+      if (!ORCIDHref) {
+        const { ownerId } = userProfile
+        const bundle: UserBundle = await SynapseClient.getUserBundle(
+          ownerId,
+          SynapseConstants.USER_BUNDLE_MASK_ORCID,
+          undefined,
+        )
+        setORCIDHref(bundle.ORCID)
+      }
+    }
+    updateOrcID()
+  }, [userProfile])
+
+  const toggleContextMenu = (_event: any) => {
+    setIsContextMenuOpen(isOpen => !isOpen)
   }
 
-  render() {
-    const {
-      userProfile,
-      menuActions,
-      isLarge = false,
-      imageURL,
-      hideEmail = false,
-      disableLink = false,
-      link,
-      openLinkInNewTab = false,
-      isValidated,
-      isCertified,
-    } = this.props
-    const { isContextMenuOpen, showModal } = this.state
-    const {
-      displayName,
-      userName,
-      firstName,
-      lastName,
-      position,
-      company,
-    } = userProfile
-    const validatedUserProfileTooltipId = `${userName}-tooltip`
-    let name = ''
-    const linkLocation = link
-      ? link
-      : `https://www.synapse.org/#!Profile:${userProfile.ownerId}`
-    // linkLocation is overriden by custom click handler
-    const email = `${userName}@synapse.org`
-    if (displayName) {
-      name = displayName
-    } else if (firstName && lastName) {
-      name = `${firstName} ${lastName}`
-    } else if (userName) {
-      name = userName
-    }
-    const avatar = (
-      <Avatar
-        userProfile={userProfile}
-        imageURL={imageURL}
-        avatarSize={'LARGE'}
-      />
-    )
-    const mediumCard = (
-      <React.Fragment>
-        {!hideEmail && (
-          <ToastMessage
-            show={showModal}
-            text="Email address copied to clipboard"
-            autohide={true}
-          ></ToastMessage>
-        )}
-        {disableLink && avatar}
-        {!disableLink && (
-          // eslint-disable-next-line react/jsx-no-target-blank
-          <a
-            href={linkLocation}
-            target={openLinkInNewTab ? '_blank' : ''}
-            rel={openLinkInNewTab ? 'noreferrer' : ''}
-            className={`SRC-no-underline-on-hover ${
-              isLarge ? 'SRC-isLargeCard' : ''
-            }`}
-          >
-            {avatar}
-          </a>
-        )}
-        <div className="SRC-cardContent">
-          <p className="SRC-eqHeightRow SRC-userCardName">
-            {/*
+  const validatedUserProfileTooltipId = `${userName}-tooltip`
+  let name = ''
+  const linkLocation = link
+    ? link
+    : `https://www.synapse.org/#!Profile:${userProfile.ownerId}`
+  // linkLocation is overriden by custom click handler
+  const email = `${userName}@synapse.org`
+  if (displayName) {
+    name = displayName
+  } else if (firstName && lastName) {
+    name = `${firstName} ${lastName}`
+  } else if (userName) {
+    name = userName
+  }
+  const avatar = (
+    <Avatar
+      userProfile={userProfile}
+      imageURL={imageURL}
+      avatarSize={'LARGE'}
+    />
+  )
+  const mediumCard = (
+    <React.Fragment>
+      {!hideEmail && (
+        <ToastMessage
+          show={showModal}
+          text="Email address copied to clipboard"
+          autohide={true}
+        ></ToastMessage>
+      )}
+      {disableLink && avatar}
+      {!disableLink && (
+        // eslint-disable-next-line react/jsx-no-target-blank
+        <a
+          href={linkLocation}
+          target={openLinkInNewTab ? '_blank' : ''}
+          rel={openLinkInNewTab ? 'noreferrer' : ''}
+          className={`SRC-no-underline-on-hover ${
+            isLarge ? 'SRC-isLargeCard' : ''
+          }`}
+        >
+          {avatar}
+        </a>
+      )}
+      <div className="SRC-cardContent">
+        <p className="SRC-eqHeightRow SRC-userCardName">
+          {/*
               if its a medium component the header should be clickable (unless disableLink is set),
               if its large then it should NOT be clickable
             */}
-            {/* make SRC-whiteText overridable with a good name! */}
-            {isLarge || disableLink ? (
-              <span className={isLarge ? 'SRC-whiteText' : 'SRC-blackText'}>
-                {name}
-              </span>
-            ) : (
-              // consolidate click events
-              // eslint-disable-next-line react/jsx-no-target-blank
-              <a
-                href={linkLocation}
-                target={openLinkInNewTab ? '_blank' : ''}
-                rel={openLinkInNewTab ? 'noreferrer' : ''}
-                tabIndex={0}
-                className={'SRC-hand-cursor SRC-primary-text-color'}
-              >
-                {name}
-              </a>
-            )}
-            {isValidated && (
-              <span
-                data-for={validatedUserProfileTooltipId}
-                data-tip="This user profile has been validated."
-              >
-                <ReactTooltip
-                  delayShow={300}
-                  place="bottom"
-                  type="dark"
-                  effect="solid"
-                  id={validatedUserProfileTooltipId}
-                />
-                {ValidatedProfileIcon}
-              </span>
-            )}
-          </p>
-          {(position || company) && (
-            <p className={`${isLarge ? 'SRC-whiteText' : ''}`}>
-              {position} {position ? ' / ' : ''} {company}
-            </p>
+          {/* make SRC-whiteText overridable with a good name! */}
+          {isLarge || disableLink ? (
+            <span className={isLarge ? 'SRC-whiteText' : 'SRC-blackText'}>
+              {name}
+            </span>
+          ) : (
+            // consolidate click events
+            // eslint-disable-next-line react/jsx-no-target-blank
+            <a
+              href={linkLocation}
+              target={openLinkInNewTab ? '_blank' : ''}
+              rel={openLinkInNewTab ? 'noreferrer' : ''}
+              tabIndex={0}
+              className={'SRC-hand-cursor SRC-primary-text-color'}
+            >
+              {name}
+            </a>
           )}
-          {!hideEmail && (
+          {isValidated && (
+            <span
+              data-for={validatedUserProfileTooltipId}
+              data-tip="This user profile has been validated."
+            >
+              <ReactTooltip
+                delayShow={300}
+                place="bottom"
+                type="dark"
+                effect="solid"
+                id={validatedUserProfileTooltipId}
+              />
+              {ValidatedProfileIcon}
+            </span>
+          )}
+        </p>
+        {(position || company) && (
+          <p className={`${isLarge ? 'SRC-whiteText' : ''}`}>
+            {position} {position ? ' / ' : ''} {company}
+          </p>
+        )}
+        {!hideEmail && (
+          <p
+            ref={copyToClipboardRef}
+            className={`${
+              isLarge
+                ? 'SRC-whiteText'
+                : 'SRC-primary-text-color SRC-primary-color-hover'
+            }
+              SRC-hand-cursor SRC-eqHeightRow SRC-inlineFlex SRC-emailText SRC-cardSvg`}
+            onClick={copyToClipboard(
+              copyToClipboardRef,
+              email,
+              onCopyToClipboard,
+            )}
+            onKeyPress={copyToClipboard(
+              copyToClipboardRef,
+              email,
+              onCopyToClipboard,
+            )}
+            tabIndex={0}
+          >
+            <span style={{ paddingRight: '5px' }}>
+              {`${userName}@synapse.org`}
+            </span>
+            {IconCopy}
+          </p>
+        )}
+        {ORCIDHref && (
+          <a
+            href={ORCIDHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            tabIndex={0}
+          >
             <p
-              className={`${
+              className={
                 isLarge
                   ? 'SRC-whiteText'
                   : 'SRC-primary-text-color SRC-primary-color-hover'
               }
-              SRC-hand-cursor SRC-eqHeightRow SRC-inlineFlex SRC-emailText SRC-cardSvg`}
-              onClick={this.copyToClipboard(email)}
-              onKeyPress={this.copyToClipboard(email)}
-              tabIndex={0}
-              ref={this.htmlDivRef}
             >
-              <span style={{ paddingRight: '5px' }}>
-                {`${userName}@synapse.org`}
-              </span>
-              {IconCopy}
+              View ORCID
             </p>
-          )}
-          {this.state.ORCIDHref && (
-              <a
-              href={this.state.ORCIDHref}
-              target='_blank'
-              rel='noopener noreferrer'
-              tabIndex={0}
-            >
-              <p className={isLarge
-                ? 'SRC-whiteText'
-                : 'SRC-primary-text-color SRC-primary-color-hover'}>View ORCID</p>
-            </a>
-          )}
-        </div>
-        {/* conditionally render menu actions, if its not defined then we don't show the button */}
-        {menuActions && (
-          <React.Fragment>
-            <span
-              className={`SRC-extraPadding SRC-hand-cursor SRC-primary-background-color-hover SRC-inlineBlock
+          </a>
+        )}
+      </div>
+      {/* conditionally render menu actions, if its not defined then we don't show the button */}
+      {menuActions && (
+        <React.Fragment>
+          <span
+            role="menu"
+            className={`SRC-extraPadding SRC-hand-cursor SRC-primary-background-color-hover SRC-inlineBlock
               SRC-cardMenuButton ${
                 isContextMenuOpen ? 'SRC-primary-background-color' : ''
               }`}
-              style={{ outline: 'none' }}
-              tabIndex={0}
-              onClick={this.toggleContextMenu}
-              onKeyPress={this.toggleContextMenu}
-            >
-              <FontAwesomeIcon
-                className={
-                  isContextMenuOpen || isLarge
-                    ? 'SRC-whiteText'
-                    : 'SRC-primary-text-color'
-                }
-                icon="ellipsis-v"
-                fixedWidth={true}
-              />
-            </span>
-            {isContextMenuOpen && (
-              <UserCardContextMenu
-                menuActions={menuActions}
-                userProfile={userProfile}
-              />
-            )}
-          </React.Fragment>
-        )}
-        {!menuActions && <span style={{ padding: '0px 0px 0px 35px' }} />}
-      </React.Fragment>
-    )
+            style={{ outline: 'none' }}
+            tabIndex={0}
+            onClick={toggleContextMenu}
+            onKeyPress={toggleContextMenu}
+          >
+            <FontAwesomeIcon
+              className={
+                isContextMenuOpen || isLarge
+                  ? 'SRC-whiteText'
+                  : 'SRC-primary-text-color'
+              }
+              icon="ellipsis-v"
+              fixedWidth={true}
+            />
+          </span>
+          {isContextMenuOpen && (
+            <UserCardContextMenu
+              menuActions={menuActions}
+              userProfile={userProfile}
+            />
+          )}
+        </React.Fragment>
+      )}
+      {!menuActions && <span style={{ padding: '0px 0px 0px 35px' }} />}
+    </React.Fragment>
+  )
 
-    if (!isLarge) {
-      return (
-        <div
-          style={{ border: '1px solid #DDDDDF', backgroundColor: 'white' }}
-          className={`cardContainer SRC-userCard SRC-userCardMediumUp ${
-            isContextMenuOpen ? 'SRC-hand-cursor' : ''
-          }`}
-          onClick={isContextMenuOpen ? this.toggleContextMenu : undefined}
-        >
-          {mediumCard}
-        </div>
-      )
-    }
-    // else return medium card inside large component
-    // when the component is large we have to set the click handler to wrap both the top and bottom portion
+  if (!isLarge) {
     return (
       <div
-        className={
-          isContextMenuOpen ? 'SRC-hand-cursor cardContainer' : 'cardContainer'
-        }
-        onClick={isContextMenuOpen ? this.toggleContextMenu : undefined}
+        style={{ border: '1px solid #DDDDDF', backgroundColor: 'white' }}
+        className={`cardContainer SRC-userCard SRC-userCardMediumUp ${
+          isContextMenuOpen ? 'SRC-hand-cursor' : ''
+        }`}
+        onClick={isContextMenuOpen ? toggleContextMenu : undefined}
       >
-        <div
-          className={`SRC-primary-background-color SRC-userCard SRC-userCardMediumUp ${
-            isContextMenuOpen ? 'SRC-hand-cursor' : ''
-          }`}
-        >
-          {mediumCard}
-        </div>
-        {isLarge ? (
-          <UserCardLarge userProfile={userProfile} isCertified={isCertified} />
-        ) : (
-          false
-        )}
+        {mediumCard}
       </div>
     )
   }
+  // else return medium card inside large component
+  // when the component is large we have to set the click handler to wrap both the top and bottom portion
+  return (
+    <div
+      className={
+        isContextMenuOpen ? 'SRC-hand-cursor cardContainer' : 'cardContainer'
+      }
+      onClick={isContextMenuOpen ? toggleContextMenu : undefined}
+    >
+      <div
+        className={`SRC-primary-background-color SRC-userCard SRC-userCardMediumUp ${
+          isContextMenuOpen ? 'SRC-hand-cursor' : ''
+        }`}
+      >
+        {mediumCard}
+      </div>
+      {isLarge ? (
+        <UserCardLarge userProfile={userProfile} isCertified={isCertified} />
+      ) : (
+        false
+      )}
+    </div>
+  )
 }
+
+export default UserCardMedium

--- a/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
+++ b/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
@@ -26,7 +26,7 @@ export enum EntityDetailsListDataConfigurationType {
 export type EntityDetailsListDataConfiguration = {
   type: EntityDetailsListDataConfigurationType
   /** Defined if type is HEADER_LIST */
-  headerList?: (EntityHeader | ProjectHeader)[]
+  headerList?: (Pick<EntityHeader, 'name' | 'id' | 'type'> | ProjectHeader)[]
   /** Defined if type is PARENT_CONTAINER */
   parentContainerId?: string
   /** Defined if type is USER_PROJECTS */

--- a/src/lib/containers/entity_finder/tree/TreeNode.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeNode.tsx
@@ -19,7 +19,7 @@ import { BUNDLE_REQUEST_OBJECT } from '../EntityFinderUtils'
 
 export type RootNodeConfiguration = {
   nodeText: string
-  children: (EntityHeader | ProjectHeader)[]
+  children: (Pick<EntityHeader, 'name' | 'id' | 'type'> | ProjectHeader)[]
 }
 
 export enum NodeAppearance {
@@ -28,7 +28,7 @@ export enum NodeAppearance {
 }
 
 export type TreeNodeProps = {
-  entityHeader?: EntityHeader | ProjectHeader
+  entityHeader?: Pick<EntityHeader, 'name' | 'id' | 'type'> | ProjectHeader
   selected: Reference[]
   setSelectedId: (entityId: string) => void
   level?: number
@@ -67,7 +67,7 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
 
   const [isExpanded, setIsExpanded] = useState(isRootNode || autoExpand(nodeId))
   const [entityChildren, setEntityChildren] = useState<
-    (EntityHeader | ProjectHeader)[]
+    (Pick<EntityHeader, 'name' | 'id' | 'type'> | ProjectHeader)[]
   >([])
 
   // For retrieving the entity bundle and children

--- a/src/lib/containers/entity_finder/tree/TreeView.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeView.tsx
@@ -97,7 +97,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
 
   const [isLoading, setIsLoading] = useState(false)
   const [topLevelEntities, setTopLevelEntities] = useState<
-    (EntityHeader | ProjectHeader)[]
+    (Pick<EntityHeader, 'name' | 'id' | 'type'> | ProjectHeader)[]
   >([])
   const [scope, setScope] = useState(initialScope)
   const [initialContainerPath, setInitialContainerPath] = useState<EntityPath>()

--- a/src/lib/testutils/TestingLibraryUtils.tsx
+++ b/src/lib/testutils/TestingLibraryUtils.tsx
@@ -1,0 +1,40 @@
+import React, { ReactNode } from 'react'
+import { QueryClient } from 'react-query'
+import { MOCK_CONTEXT_VALUE } from '../../mocks/MockSynapseContext'
+import {
+  SynapseContextProvider,
+  SynapseContextType,
+} from '../utils/SynapseContext'
+
+type RtlWrapperProps = {
+  children?: ReactNode
+}
+
+/**
+ * Creates a test wrapper for components being tested with @testing-library/react. This wrapper
+ * includes context and an isolated query cache.
+ */
+export const createWrapper = (props?: SynapseContextType) => {
+  // Creating a new query client for each rendering is important isolating tests, otherwise the
+  // cache could be shared across tests.
+  // This is also easier/more reliable than clearing the queryCache after each test.
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30 * 1000, // 30s
+        retry: false, // SynapseClient knows which queries to retry
+      },
+    },
+  })
+  const wrapperProps = props ?? MOCK_CONTEXT_VALUE
+  return function RtlWrapper({ children }: RtlWrapperProps) {
+    return (
+      <SynapseContextProvider
+        synapseContext={wrapperProps}
+        queryClient={queryClient}
+      >
+        {children}
+      </SynapseContextProvider>
+    )
+  }
+}

--- a/src/lib/utils/APIConstants.ts
+++ b/src/lib/utils/APIConstants.ts
@@ -1,0 +1,49 @@
+/**
+ * Separating API endpoints into their own constants file
+ */
+
+import { getEndpoint, BackendDestinationEnum } from './functions/getEndpoint'
+
+export const BACKEND_ENDPOINT = `${getEndpoint(
+  BackendDestinationEnum.REPO_ENDPOINT,
+)}`
+
+export const REPO = `/repo/v1`
+export const AUTH = `/auth/v1`
+export const FILE = `/file/v1`
+
+export const ENTITY = `${REPO}/entity`
+export const ENTITY_ID = (id: string | number) => `${REPO}/entity/${id}`
+/**
+ * Some services allow (but do not require) you to specify the version in the path.
+ */
+export const ENTITY_ID_VERSION = (id: string | number, version?: number) =>
+  `${REPO}/entity/${id}${version ? `/version/${version}` : ''}`
+export const ENTITY_BUNDLE_V2 = (id: string | number, version?: number) =>
+  `${ENTITY_ID_VERSION(id, version)}/bundle2`
+export const ENTITY_ACCESS = (id: string | number) =>
+  `${REPO}/entity/${id}/access`
+
+export const ENTITY_JSON = (id: string | number) => `${REPO}/entity/${id}/json`
+
+export const ENTITY_SCHEMA = (id: string | number) =>
+  `${REPO}/entity/${id}/schema`
+export const ENTITY_SCHEMA_BINDING = (id: string | number) =>
+  `${ENTITY_SCHEMA(id)}/binding`
+export const ENTITY_SCHEMA_VALIDATION = (id: string | number) =>
+  `${ENTITY_SCHEMA(id)}/validation`
+
+export const USER_PROFILE_ENDPOINT = `${REPO}/userProfile`
+
+export const SCHEMA = `${REPO}/schema`
+export const REGISTERED_SCHEMA = `${REPO}/schema/type/registered`
+export const REGISTERED_SCHEMA_ID = (schema$id: string | number) =>
+  `${REPO}/schema/type/registered/${schema$id}`
+
+export const USER = `${REPO}/user`
+export const USER_BUNDLE = `${USER}/bundle`
+export const USER_ID = (id: string | number) => `${USER}/${id}`
+export const USER_ID_BUNDLE = (id: string | number) => `${USER_ID(id)}/bundle`
+
+export const USER_PROFILE = `${REPO}/userProfile`
+export const USER_PROFILE_ID = (id: string | number) => `${USER_PROFILE}/${id}`

--- a/src/lib/utils/functions/EntityTypeUtils.ts
+++ b/src/lib/utils/functions/EntityTypeUtils.ts
@@ -3,7 +3,11 @@ import { ConcreteEntityType } from '../synapseTypes/ConcreteEntityType'
 import { Hit } from '../synapseTypes/Search'
 
 export function getEntityTypeFromHeader(
-  header: EntityHeader | ProjectHeader | Hit,
+  header:
+    | Pick<EntityHeader, 'name' | 'id' | 'type'>
+    | EntityHeader
+    | ProjectHeader
+    | Hit,
 ) {
   // Hit has the `node_type` field which is what we already want.
   if ((header as Hit).node_type) {

--- a/src/lib/utils/functions/getEndpoint.ts
+++ b/src/lib/utils/functions/getEndpoint.ts
@@ -10,7 +10,7 @@ type EndpointObject = {
 }
 
 export const PRODUCTION_ENDPOINT_CONFIG: EndpointObject = {
-  REPO: 'https://repo-prod.prod.sagebase.org/',
+  REPO: 'https://repo-prod.prod.sagebase.org',
   PORTAL: 'https://www.synapse.org/',
 }
 

--- a/src/lib/utils/functions/getUserData.ts
+++ b/src/lib/utils/functions/getUserData.ts
@@ -9,7 +9,7 @@ function getUserProfileWithProfilePicAttached(
   principalIds: string[],
   token?: string,
 ) {
-  return SynapseClient.getUserProfiles(principalIds).then((data) => {
+  return SynapseClient.getUserProfiles(principalIds).then(data => {
     // people will either have a profile pic file handle id
     // or they won't. Have to break this down into two groups.
     const withProfilePic = data.list.filter((value: any) => {
@@ -18,7 +18,7 @@ function getUserProfileWithProfilePicAttached(
     if (withProfilePic.length === 0) {
       return data
     }
-    const fileHandleAssociationList = withProfilePic.map((value) => {
+    const fileHandleAssociationList = withProfilePic.map(value => {
       return {
         associateObjectId: value.ownerId,
         associateObjectType: 'UserProfileAttachment',
@@ -32,12 +32,12 @@ function getUserProfileWithProfilePicAttached(
       requestedFiles: fileHandleAssociationList,
     }
     return SynapseClient.getFiles(request, token)
-      .then((fileHandleList) => {
+      .then(fileHandleList => {
         // we retrieve all the persons with profile pic file handles
         // so we next loop through them, find the original person in the data.list
         // and add a field with their pre-signed url
-        fileHandleList.requestedFiles.forEach((fileHandle) => {
-          const matchingPersonIndex = data.list.findIndex((el) => {
+        fileHandleList.requestedFiles.forEach(fileHandle => {
+          const matchingPersonIndex = data.list.findIndex(el => {
             return fileHandle.fileHandleId === el.profilePicureFileHandleId
           })
           data.list[matchingPersonIndex].clientPreSignedURL =
@@ -45,7 +45,7 @@ function getUserProfileWithProfilePicAttached(
         })
         return Promise.resolve(data)
       })
-      .catch((err) => {
+      .catch(err => {
         throw Error(`Err on getting user data ${err}`)
       })
   })
@@ -53,7 +53,7 @@ function getUserProfileWithProfilePicAttached(
 
 export type UserProfileAndImg = {
   userProfile: UserProfile
-  preSignedURL: string
+  preSignedURL?: string
 }
 function getUserProfileWithProfilePic(
   ownerId: string,
@@ -83,7 +83,7 @@ function getUserProfileWithProfilePic(
       }
 
       return SynapseClient.getFiles(request, token)
-        .then((fileHandleList) => {
+        .then(fileHandleList => {
           // we retrieve all the persons with profile pic file handles
           // so we next loop through them, find the original person in the data.list
           // and add a field with their pre-signed url
@@ -93,7 +93,7 @@ function getUserProfileWithProfilePic(
             preSignedURL: firstElement.preSignedURL,
           })
         })
-        .catch((err) => {
+        .catch(err => {
           console.log({ err })
         })
     },

--- a/src/lib/utils/hooks/SynapseAPI/useUserBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useUserBundle.ts
@@ -39,7 +39,7 @@ export function useGetUserProfileWithProfilePic(
   options?: UseQueryOptions<UserProfileAndImg, SynapseClientError>,
 ) {
   const { accessToken } = useSynapseContext()
-  const queryKey = [accessToken, 'user', principalId, 'profile and pic']
+  const queryKey = [accessToken, 'user', principalId, 'profile', 'withPic']
 
   const { data: userProfile } = useGetUserProfile(principalId)
 

--- a/src/lib/utils/hooks/SynapseAPI/useUserBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useUserBundle.ts
@@ -43,7 +43,7 @@ export function useGetUserProfileWithProfilePic(
 
   const { data: userProfile } = useGetUserProfile(principalId)
 
-  // TODO: create useGetFile hook with careful configuration to prevent serving expired pre-signed URLs without re-fetching every 5 seconds
+  // TODO: create useGetFile hook with careful configuration to prevent serving expired pre-signed URLs
   return useQuery<UserProfileAndImg, SynapseClientError>(
     queryKey,
     () => getProfilePic(userProfile!, accessToken),

--- a/src/lib/utils/hooks/SynapseAPI/useUserBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useUserBundle.ts
@@ -1,22 +1,48 @@
-import { useQuery, UseQueryOptions } from 'react-query'
+import {
+  QueryObserverOptions,
+  useQuery,
+  useQueryClient,
+  UseQueryOptions,
+} from 'react-query'
 import {
   getUserProfileWithProfilePic,
   UserProfileAndImg,
 } from '../../functions/getUserData'
 import { SynapseClientError } from '../../SynapseClient'
 import { useSynapseContext } from '../../SynapseContext'
+import { UserProfile } from '../../synapseTypes'
 
 export function useGetUserProfileWithProfilePic(
   principalId: string,
-  options?: UseQueryOptions<
-    UserProfileAndImg,
-    SynapseClientError,
-    UserProfileAndImg
-  >,
+  options?: UseQueryOptions<UserProfileAndImg, SynapseClientError>,
 ) {
   const { accessToken } = useSynapseContext()
+  const queryClient = useQueryClient()
+  const queryKey = [accessToken, 'user', principalId, 'profile', 'withPic']
+
+  // We store the profile in a session storage cache used by SWC
+  const sessionStorageCacheKey = `${principalId}_USER_PROFILE`
+  const cachedValue = sessionStorage.getItem(sessionStorageCacheKey)
+
+  const defaultOptions: QueryObserverOptions<
+    UserProfileAndImg,
+    SynapseClientError
+  > = {
+    // Use the sessionStorage cache to pre-populate profile data before the request succeeds.
+    placeholderData: cachedValue
+      ? { userProfile: JSON.parse(cachedValue) as UserProfile }
+      : undefined,
+    // When the request succeeds, put the profile in the sessionStorage cache
+    onSuccess: profileAndImage => {
+      sessionStorage.setItem(
+        sessionStorageCacheKey,
+        JSON.stringify(profileAndImage.userProfile),
+      )
+    },
+  }
+  queryClient.setQueryDefaults(queryKey, defaultOptions)
   return useQuery<UserProfileAndImg, SynapseClientError>(
-    ['userprofile', principalId, accessToken],
+    queryKey,
     () => getUserProfileWithProfilePic(principalId, accessToken),
     options,
   )

--- a/src/lib/utils/synapseTypes/CloudProviderFileHandle.ts
+++ b/src/lib/utils/synapseTypes/CloudProviderFileHandle.ts
@@ -12,7 +12,7 @@ export enum CloudProviderFileHandleConcreteTypeEnum {
 interface CloudProviderFileHandleInterface extends FileHandle {
   readonly bucketName: string
   readonly key: string
-  readonly previewId: string
+  readonly previewId?: string
   readonly isPreview: boolean
 }
 

--- a/src/lib/utils/synapseTypes/DoiAssociation.ts
+++ b/src/lib/utils/synapseTypes/DoiAssociation.ts
@@ -8,7 +8,7 @@ export type DoiAssociation = {
   doiUrl: string
   objectId: string
   objectType: ObjectType
-  objectVersion: number
+  objectVersion?: number
   associatedBy: string
   associatedOn: string
   updatedBy: string

--- a/src/lib/utils/synapseTypes/EntityHeader.ts
+++ b/src/lib/utils/synapseTypes/EntityHeader.ts
@@ -1,20 +1,38 @@
 import { ConcreteEntityType } from './ConcreteEntityType'
 
-// https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/EntityHeader.html
+/**
+ * [EntityHeader | Synapse REST Docs](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/EntityHeader.html)
+ */
 export type EntityHeader = {
-  name: string //	The name of the entity
-  id: string //	The id of the entity
-  type: ConcreteEntityType //	The type of the entity
-  versionNumber: number //	The version number of the entity
-  versionLabel: string //	The user defined version label of the entity
-  benefactorId: number //	The ID of the entity that this Entity's ACL is inherited from.
-  createdOn: string //	The date this entity was created.
-  modifiedOn: string //	The date this entity was last modified.
-  createdBy: string //	The ID of the user that created this entity.
-  modifiedBy: string //	The ID of the user that last modified this entity.
+  /**	The name of the entity */
+  name: string
+  /**	The id of the entity */
+  id: string
+  /**	The type of the entity */
+  type: ConcreteEntityType
+  /** The version number of the entity */
+  versionNumber: number
+  /**	The user defined version label of the entity */
+  versionLabel: string
+  /**	The ID of the entity that this Entity's ACL is inherited from. */
+  benefactorId: number
+  /**	The date this entity was created. */
+  createdOn: string
+  /**	The date this entity was last modified. */
+  modifiedOn: string
+  /**	The ID of the user that created this entity. */
+  createdBy: string
+  /**	The ID of the user that last modified this entity. */
+  modifiedBy: string
 }
 
-// https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/EntityPath.html
+/**
+ * The full path for an entity. Note that the root entity, syn4489, may be included.
+ * The docs do not indicate that most fields are omitted from the EntityHeader objects, but our custom type
+ * signature captures this.
+ *
+ * [EntityPath | Synapse REST Docs](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/EntityPath.html)
+ */
 export type EntityPath = {
-  path: EntityHeader[] // The list of all entities in this entity's path. The first element is the root parent and the last element (n) is the entity.
+  path: Pick<EntityHeader, 'name' | 'id' | 'type'>[] // The list of all entities in this entity's path. The first element is the root parent and the last element (n) is the entity.
 }

--- a/src/lib/utils/synapseTypes/FileHandle.ts
+++ b/src/lib/utils/synapseTypes/FileHandle.ts
@@ -19,7 +19,7 @@ export interface FileHandle {
   /** Must be: http://en.wikipedia.org/wiki/Internet_media_type */
   contentType: string
   /** The file's content MD5. */
-  contentMd5: string
+  contentMd5?: string
   /** The short, user visible name for this file. */
   fileName: string
   /** The optional storage location descriptor */

--- a/src/mocks/MockSynapseContext.tsx
+++ b/src/mocks/MockSynapseContext.tsx
@@ -16,6 +16,8 @@ export const MOCK_CONTEXT = React.createContext(MOCK_CONTEXT_VALUE)
 
 /**
  * Full context object with default values for testing.
+ *
+ * If using @testing-library/react, see {@link TestingLibraryUtils#createWrapper}
  */
 export const SynapseTestContext = jest
   .fn()

--- a/src/mocks/entity/mockEntity.ts
+++ b/src/mocks/entity/mockEntity.ts
@@ -1,15 +1,54 @@
-import { Entity, EntityHeader, FileEntity } from '../../lib/utils/synapseTypes'
+import {
+  AnnotationsValueType,
+  Entity,
+  EntityBundle,
+  EntityHeader,
+  EntityType,
+  FileEntity,
+  ObjectType,
+  RestrictionLevel,
+} from '../../lib/utils/synapseTypes'
+import {
+  mockFileHandle,
+  mockPreviewFileHandle,
+  MOCK_FILE_HANDLE_ID,
+} from '../mock_file_handle'
+import { MOCK_USER_ID } from '../user/mock_user_profile'
 
-export const MOCK_FILE_HANDLE_ID = 'syn123'
+export const MOCK_FILE_ENTITY_ID = 'syn123'
 export const MOCK_FOLDER_ID = 'syn1234'
 export const MOCK_PROJECT_ID = 'syn12345'
 
 export const mockFileEntity: FileEntity = {
-  id: MOCK_FILE_HANDLE_ID,
+  id: MOCK_FILE_ENTITY_ID,
   parentId: MOCK_PROJECT_ID,
-  dataFileHandleId: '123332',
-  name: 'my file name',
+  dataFileHandleId: MOCK_FILE_HANDLE_ID,
+  name: 'My mock file entity',
   concreteType: 'org.sagebionetworks.repo.model.FileEntity',
+}
+
+export const mockFileEntityBundle: EntityBundle = {
+  entity: mockFileEntity,
+  entityType: EntityType.FILE,
+  fileHandles: [mockFileHandle, mockPreviewFileHandle],
+  annotations: {
+    id: MOCK_FILE_ENTITY_ID,
+    etag: '00000000-0000-0000-0000-000000000000',
+    annotations: {
+      myStringKey: {
+        type: AnnotationsValueType.STRING,
+        value: ['myValue'],
+      },
+      myIntegerKey: {
+        type: AnnotationsValueType.LONG,
+        value: [4325435345213, 4321],
+      },
+      myFloatKey: {
+        type: AnnotationsValueType.LONG,
+        value: [1.5, 17 / 13],
+      },
+    },
+  },
 }
 
 export const mockFileEntityHeader: EntityHeader = {
@@ -43,4 +82,145 @@ export const mockFolderEntityHeader: EntityHeader = {
   modifiedOn: '',
   createdBy: '', // TODO: Replace with a valid mock user ID
   modifiedBy: '',
+}
+
+export const mockProjectEntityBundle: EntityBundle = {
+  entity: {
+    name: 'A Mock Project',
+    id: MOCK_PROJECT_ID,
+    etag: '7849ff2c-1c93-4104-adcf-9e6d6b0c50b5',
+    createdOn: '2020-11-18T20:05:06.519Z',
+    modifiedOn: '2021-05-19T12:44:35.457Z',
+    createdBy: `${MOCK_USER_ID}`,
+    modifiedBy: `${MOCK_USER_ID}`,
+    parentId: 'syn4489',
+    concreteType: 'org.sagebionetworks.repo.model.Project',
+  },
+  entityType: EntityType.PROJECT,
+  annotations: {
+    id: MOCK_PROJECT_ID,
+    etag: '7849ff2c-1c93-4104-adcf-9e6d6b0c50b5',
+    annotations: {
+      projectImage: {
+        type: AnnotationsValueType.STRING,
+        value: ['69006408'],
+      },
+      projectDescription: {
+        type: AnnotationsValueType.STRING,
+        value: ['WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW'],
+      },
+      projectDisplayName: {
+        type: AnnotationsValueType.STRING,
+        value: ['WWWWWWWWWWWWWWWWWW'],
+      },
+    },
+  },
+  permissions: {
+    canView: true,
+    canEdit: true,
+    canAddChild: true,
+    canCertifiedUserEdit: true,
+    canCertifiedUserAddChild: true,
+    isCertifiedUser: true,
+    canChangePermissions: true,
+    canChangeSettings: true,
+    canDelete: true,
+    canDownload: true,
+    canUpload: true,
+    canEnableInheritance: false,
+    ownerPrincipalId: MOCK_USER_ID,
+    canPublicRead: true,
+    canModerate: true,
+    isCertificationRequired: true,
+  },
+  path: {
+    path: [
+      {
+        name: 'root',
+        id: 'syn4489',
+        type: 'org.sagebionetworks.repo.model.Folder',
+      },
+      {
+        name: 'A Mock Project',
+        id: MOCK_PROJECT_ID,
+        type: 'org.sagebionetworks.repo.model.Project',
+      },
+    ],
+  },
+  hasChildren: true,
+  accessControlList: {
+    id: MOCK_PROJECT_ID,
+    creationDate: '2020-11-18T20:05:06.540Z',
+    etag: 'f143bbfd-ba09-4a42-b1e9-f9368777ad9b',
+    resourceAccess: [
+      {
+        principalId: MOCK_USER_ID,
+        accessType: [
+          'DELETE',
+          'CHANGE_SETTINGS',
+          'MODERATE',
+          'CHANGE_PERMISSIONS',
+          'UPDATE',
+          'READ',
+          'DOWNLOAD',
+          'CREATE',
+        ],
+      },
+      {
+        principalId: 273948,
+        accessType: ['READ'],
+      },
+      {
+        principalId: 273949,
+        accessType: ['READ'],
+      },
+    ],
+  },
+  fileHandles: [],
+  rootWikiId: '607416',
+  benefactorAcl: {
+    id: MOCK_PROJECT_ID,
+    creationDate: '2020-11-18T20:05:06.540Z',
+    etag: 'f143bbfd-ba09-4a42-b1e9-f9368777ad9b',
+    resourceAccess: [
+      {
+        principalId: MOCK_USER_ID,
+        accessType: [
+          'DELETE',
+          'CHANGE_SETTINGS',
+          'MODERATE',
+          'CHANGE_PERMISSIONS',
+          'UPDATE',
+          'READ',
+          'DOWNLOAD',
+          'CREATE',
+        ],
+      },
+      {
+        principalId: 273948,
+        accessType: ['READ'],
+      },
+      {
+        principalId: 273949,
+        accessType: ['READ'],
+      },
+    ],
+  },
+  doiAssociation: {
+    associationId: '9606623',
+    etag: 'ddef9fe1-56b2-42f5-9a3c-db2d6f15401b',
+    doiUri: `10.7303/${MOCK_PROJECT_ID}`,
+    doiUrl: `https://repo-prod.prod.sagebase.org/repo/v1/doi/locate?id=${MOCK_PROJECT_ID}&type=ENTITY`,
+    objectId: MOCK_PROJECT_ID,
+    objectType: ObjectType.ENTITY,
+    associatedBy: `${MOCK_USER_ID}`,
+    associatedOn: '2021-01-04T15:42:18.000Z',
+    updatedBy: `${MOCK_USER_ID}`,
+    updatedOn: '2021-04-28T18:49:48.000Z',
+  },
+  threadCount: 2,
+  restrictionInformation: {
+    restrictionLevel: RestrictionLevel.OPEN,
+    hasUnmetAccessRequirement: false,
+  },
 }

--- a/src/mocks/mockSchema.ts
+++ b/src/mocks/mockSchema.ts
@@ -1,0 +1,23 @@
+import {
+  BoundObjectType,
+  JsonSchemaObjectBinding,
+} from '../lib/utils/synapseTypes/Schema/JsonSchemaObjectBinding'
+
+export const mockSchemaBinding: JsonSchemaObjectBinding = {
+  jsonSchemaVersionInfo: {
+    organizationId: '1',
+    organizationName: 'org.sagebionetworks',
+    schemaId: '1',
+    schemaName: 'Mock schema',
+    versionId: '555',
+    $id: 'mock-schema',
+    jsonSHA256Hex:
+      '5f2cd73c0fe25b30cbee2f213b6d633951f1873ca1911f494d4654f702a69e95',
+    createdOn: '2021-04-01T08:00:00.000Z',
+    createdBy: '1',
+  },
+  objectId: 3333,
+  objectType: BoundObjectType.entity,
+  createdOn: '2021-04-01T08:00:00.000Z',
+  createdBy: '1',
+}

--- a/src/mocks/mock_file_handle.ts
+++ b/src/mocks/mock_file_handle.ts
@@ -1,14 +1,40 @@
-import { FileHandle } from '../lib/utils/synapseTypes/'
+import {
+  CloudProviderFileHandleConcreteTypeEnum,
+  S3FileHandle,
+} from '../lib/utils/synapseTypes/CloudProviderFileHandle'
+import { MOCK_USER_ID } from './user/mock_user_profile'
 
-export const mockFileHandle:FileHandle = {
-  id: "8781190",
-  etag: "abc-deg-4028-8eb8-aaaaa",
-  createdBy: "33203344343",
-  createdOn: "2016-05-09T22:08:22.000Z",
-  concreteType: "org.sagebionetworks.repo.model.file.S3FileHandle",
-  contentType: "application/octet-stream",
-  contentMd5: "123456789",
-  fileName: "ACT_Proteomics_PFC_RAW_ad_act27.raw",
+export const MOCK_FILE_HANDLE_ID = '987654321'
+export const MOCK_PREVIEW_FILE_HANDLE_ID = '987654322'
+
+export const mockFileHandle: S3FileHandle = {
+  id: `${MOCK_FILE_HANDLE_ID}`,
+  etag: 'abc-deg-4028-8eb8-aaaaa',
+  createdBy: `${MOCK_USER_ID}`,
+  createdOn: '2016-05-09T22:08:22.000Z',
+  concreteType: CloudProviderFileHandleConcreteTypeEnum.S3FileHandle,
+  contentType: 'application/octet-stream',
+  contentMd5: '123456789',
+  fileName: 'mock-file.raw',
   storageLocationId: 1,
-  contentSize: 20
+  contentSize: 20,
+  bucketName: 'proddata.sagebase.org',
+  key: `${MOCK_USER_ID}/mock-s3-key/file1.txt`,
+  previewId: `${MOCK_PREVIEW_FILE_HANDLE_ID}`,
+  isPreview: false,
+}
+
+export const mockPreviewFileHandle: S3FileHandle = {
+  id: '76215986',
+  etag: '95404487-9f9a-46ce-bf97-03d434579fb1',
+  createdBy: `${MOCK_USER_ID}`,
+  createdOn: '2021-05-17T19:29:37.000Z',
+  concreteType: CloudProviderFileHandleConcreteTypeEnum.S3FileHandle,
+  contentType: 'text/plain',
+  fileName: 'preview.txt',
+  storageLocationId: 1,
+  contentSize: 100,
+  bucketName: 'proddata.sagebase.org',
+  key: `${MOCK_USER_ID}/mock-s3-key`,
+  isPreview: true,
 }

--- a/src/mocks/msw/handlers.ts
+++ b/src/mocks/msw/handlers.ts
@@ -32,11 +32,13 @@ const handlers = [
       ':id',
     )}`,
     async (req, res, ctx) => {
-      let response
+      let response = {}
+      let status = 404
       if (req.params.id === MOCK_USER_ID.toString()) {
         response = mockUserProfileData
+        status = 200
       }
-      return res(ctx.status(200), ctx.json(response))
+      return res(ctx.status(status), ctx.json(response))
     },
   ),
 
@@ -45,11 +47,13 @@ const handlers = [
       ':id',
     )}`,
     async (req, res, ctx) => {
-      let response
+      let response = {}
+      let status = 404
       if (req.params.id === MOCK_USER_ID.toString()) {
         response = mockUserBundle
+        status = 200
       }
-      return res(ctx.status(200), ctx.json(response))
+      return res(ctx.status(status), ctx.json(response))
     },
   ),
 
@@ -58,13 +62,16 @@ const handlers = [
       ':entityId',
     )}`,
     async (req, res, ctx) => {
-      let response
+      let response = {}
+      let status = 404
       if (req.params.entityId === MOCK_FILE_ENTITY_ID) {
         response = mockFileEntityBundle
+        status = 200
       } else if (req.params.entityId === MOCK_PROJECT_ID) {
         response = mockProjectEntityBundle
+        status = 200
       }
-      return res(ctx.status(200), ctx.json(response))
+      return res(ctx.status(status), ctx.json(response))
     },
   ),
 

--- a/src/mocks/msw/handlers.ts
+++ b/src/mocks/msw/handlers.ts
@@ -1,0 +1,81 @@
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '../../lib/utils/functions/getEndpoint'
+import { mockSchemaBinding } from '../mockSchema'
+import { rest } from 'msw'
+import {
+  mockFileEntityBundle,
+  mockProjectEntityBundle,
+  MOCK_FILE_ENTITY_ID,
+  MOCK_PROJECT_ID,
+} from '../entity/mockEntity'
+import {
+  mockUserBundle,
+  mockUserProfileData,
+  MOCK_USER_ID,
+} from '../user/mock_user_profile'
+import {
+  ENTITY_BUNDLE_V2,
+  ENTITY_SCHEMA_BINDING,
+  USER_ID_BUNDLE,
+  USER_PROFILE_ID,
+} from '../../lib/utils/APIConstants'
+
+const handlers = [
+  rest.options('*', async (req, res, ctx) => {
+    return res(ctx.status(200))
+  }),
+
+  rest.get(
+    `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${USER_PROFILE_ID(
+      ':id',
+    )}`,
+    async (req, res, ctx) => {
+      let response
+      if (req.params.id === MOCK_USER_ID.toString()) {
+        response = mockUserProfileData
+      }
+      return res(ctx.status(200), ctx.json(response))
+    },
+  ),
+
+  rest.get(
+    `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${USER_ID_BUNDLE(
+      ':id',
+    )}`,
+    async (req, res, ctx) => {
+      let response
+      if (req.params.id === MOCK_USER_ID.toString()) {
+        response = mockUserBundle
+      }
+      return res(ctx.status(200), ctx.json(response))
+    },
+  ),
+
+  rest.post(
+    `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
+      ':entityId',
+    )}`,
+    async (req, res, ctx) => {
+      let response
+      if (req.params.entityId === MOCK_FILE_ENTITY_ID) {
+        response = mockFileEntityBundle
+      } else if (req.params.entityId === MOCK_PROJECT_ID) {
+        response = mockProjectEntityBundle
+      }
+      return res(ctx.status(200), ctx.json(response))
+    },
+  ),
+
+  rest.get(
+    `${getEndpoint(
+      BackendDestinationEnum.REPO_ENDPOINT,
+    )}${ENTITY_SCHEMA_BINDING(':entityId')}`,
+    async (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json(mockSchemaBinding))
+    },
+  ),
+]
+
+export { handlers }

--- a/src/mocks/msw/server.ts
+++ b/src/mocks/msw/server.ts
@@ -1,0 +1,7 @@
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+const server = setupServer(...handlers)
+
+export { server, rest }

--- a/src/mocks/user/mock_user_profile.ts
+++ b/src/mocks/user/mock_user_profile.ts
@@ -4,24 +4,26 @@ import {
   UserProfile,
 } from '../../lib/utils/synapseTypes'
 
+export const MOCK_USER_ID = 999
+
 export const mockUserProfileData: UserProfile = {
-  summary: 'my summary data',
+  summary: 'My summary bio',
   firstName: 'First',
   lastName: 'Last',
   location: 'Seattle,WA,USA',
   industry: '',
   company: 'Researcher',
   position: '',
-  ownerId: '1',
+  ownerId: `${MOCK_USER_ID}`,
   userName: 'myUserName',
   createdOn: '2018-06-18T21:42:48.000Z',
   url: '',
 }
 
 export const mockUserBundle: UserBundle = {
-  userId: '1',
+  userId: `${MOCK_USER_ID}`,
   userProfile: {
-    ownerId: '123456789',
+    ownerId: `${MOCK_USER_ID}`,
     firstName: 'First',
     lastName: 'Last',
     userName: 'myUserName',
@@ -41,7 +43,7 @@ export const mockUserBundle: UserBundle = {
 }
 
 export const mockUserGroupHeader: UserGroupHeader = {
-  ownerId: '123456789',
+  ownerId: `${MOCK_USER_ID}`,
   firstName: 'First',
   lastName: 'Last',
   userName: 'myUserName',


### PR DESCRIPTION
None of this is directly related to SWC-5620 but all of these changes made developing/testing SWC-5620 easier. Most of the changes are related to mocks and running msw.

Summary:
* Refactored UserCard (it was hard to test UserCard with msw in new components for SWC-5620)
	* Now uses existing hook to fetch user data and profile picture. Previously, UserCard was using a sessionStorage cache, but now it uses react-query and duplicated logic to fetch a profile picture was removed.
* Refactored UserCardMedium
	* Converted from class component to function component
	* This was unnecessary, but it made it easier for me to reason with the component's lifecycle. I can revert if desired.
* UserCardTests.test.tsx changes
	* Now uses Mock Service worker. The worker only gets invoked for one or two tests, but it's a start.
	* Use a more reliable, reusable wrapper for React Testing Library tests
* Started converting SynapseClient API paths to constants
	* We need the API paths for Mock Service Worker, so these should be reusable constants.
* Reorganized mocks and added Mock Service Worker handlers
	* Some of the handlers are unused here but will be used in SWC-5620 tests.
	* Mocks have been fleshed out a bit
* Various type improvements to better reflect actual server responses