### PR TITLE
fix selector specificity issue discovered in portals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/containers/row_renderers/utils/CardFooter.tsx
+++ b/src/lib/containers/row_renderers/utils/CardFooter.tsx
@@ -142,10 +142,10 @@ class CardFooter extends React.Component<CardFooterProps, State> {
             {this.renderRows(valuesFiltered, limit, isDesktop)}
             {hasMoreValuesThanLimit && (
               <tr className="SRC-cardRow">
-                <td className="SRC-primary-color-border-bottom">
+                <td>
                   <button
                     style={{ textAlign: 'left', margin: 0, padding: 0 }}
-                    className="SRC-primary-text-color SRC-basicButton"
+                    className="SRC-primary-text-color SRC-basicButton primary-underlined-button"
                     onClick={this.toggleShowMore}
                   >
                     Show {isShowMoreOn ? 'Less' : 'More'}

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -361,7 +361,7 @@ button.SRC-roundBorder {
   border-bottom: 1px solid SRC.$border-color-gray;
 }
 
-.SRC-primary-color-border-bottom {
+button.primary-underlined-button {
   border-bottom: 1px solid SRC.$primary-action-color;
 }
 


### PR DESCRIPTION
In portals, table data element is much larger than the button.  But we can't just set the css class on the button since the border definition in SRC-basicButton overrides.  So make this a button-specific css style.