### PR TITLE
Add new Annotation Editor to Entity Modal + other changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@fortawesome/react-fontawesome": "^0.1.3",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.57",
     "@rjsf/core": "^3.0.0",
     "@sage-bionetworks/rjsf-core": "^3.1.3",
     "@upsetjs/react": "^1.6.2",

--- a/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
+++ b/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
@@ -54,7 +54,7 @@ export function CustomArrayFieldTemplate<T>(props: ArrayFieldTemplateProps<T>) {
                 onClick={props.onAddClick}
                 type="button"
               >
-                Add Item <Add />
+                Add Value
               </Button>
             </div>
           )}

--- a/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
+++ b/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
@@ -35,6 +35,8 @@ export type SchemaDrivenAnnotationEditorProps = {
   schemaId?: string
   liveValidate?: boolean
   onSuccess?: () => void
+  /** If defined, shows a 'Cancel' button and runs this effect on click */
+  onCancel?: () => void
 }
 
 export type SchemaDrivenAnnotationEditorModalProps = {
@@ -72,6 +74,7 @@ export const SchemaDrivenAnnotationEditor: React.FunctionComponent<SchemaDrivenA
   onSuccess = () => {
     /* no-op */
   },
+  onCancel,
 }: SchemaDrivenAnnotationEditorProps) => {
   const formRef = useRef<Form<Record<string, unknown>>>(null)
 
@@ -145,9 +148,11 @@ export const SchemaDrivenAnnotationEditor: React.FunctionComponent<SchemaDrivenA
   )
 
   return (
-    <div className="bootstrap-4-backport">
+    <div className="bootstrap-4-backport AnnotationEditor">
       {isLoading ? (
-        <SynapseSpinner />
+        <div className="LoadingPlaceholder">
+          <SynapseSpinner size={30} />
+        </div>
       ) : (
         <>
           <ReactTooltip id={ANNOTATION_EDITOR_TOOLTIP_ID} />
@@ -188,7 +193,7 @@ export const SchemaDrivenAnnotationEditor: React.FunctionComponent<SchemaDrivenA
             </Alert>
           )}
           <Form
-            className="AnnotationEditor"
+            className="AnnotationEditorForm"
             liveValidate={liveValidate}
             noHtml5Validate={true}
             ArrayFieldTemplate={CustomArrayFieldTemplate}
@@ -293,6 +298,14 @@ export const SchemaDrivenAnnotationEditor: React.FunctionComponent<SchemaDrivenA
               >
                 {entityId ? 'Save' : 'Validate'}
               </Button>
+              {onCancel && (
+                <>
+                  <div className="Spacer" />
+                  <Button variant="primary-500" onClick={onCancel}>
+                    Cancel
+                  </Button>
+                </>
+              )}
             </div>
           </Form>
           {showConfirmation && (

--- a/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
+++ b/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
@@ -61,14 +61,6 @@ const patternPropertiesBannedKeys = entityJsonKeys.reduce((current, item) => {
   return current
 }, {})
 
-function getStandardEntityFields(json: EntityJson): EntityJson {
-  return pick(json, entityJsonKeys) as EntityJson
-}
-
-function removeStandardEntityFields(json: EntityJson): Record<string, unknown> {
-  return omit(json, entityJsonKeys)
-}
-
 /**
  * Renders a form for editing an entity's annotations. The component also supports supplying just a schema ID,
  * but work to support annotation flows without an entity (i.e. before creating entities) is not yet complete.
@@ -82,11 +74,6 @@ export const SchemaDrivenAnnotationEditor: React.FunctionComponent<SchemaDrivenA
   },
 }: SchemaDrivenAnnotationEditorProps) => {
   const formRef = useRef<Form<Record<string, unknown>>>(null)
-
-  // If fetching an entity, store the non-annotation fields in this object
-  const [entityJson, setEntityJson] = React.useState<
-    Record<string, unknown> | undefined
-  >(undefined)
 
   // Annotation fields fetched and modified via the form
   const [formData, setFormData] = React.useState<
@@ -108,22 +95,16 @@ export const SchemaDrivenAnnotationEditor: React.FunctionComponent<SchemaDrivenA
 
   const ANNOTATION_EDITOR_TOOLTIP_ID = 'AnnotationEditorTooltip'
 
-  const { data: json } = useGetJson(entityId!, {
+  const { entityMetadata: entityJson, annotations } = useGetJson(entityId!, {
     enabled: !entityId || !formData, // once we have data, don't refetch. it would overwrite the user's entries
   })
 
   useEffect(() => {
-    if (json) {
-      /**
-       * To only show annotations in the form, we must remove non-annotation fields.
-       * We will need to submit these values when we create the entity, so we set them aside
-       * and will merge objects later.
-       */
-
-      setEntityJson(getStandardEntityFields(json))
-      setFormData(removeStandardEntityFields(json))
+    if (annotations) {
+      // Put the annotations into a state variable so it can be modified by the form.
+      setFormData(annotations)
     }
-  }, [json])
+  }, [annotations])
 
   const { data: schema, isLoading: isLoadingBinding } = useGetSchemaBinding(
     entityId!,

--- a/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
+++ b/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
@@ -1,6 +1,6 @@
 import Form, { AjvError } from '@sage-bionetworks/rjsf-core'
 import { JSONSchema7 } from 'json-schema'
-import { isEmpty, omit, pick } from 'lodash-es'
+import { isEmpty } from 'lodash-es'
 import React, { useEffect, useRef } from 'react'
 import { Alert, Button, Modal } from 'react-bootstrap'
 import ReactTooltip from 'react-tooltip'
@@ -18,7 +18,7 @@ import {
   useGetSchemaBinding,
 } from '../../../utils/hooks/SynapseAPI/useSchema'
 import { SynapseClientError } from '../../../utils/SynapseClient'
-import { EntityJson, entityJsonKeys } from '../../../utils/synapseTypes'
+import { entityJsonKeys } from '../../../utils/synapseTypes'
 import { SynapseSpinner } from '../../LoadingScreen'
 import { AdditionalPropertiesSchemaField } from './AdditionalPropertiesSchemaField'
 import { CustomAdditionalPropertiesFieldTemplate } from './CustomAdditionalPropertiesFieldTemplate'

--- a/src/lib/containers/entity/metadata/AnnotationsTable.tsx
+++ b/src/lib/containers/entity/metadata/AnnotationsTable.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 import { isEmpty } from 'lodash-es'
-import { entityTypeToFriendlyName } from '../../../utils/functions/EntityTypeUtils'
+import {
+  convertToEntityType,
+  entityTypeToFriendlyName,
+} from '../../../utils/functions/EntityTypeUtils'
 import {
   BackendDestinationEnum,
   getEndpoint,
 } from '../../../utils/functions/getEndpoint'
-import useGetEntityBundle from '../../../utils/hooks/SynapseAPI/useEntityBundle'
 import { useGetSchemaBinding } from '../../../utils/hooks/SynapseAPI/useSchema'
 import { useSynapseContext } from '../../../utils/SynapseContext'
+import { useGetJson } from '../../../utils/hooks/SynapseAPI/useEntity'
 
 export type AnnotationsTableProps = {
   entityId: string
@@ -21,38 +24,40 @@ export const AnnotationsTable: React.FC<AnnotationsTableProps> = ({
    */
   const { isInExperimentalMode } = useSynapseContext()
 
-  const { data: entityBundle } = useGetEntityBundle(entityId)
+  const { entityMetadata, annotations } = useGetJson(entityId)
 
   const { data: boundSchema } = useGetSchemaBinding(entityId, {
     enabled: isInExperimentalMode,
   })
 
-  return entityBundle ? (
+  return entityMetadata && annotations ? (
     <>
-      {isEmpty(entityBundle.annotations?.annotations) ? (
+      {isEmpty(annotations) ? (
         <div className="placeholder">
-          This {entityTypeToFriendlyName(entityBundle.entityType!)} has no
-          annotations.
+          This{' '}
+          {entityTypeToFriendlyName(
+            convertToEntityType(entityMetadata.concreteType),
+          )}{' '}
+          has no annotations.
         </div>
       ) : null}
       <table className="AnnotationsTable">
         <tbody>
-          {Object.keys(entityBundle.annotations?.annotations ?? []).map(
-            (key: string) => {
-              return (
-                <tr key={key} className="AnnotationsTable__Row">
-                  <td className="AnnotationsTable__Row__Key">{key}</td>
-                  <td className="AnnotationsTable__Row__Value">
-                    {entityBundle.annotations?.annotations[key].value
-                      ? entityBundle.annotations?.annotations[key].value.join(
-                          ', ',
-                        )
-                      : null}
-                  </td>
-                </tr>
-              )
-            },
-          )}
+          {Object.keys(annotations).map((key: string) => {
+            return (
+              <tr key={key} className="AnnotationsTable__Row">
+                <td className="AnnotationsTable__Row__Key">{key}</td>
+                <td className="AnnotationsTable__Row__Value">
+                  {Array.isArray(annotations[key])
+                    ? (annotations[key] as
+                        | string[]
+                        | number[]
+                        | boolean[]).join(', ')
+                    : annotations[key]!.toString()}
+                </td>
+              </tr>
+            )
+          })}
           {boundSchema && isInExperimentalMode ? (
             <tr className="AnnotationsTable__Row">
               <td className="AnnotationsTable__Row__Key Schema">

--- a/src/lib/containers/entity/metadata/EntityModal.tsx
+++ b/src/lib/containers/entity/metadata/EntityModal.tsx
@@ -99,7 +99,9 @@ export const EntityModal: React.FC<EntityModalProps> = ({
       {!isInEditMode && ( // in edit mode, an editor manages its own footer
         <Modal.Footer>
           <div className="ButtonContainer">
-            {entityBundle && entityBundle.permissions?.canEdit ? (
+            {entityBundle &&
+            entityBundle.permissions?.canEdit &&
+            currentTab === EntityModalTabs.ANNOTATIONS ? ( // Currently only have an editor for annotations
               <>
                 <Button
                   variant="primary-500"

--- a/src/lib/containers/entity/metadata/EntityModal.tsx
+++ b/src/lib/containers/entity/metadata/EntityModal.tsx
@@ -6,9 +6,9 @@ import {
   getEndpoint,
 } from '../../../utils/functions/getEndpoint'
 import useGetEntityBundle from '../../../utils/hooks/SynapseAPI/useEntityBundle'
-import { SynapseSpinner } from '../../LoadingScreen'
 import { AnnotationsTable } from './AnnotationsTable'
 import { MetadataTable } from './MetadataTable'
+import Skeleton from '@material-ui/lab/Skeleton'
 
 export enum EntityModalTabs {
   METADATA = 'METADATA', // non-annotation metadata about the entity
@@ -34,10 +34,9 @@ export const EntityModal: React.FC<EntityModalProps> = ({
   initialTab = EntityModalTabs.METADATA,
   showTabs = true,
 }: EntityModalProps) => {
+
   const [currentTab, setCurrentTab] = useState<EntityModalTabs>(initialTab)
-  const { data: entityBundle, isLoading: isLoadingBundle } = useGetEntityBundle(
-    entityId,
-  )
+  const { data: entityBundle, isLoading } = useGetEntityBundle(entityId)
 
   return (
     <Modal
@@ -47,9 +46,13 @@ export const EntityModal: React.FC<EntityModalProps> = ({
       onHide={onClose}
     >
       <Modal.Header closeButton>
-        <Modal.Title>
-          {isLoadingBundle ? <SynapseSpinner /> : entityBundle?.entity?.name}
-        </Modal.Title>
+        {entityBundle ? (
+          <Modal.Title>{entityBundle.entity!.name}</Modal.Title>
+        ) : (
+          <Skeleton>
+            <Modal.Title>Placeholder</Modal.Title>
+          </Skeleton>
+        )}
       </Modal.Header>
       <Modal.Body>
         {showTabs ? (
@@ -72,39 +75,38 @@ export const EntityModal: React.FC<EntityModalProps> = ({
             })}
           </div>
         ) : null}
-        {isLoadingBundle ? (
-          <SynapseSpinner />
-        ) : (
-          <>
-            {currentTab === EntityModalTabs.ANNOTATIONS && (
-              <AnnotationsTable entityId={entityId} />
-            )}
-            {currentTab === EntityModalTabs.METADATA && (
-              <MetadataTable entityId={entityId} />
-            )}
-          </>
-        )}
+        <>
+          {currentTab === EntityModalTabs.ANNOTATIONS && (
+            <AnnotationsTable entityId={entityId} />
+          )}
+          {currentTab === EntityModalTabs.METADATA && (
+            <MetadataTable entityId={entityId} />
+          )}
+        </>
       </Modal.Body>
       <Modal.Footer>
         <div className="ButtonContainer">
           <div className="Spacer" />
-          <Button
-            variant="primary"
-            onClick={() =>
-              window.open(
-                `${getEndpoint(
-                  BackendDestinationEnum.PORTAL_ENDPOINT,
-                )}#!Synapse:${entityId}`,
-                '_blank',
-                'noopener',
-              )
-            }
-          >
-            Open{' '}
-            {!isLoadingBundle
-              ? entityTypeToFriendlyName(entityBundle!.entityType!)
-              : ''}
-          </Button>
+          {entityBundle ? (
+            <Button
+              variant="primary"
+              onClick={() =>
+                window.open(
+                  `${getEndpoint(
+                    BackendDestinationEnum.PORTAL_ENDPOINT,
+                  )}#!Synapse:${entityId}`,
+                  '_blank',
+                  'noopener',
+                )
+              }
+            >
+              Open {entityTypeToFriendlyName(entityBundle.entityType!)}
+            </Button>
+          ) : (
+            <Skeleton>
+              <Button>Open</Button>
+            </Skeleton>
+          )}
         </div>
       </Modal.Footer>
     </Modal>

--- a/src/lib/containers/entity/metadata/EntityModal.tsx
+++ b/src/lib/containers/entity/metadata/EntityModal.tsx
@@ -9,6 +9,7 @@ import useGetEntityBundle from '../../../utils/hooks/SynapseAPI/useEntityBundle'
 import { AnnotationsTable } from './AnnotationsTable'
 import { MetadataTable } from './MetadataTable'
 import Skeleton from '@material-ui/lab/Skeleton'
+import { SchemaDrivenAnnotationEditor } from '../annotations/SchemaDrivenAnnotationEditor'
 
 export enum EntityModalTabs {
   METADATA = 'METADATA', // non-annotation metadata about the entity
@@ -34,13 +35,15 @@ export const EntityModal: React.FC<EntityModalProps> = ({
   initialTab = EntityModalTabs.METADATA,
   showTabs = true,
 }: EntityModalProps) => {
-
   const [currentTab, setCurrentTab] = useState<EntityModalTabs>(initialTab)
-  const { data: entityBundle, isLoading } = useGetEntityBundle(entityId)
+  const [isInEditMode, setIsInEditMode] = useState(false)
+  const { data: entityBundle } = useGetEntityBundle(entityId)
 
   return (
     <Modal
       className="bootstrap-4-backport EntityMetadata"
+      backdrop={'static'}
+      size={isInEditMode ? 'lg' : undefined}
       show={show}
       animation={false}
       onHide={onClose}
@@ -77,38 +80,63 @@ export const EntityModal: React.FC<EntityModalProps> = ({
         ) : null}
         <>
           {currentTab === EntityModalTabs.ANNOTATIONS && (
-            <AnnotationsTable entityId={entityId} />
+            <>
+              {isInEditMode ? (
+                <SchemaDrivenAnnotationEditor
+                  entityId={entityId}
+                  onCancel={() => setIsInEditMode(false)}
+                />
+              ) : (
+                <AnnotationsTable entityId={entityId} />
+              )}
+            </>
           )}
           {currentTab === EntityModalTabs.METADATA && (
             <MetadataTable entityId={entityId} />
           )}
         </>
       </Modal.Body>
-      <Modal.Footer>
-        <div className="ButtonContainer">
-          <div className="Spacer" />
-          {entityBundle ? (
-            <Button
-              variant="primary"
-              onClick={() =>
-                window.open(
-                  `${getEndpoint(
-                    BackendDestinationEnum.PORTAL_ENDPOINT,
-                  )}#!Synapse:${entityId}`,
-                  '_blank',
-                  'noopener',
-                )
-              }
-            >
-              Open {entityTypeToFriendlyName(entityBundle.entityType!)}
-            </Button>
-          ) : (
-            <Skeleton>
-              <Button>Open</Button>
-            </Skeleton>
-          )}
-        </div>
-      </Modal.Footer>
+      {!isInEditMode && ( // in edit mode, an editor manages its own footer
+        <Modal.Footer>
+          <div className="ButtonContainer">
+            {entityBundle && entityBundle.permissions?.canEdit ? (
+              <>
+                <Button
+                  variant="primary-500"
+                  onClick={() => {
+                    setIsInEditMode(true)
+                  }}
+                >
+                  Edit
+                </Button>
+                <div className="Spacer" />
+              </>
+            ) : (
+              <div className="Spacer" />
+            )}
+            {entityBundle ? (
+              <Button
+                variant="primary-500"
+                onClick={() =>
+                  window.open(
+                    `${getEndpoint(
+                      BackendDestinationEnum.PORTAL_ENDPOINT,
+                    )}#!Synapse:${entityId}`,
+                    '_blank',
+                    'noopener',
+                  )
+                }
+              >
+                Open {entityTypeToFriendlyName(entityBundle.entityType!)}
+              </Button>
+            ) : (
+              <Skeleton>
+                <Button>Open</Button>
+              </Skeleton>
+            )}
+          </div>
+        </Modal.Footer>
+      )}
     </Modal>
   )
 }

--- a/src/lib/rollup.index.ts
+++ b/src/lib/rollup.index.ts
@@ -26,6 +26,7 @@ import ShowDownloadV2 from './containers/download_list_v2/ShowDownloadV2'
 import FullWidthAlert from './containers/FullWidthAlert'
 import { DownloadConfirmation } from './containers/download_list/DownloadConfirmation'
 import { SchemaDrivenAnnotationEditor } from './containers/entity/annotations/SchemaDrivenAnnotationEditor'
+import { EntityModal } from './containers/entity/metadata/EntityModal'
 import {
   SynapseContextProvider,
   SynapseContextConsumer,
@@ -63,7 +64,8 @@ const SynapseComponents = {
   FullWidthAlert: FullWidthAlert,
   SchemaDrivenAnnotationEditor,
   SynapseNavDrawer,
-  FavoritesPage
+  FavoritesPage,
+  EntityModal,
 }
 
 export { SynapseComponents, SynapseConstants, SynapseClient, SynapseContext }

--- a/src/lib/style/components/_annotations.scss
+++ b/src/lib/style/components/_annotations.scss
@@ -2,108 +2,119 @@
 
 .bootstrap-4-backport {
   .AnnotationEditor {
-    display: grid;
-    // We can't rearrange the order of the HTML elements, so we use grid rows to reorder them.
-    grid-template-rows: auto auto auto auto auto;
-    margin-bottom: 15px;
-
-    > .form-group {
-      grid-row-start: 1;
-    }
-    .ErrorList {
-      grid-row-start: 2;
-      margin-top: 1rem;
-    }
-
-    .alert {
-      grid-row-start: 3;
-      margin-top: 5px;
-      margin-bottom: 5px;
-    }
-
-    > hr {
-      grid-row-start: 4;
-      width: 100%;
-    }
-
-    .SaveButtonContainer {
+    .LoadingPlaceholder {
       display: flex;
-      flex-direction: row-reverse;
-      grid-row-start: 5;
+      margin: 60px auto;
     }
 
-    .col-xs-3,
-    .col-xs-6 {
-      padding-left: 5px;
-      padding-right: 5px;
-    }
-    .row {
-      padding: 0px 10px;
-    }
-    .calendar-with-icon-form-group.form-group {
-      input {
-        margin-bottom: 0;
-      }
-      .input-group-prepend {
-        margin-bottom: 0;
-      }
-    }
-
-    .AddButton,
-    .RemoveButton {
-      border-radius: 0px;
-      height: 25px;
-      width: 25px;
-      padding: 0px;
-      margin: 12px 5px 1rem;
-      justify-self: center;
-      align-self: start;
-    }
-
-    .array-item {
+    .AnnotationEditorForm {
       display: grid;
-      grid-template-columns: [input] auto [remove] 30px [add] 30px;
-      grid-template-rows: [description] auto [widget] auto [errors] auto;
+      // We can't rearrange the order of the HTML elements, so we use grid rows to reorder them.
+      grid-template-rows: auto auto auto auto auto;
+      margin-bottom: 15px;
 
-      .field-description {
-        grid-row-start: description;
+      > .form-group {
+        grid-row-start: 1;
+      }
+      .ErrorList {
+        grid-row-start: 2;
+        margin-top: 1rem;
       }
 
-      .form-control,
-      .calendar-with-icon-form-group {
-        grid-row-start: widget;
+      .alert {
+        grid-row-start: 3;
+        margin-top: 5px;
+        margin-bottom: 5px;
       }
 
-      div {
-        grid-row-start: errors;
+      > hr {
+        grid-row-start: 4;
+        width: 100%;
       }
 
-      .AddButton {
-        grid-row-start: widget;
-        grid-column-start: add;
+      .SaveButtonContainer {
+        display: flex;
+        flex-direction: row-reverse;
+        grid-row-start: 5;
+
+        .Spacer {
+          flex-grow: 1;
+        }
       }
 
+      .col-xs-3,
+      .col-xs-6 {
+        padding-left: 5px;
+        padding-right: 5px;
+      }
+      .row {
+        padding: 0px 10px;
+      }
+      .calendar-with-icon-form-group.form-group {
+        input {
+          margin-bottom: 0;
+        }
+        .input-group-prepend {
+          margin-bottom: 0;
+        }
+      }
+
+      .AddButton,
       .RemoveButton {
-        grid-row-start: widget;
-        grid-column-start: remove;
+        border-radius: 0px;
+        height: 25px;
+        width: 25px;
+        padding: 0px;
+        margin: 12px 5px 1rem;
+        justify-self: center;
+        align-self: start;
       }
-    }
 
-    label {
-      color: SRC.$gray-deemphasized;
-      font-weight: normal;
-      span.required {
-        color: SRC.$red-required;
-        margin-left: 2px;
+      .array-item {
+        display: grid;
+        grid-template-columns: [input] auto [remove] 30px [add] 30px;
+        grid-template-rows: [description] auto [widget] auto [errors] auto;
+
+        .field-description {
+          grid-row-start: description;
+        }
+
+        .form-control,
+        .calendar-with-icon-form-group {
+          grid-row-start: widget;
+        }
+
+        div {
+          grid-row-start: errors;
+        }
+
+        .AddButton {
+          grid-row-start: widget;
+          grid-column-start: add;
+        }
+
+        .RemoveButton {
+          grid-row-start: widget;
+          grid-column-start: remove;
+        }
       }
-    }
 
-    select {
-      background-color: SRC.$gray-light;
-    }
+      label {
+        color: SRC.$gray-deemphasized;
+        font-weight: normal;
+        span.required {
+          color: SRC.$red-required;
+          margin-left: 2px;
+        }
+      }
 
-    .field-array > .array-item > label.form-label {
-      display: none;
+      select {
+        background-color: SRC.$gray-light;
+      }
+
+      .field-array > .array-item > label.form-label {
+        display: none;
+      }
     }
   }
 }

--- a/src/lib/utils/hooks/SynapseAPI/useEntity.ts
+++ b/src/lib/utils/hooks/SynapseAPI/useEntity.ts
@@ -2,6 +2,8 @@
  * Hooks to access Entity Services in Synapse
  */
 
+import { omit, pick } from 'lodash-es'
+import { useEffect, useState } from 'react'
 import {
   useMutation,
   UseMutationOptions,
@@ -12,18 +14,56 @@ import {
 import { SynapseClient } from '../..'
 import { SynapseClientError } from '../../SynapseClient'
 import { useSynapseContext } from '../../SynapseContext'
-import { EntityJson } from '../../synapseTypes'
+import { EntityJson, entityJsonKeys, EntityJsonValue } from '../../synapseTypes'
 
+export function getStandardEntityFields(json: EntityJson): EntityJson {
+  return pick(json, entityJsonKeys) as EntityJson
+}
+
+export function removeStandardEntityFields(
+  json: EntityJson,
+): Record<
+  string,
+  string | number | boolean | string[] | number[] | boolean[] | undefined
+> {
+  return omit(json, entityJsonKeys)
+}
+
+/**
+ * In addition to the standard objects returned by {@link useQuery}, this hook also returns the following objects:
+ * - `entityMetadata`: the standard entity fields contained in the JSON response
+ * - `annotations`: the annotations contained in the JSON response
+ *
+ * The union of these objects would be equal in value to the `data` object.
+ */
 export function useGetJson(
   entityId: string,
   options?: UseQueryOptions<EntityJson, SynapseClientError>,
 ) {
+  const [entityMetadata, setEntityMetadata] = useState<EntityJson | undefined>()
+  const [annotations, setAnnotations] = useState<
+    Record<string, EntityJsonValue> | undefined
+  >()
   const { accessToken } = useSynapseContext()
-  return useQuery<EntityJson, SynapseClientError>(
+  const query = useQuery<EntityJson, SynapseClientError>(
     [accessToken, 'entity', entityId, 'json'],
     () => SynapseClient.getEntityJson(entityId, accessToken),
     options,
   )
+
+  // Separate the standard fields and annotations.
+  useEffect(() => {
+    if (query.data) {
+      setEntityMetadata(getStandardEntityFields(query.data))
+      setAnnotations(removeStandardEntityFields(query.data))
+    }
+  }, [query.data])
+
+  return {
+    ...query,
+    entityMetadata,
+    annotations,
+  }
 }
 
 export function useUpdateViaJson(

--- a/src/lib/utils/synapseTypes/Entity.ts
+++ b/src/lib/utils/synapseTypes/Entity.ts
@@ -36,9 +36,19 @@ export interface Entity {
   uri?: string
 }
 
+// Possible value types in an entity JSON object.
+export type EntityJsonValue =
+  | string
+  | number
+  | boolean
+  | string[]
+  | number[]
+  | boolean[]
+  | undefined
+
 // Entity data returned as in https://docs.synapse.org/rest/GET/entity/id/json.html
 // Not comprehensive, but we don't need it to be, since we currently only use JSON for annotations.
-export interface EntityJson extends Record<string, unknown> {
+export interface EntityJson extends Record<string, EntityJsonValue> {
   name: string
   id: string
   etag: string

--- a/src/mocks/msw/handlers.ts
+++ b/src/mocks/msw/handlers.ts
@@ -15,6 +15,7 @@ import {
   MOCK_INVALID_PROJECT_NAME,
   MOCK_PROJECT_ID,
   MOCK_PROJECT_NAME,
+  mockFileEntityJson,
 } from '../entity/mockEntity'
 import {
   mockUserBundle,
@@ -29,6 +30,7 @@ import {
   USER_ID_BUNDLE,
   USER_PROFILE_ID,
   USER_PROFILE,
+  ENTITY_JSON,
 } from '../../lib/utils/APIConstants'
 
 const handlers = [
@@ -85,7 +87,9 @@ const handlers = [
     `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY}`,
     async (req, res, ctx) => {
       let response: any = {
-        reason: `Mock Service worker could not find a matching mock entity for this request : ${JSON.stringify(req.body)}`,
+        reason: `Mock Service worker could not find a matching mock entity for this request : ${JSON.stringify(
+          req.body,
+        )}`,
       }
       let status = 404
       if (req.body) {
@@ -102,11 +106,11 @@ const handlers = [
           status = 403
         }
       }
-      
+
       return res(ctx.status(status), ctx.json(response))
     },
   ),
-  
+
   rest.post(
     `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
       ':entityId',
@@ -137,14 +141,22 @@ const handlers = [
   ),
 
   rest.get(
-    `${getEndpoint(
-      BackendDestinationEnum.REPO_ENDPOINT,
-    )}${FAVORITES}`,
+    `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${FAVORITES}`,
     async (req, res, ctx) => {
       return res(ctx.status(200), ctx.json(mockPaginatedEntityHeaders))
     },
   ),
 
+  rest.get(
+    `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_JSON(
+      ':entityId',
+    )}`,
+
+    async (req, res, ctx) => {
+      const response = mockFileEntityJson
+      return res(ctx.status(200), ctx.json(response))
+    },
+  ),
 ]
 
 export { handlers }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2628,14 +2628,14 @@
     chalk "^4.0.0"
 
 "@material-ui/core@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.3.tgz"
-  integrity sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.2.tgz#59a8b19f16b8c218d912f37f5ae70473c3c82c73"
+  integrity sha512-Q1npB8V73IC+eV2X6as+g71MpEGQwqKHUI2iujY62npk35V8nMx/bUXAHjv5kKG1BZ8s8XUWoG6s/VkjYPjjQA==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/styles" "^4.11.3"
-    "@material-ui/system" "^4.11.3"
-    "@material-ui/types" "^5.1.0"
+    "@material-ui/styles" "^4.11.4"
+    "@material-ui/system" "^4.12.1"
+    "@material-ui/types" "5.1.0"
     "@material-ui/utils" "^4.11.2"
     "@types/react-transition-group" "^4.2.0"
     clsx "^1.0.4"
@@ -2652,14 +2652,25 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
-"@material-ui/styles@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz"
-  integrity sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==
+"@material-ui/lab@^4.0.0-alpha.57":
+  version "4.0.0-alpha.60"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz#5ad203aed5a8569b0f1753945a21a05efa2234d2"
+  integrity sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+
+"@material-ui/styles@^4.11.4":
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"
+  integrity sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/hash" "^0.8.0"
-    "@material-ui/types" "^5.1.0"
+    "@material-ui/types" "5.1.0"
     "@material-ui/utils" "^4.11.2"
     clsx "^1.0.4"
     csstype "^2.5.2"
@@ -2674,19 +2685,19 @@
     jss-plugin-vendor-prefixer "^10.5.1"
     prop-types "^15.7.2"
 
-"@material-ui/system@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3.tgz"
-  integrity sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==
+"@material-ui/system@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.12.1.tgz#2dd96c243f8c0a331b2bb6d46efd7771a399707c"
+  integrity sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/utils" "^4.11.2"
     csstype "^2.5.2"
     prop-types "^15.7.2"
 
-"@material-ui/types@^5.1.0":
+"@material-ui/types@5.1.0":
   version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
   integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
 
 "@material-ui/utils@^4.11.2":

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,7 +2296,7 @@
 
 "@emotion/weak-memoize@0.2.5":
   version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@eslint/eslintrc@^0.4.2":
@@ -2628,9 +2628,9 @@
     chalk "^4.0.0"
 
 "@material-ui/core@^4.11.3":
-  version "4.12.2"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.2.tgz#59a8b19f16b8c218d912f37f5ae70473c3c82c73"
-  integrity sha512-Q1npB8V73IC+eV2X6as+g71MpEGQwqKHUI2iujY62npk35V8nMx/bUXAHjv5kKG1BZ8s8XUWoG6s/VkjYPjjQA==
+  version "4.12.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.3.tgz#80d665caf0f1f034e52355c5450c0e38b099d3ca"
+  integrity sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/styles" "^4.11.4"


### PR DESCRIPTION
* Adds the annotation editor to the EntityModal. In Synapse.org, the 'Annotations' button will open the EntityModal, directly opening the annotations tab (the tab buttons will not be rendered, so functionally it will just be an annotations modal). If the user has edit access, they will see an edit button that opens the editor in the same modal.
* The annotations table now uses the JSON representation of the annotations rather than the bundle's annotations
  * The data is now instantly updated in the cache when successfully updated, so no need to re-fetch the bundle
  * Reduces chances of exposing inconsistencies between JSON and Annotations APIs (e.g., you can set annotations like 'name' in the old API).
  * There were performance concerns about using the JSON API for reads, but it will soon be backed by a cache in the backend, so it shouldn't be an issue.
* Add Material UI [Skeletons](https://material-ui.com/components/skeleton/)


https://user-images.githubusercontent.com/17580037/129583270-714a4302-e22c-4bf4-bde1-0490aae06179.mov

