### PR TITLE
SWC-5729

### DIFF
--- a/src/lib/containers/entity/metadata/EntityModal.tsx
+++ b/src/lib/containers/entity/metadata/EntityModal.tsx
@@ -83,6 +83,9 @@ export const EntityModal: React.FC<EntityModalProps> = ({
               {isInEditMode ? (
                 <SchemaDrivenAnnotationEditor
                   entityId={entityId}
+                  onSuccess={() => {
+                    setIsInEditMode(false)
+                  }}
                   onCancel={() => setIsInEditMode(false)}
                 />
               ) : (


### PR DESCRIPTION
The issue is that annotations may be returned by the update API in a different order than they were sent. This is only an issue for non-schema-defined annotations.

Instead of trying to stabilize the ordering, we will just close the editor after a successful update. The re-order will happen, but the user won't see it or realize unless they re-open the editor.


https://user-images.githubusercontent.com/17580037/131137971-64996237-b13d-4d9b-ad31-b70842857928.mov

