### PR TITLE
SWC-5695

### DIFF
--- a/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
+++ b/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
@@ -11,12 +11,19 @@ import { Button, FormGroup, FormLabel } from 'react-bootstrap'
  * Used just to apply custom styling.
  */
 export function CustomArrayFieldTemplate<T>(props: ArrayFieldTemplateProps<T>) {
+  const { DescriptionField } = props
   return (
     <FormGroup className={props.className}>
       <FormLabel>
         {props.title}
         {props.required && <span className="required">*</span>}
       </FormLabel>
+      {props.schema.description && (
+        <DescriptionField
+          id={`${props.idSchema.$id}__description`}
+          description={props.schema.description}
+        />
+      )}
       {props.items && (
         <>
           {props.items.map((element, index) => (


### PR DESCRIPTION
Displays the description for array fields. The description was missing before this change.

<img width="873" alt="image" src="https://user-images.githubusercontent.com/17580037/127528936-bad43b79-1ce8-4c9a-ab37-72cac1ff1358.png">
