### PR TITLE
Fix ghpages deploy

### DIFF
--- a/src/demo/containers/playground/ToastDemo.md
+++ b/src/demo/containers/playground/ToastDemo.md
@@ -1,72 +1,7 @@
 Configure and push a toast message using the settings below.
 
-```js
-const [variant, setVariant] = React.useState('info')
-
-const [title, setTitle] = React.useState('')
-const [description, setDescription] = React.useState('')
-const [autoClose, setAutoClose] = React.useState(0)
-const [buttonText, setButtonText] = React.useState('')
-const [linkText, setLinkText] = React.useState('')
-
-function fireToast() {
-  displayToast(
-    variant,
-    title,
-    description,
-    autoClose,
-    buttonText ? buttonText : undefined,
-    () => {},
-    linkText ? linkText : undefined,
-    '#',
-  )
-}
-return (
-  <div className="bootstrap-4-backport">
-    <ReactBootstrap.FormLabel>Alert Variant</ReactBootstrap.FormLabel>
-    <RadioGroup
-      id="toast-demo-variant"
-      options={[
-        { label: 'Info', value: 'info' },
-        { label: 'Success', value: 'success' },
-        { label: 'Warning', value: 'warning' },
-        { label: 'Danger', value: 'danger' },
-      ]}
-      value={variant}
-      onChange={value => setVariant(value)}
-    />
-    <ReactBootstrap.FormLabel>Title</ReactBootstrap.FormLabel>
-    <ReactBootstrap.FormControl
-      value={title}
-      onChange={e => setTitle(e.target.value)}
-    />
-    <ReactBootstrap.FormLabel>Description</ReactBootstrap.FormLabel>
-    <ReactBootstrap.FormControl
-      value={description}
-      onChange={e => setDescription(e.target.value)}
-    />
-    <ReactBootstrap.FormLabel>Auto-close (ms)</ReactBootstrap.FormLabel>
-    <ReactBootstrap.FormControl
-      type="number"
-      value={autoClose}
-      onChange={e => setAutoClose(Number.parseInt(e.target.value))}
-    />
-    <ReactBootstrap.FormLabel>Optional Button Text</ReactBootstrap.FormLabel>
-    <ReactBootstrap.FormControl
-      value={buttonText}
-      onChange={e => setButtonText(e.target.value)}
-    />
-    <ReactBootstrap.FormLabel>Optional Link Text</ReactBootstrap.FormLabel>
-    <ReactBootstrap.FormControl
-      value={linkText}
-      onChange={e => setLinkText(e.target.value)}
-    />
-
-    <ReactBootstrap.Button variant="primary-500" onClick={fireToast}>
-      Push toast message
-    </ReactBootstrap.Button>
-  </div>
-)
+```jsx
+<ToastDemo />
 ```
 
 Note to developers: `displayToast` won't work unless you've created a SynapseToastContainer and placed it somewhere in your webpage. We don't configure one in this demo because the SynapseToastContainer has been configured for the entire Styleguide.

--- a/src/demo/containers/playground/ToastDemo.tsx
+++ b/src/demo/containers/playground/ToastDemo.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { Button, FormControl, FormLabel } from 'react-bootstrap'
+import { displayToast } from '../../../lib/containers/ToastMessage'
+import { RadioGroup } from '../../../lib/containers/widgets/RadioGroup'
+
+export const ToastDemo = () => {
+  const [variant, setVariant] = React.useState<
+    'info' | 'success' | 'warning' | 'danger'
+  >('info')
+
+  const [title, setTitle] = React.useState('')
+  const [description, setDescription] = React.useState('')
+  const [autoClose, setAutoClose] = React.useState(0)
+  const [buttonText, setButtonText] = React.useState('')
+  const [linkText, setLinkText] = React.useState('')
+
+  function fireToast() {
+    displayToast(
+      variant,
+      title,
+      description,
+      autoClose,
+      buttonText ? buttonText : undefined,
+      () => {
+        console.log('Primary button clicked!')
+      },
+      linkText ? linkText : undefined,
+      '#',
+    )
+  }
+  return (
+    <div className="bootstrap-4-backport">
+      <FormLabel>Alert Variant</FormLabel>
+      <RadioGroup
+        id="toast-demo-variant"
+        options={[
+          { label: 'Info', value: 'info' },
+          { label: 'Success', value: 'success' },
+          { label: 'Warning', value: 'warning' },
+          { label: 'Danger', value: 'danger' },
+        ]}
+        value={variant}
+        onChange={value =>
+          setVariant(value as 'info' | 'success' | 'warning' | 'danger')
+        }
+      />
+      <FormLabel>Title</FormLabel>
+      <FormControl value={title} onChange={e => setTitle(e.target.value)} />
+      <FormLabel>Description</FormLabel>
+      <FormControl
+        value={description}
+        onChange={e => setDescription(e.target.value)}
+      />
+      <FormLabel>Auto-close (ms)</FormLabel>
+      <FormControl
+        type="number"
+        value={autoClose}
+        onChange={e => setAutoClose(Number.parseInt(e.target.value))}
+      />
+      <FormLabel>Optional Button Text</FormLabel>
+      <FormControl
+        value={buttonText}
+        onChange={e => setButtonText(e.target.value)}
+      />
+      <FormLabel>Optional Link Text</FormLabel>
+      <FormControl
+        value={linkText}
+        onChange={e => setLinkText(e.target.value)}
+      />
+
+      <Button variant="primary-500" onClick={fireToast}>
+        Push toast message
+      </Button>
+    </div>
+  )
+}

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -42,7 +42,7 @@ module.exports = {
         {
             name: 'Demos and non-components',
             description: 'Demos or examples that are useful to display here that are not components.',
-            components: ['src/demo/containers/**/[A-Z]*.tsx', 'src/demo/containers/playground/ToastDemo.md']
+            components: ['src/demo/containers/**/[A-Z]*.tsx']
         },
       ],
 


### PR DESCRIPTION
Styleguidist uses react-docgen to parse components. Specifying a markdown file as a component causes an issue where react-docgen expects to see JS/TS, but instead sees markdown, so it reports errors.

The fix is to create an actual component and just call it from the markdown example.