### PR TITLE
quick followup release for SWC-5700

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/style/components/_synapse-nav-drawer.scss
+++ b/src/lib/style/components/_synapse-nav-drawer.scss
@@ -15,6 +15,10 @@
     &.tempDrawerOpen .MuiPaper-root {
       z-index: 1500;
     }
+    // default z-index for drawer is 1200, but we need this to be behind other modals in the app.
+    .MuiPaper-root {
+      z-index: 100;
+    }
     .filler {
       flex-grow: 1;
     }


### PR DESCRIPTION
Discovered material UI drawer already has a default z-index that is above the background click capture layer for modals!