### PR TITLE
SWC-5724

### DIFF
--- a/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
+++ b/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
@@ -1,6 +1,6 @@
 import Form, { AjvError } from '@sage-bionetworks/rjsf-core'
 import { JSONSchema7 } from 'json-schema'
-import { isEmpty } from 'lodash-es'
+import { flatMap, groupBy, isEmpty } from 'lodash-es'
 import React, { useEffect, useRef } from 'react'
 import { Alert, Button, Modal } from 'react-bootstrap'
 import { useErrorHandler } from 'react-error-boundary'
@@ -49,6 +49,11 @@ export type SchemaDrivenAnnotationEditorModalProps = {
   onHide: () => void
 }
 
+/**
+ * Inspects the property of the AjvError and modifies it to be comparable to simple key strings, like entity property keys.
+ * @param error
+ * @returns
+ */
 function getFriendlyPropertyName(error: AjvError) {
   if (error.property.startsWith('[')) {
     // Additional properties are surrounded by brackets and quotations, so let's remove them
@@ -58,6 +63,60 @@ function getFriendlyPropertyName(error: AjvError) {
   } else {
     return error.property
   }
+}
+
+function transformErrors(errors: AjvError[]): AjvError[] {
+  // Transform the errors in the following ways:
+  // - Simplify the set of errors when failing to select an enumeration defined with an anyOf (SWC-5724)
+  // - Show a custom error message when using a property that collides with an internal entity property (SWC-5678)
+
+  // Fixing anyOf errors
+  // Group the errors by the property that the error applies to
+  const grouped = groupBy(errors, error => error.property)
+  Object.keys(grouped).map(property => {
+    const errorGroup = grouped[property]
+
+    // First, see if it is an anyOf error
+    const hasAnyOfError = errorGroup.some(
+      e => e.message === 'should match some schema in anyOf',
+    )
+
+    // We determine if it's an anyOf *enum* error if all error messages in the property match one of these three messages:
+    const isEnumError =
+      hasAnyOfError &&
+      errorGroup.every(error => {
+        if (error.message === 'should be string') {
+          return true
+        } else if (error.message === 'should be equal to constant') {
+          return true
+        } else if (error.message === 'should match some schema in anyOf') {
+          return true
+        } else {
+          return false
+        }
+      })
+
+    // If it's an anyOf enum error, we just modify the first message and drop the rest
+    if (isEnumError && errorGroup.length > 0) {
+      errorGroup[0].message = 'should match one of the enumerated values'
+      grouped[property] = [errorGroup[0]]
+    }
+  })
+
+  // Ungroup the errors after potentially modifying them
+  errors = flatMap(grouped)
+
+  // Custom error message if the custom annotation key collides with an internal entity property
+  errors = errors.map(error => {
+    const propertyName = getFriendlyPropertyName(error)
+    if (entityJsonKeys.includes(propertyName)) {
+      error.message = `"${propertyName}" is a reserved internal key and cannot be used.`
+    }
+    return error
+  })
+
+  // Return the transformed errors.
+  return errors
 }
 
 // patternProperties lets us define how to treat additionalProperties in a JSON schema by property name
@@ -241,15 +300,7 @@ export const SchemaDrivenAnnotationEditor: React.FunctionComponent<SchemaDrivenA
                 'ui:FieldTemplate': CustomAdditionalPropertiesFieldTemplate,
               },
             }}
-            transformErrors={(errors: AjvError[]): AjvError[] => {
-              return errors.map(error => {
-                const propertyName = getFriendlyPropertyName(error)
-                if (entityJsonKeys.includes(propertyName)) {
-                  error.message = `"${propertyName}" is a reserved internal key and cannot be used.`
-                }
-                return error
-              })
-            }}
+            transformErrors={transformErrors}
             formData={formData}
             onChange={({ formData }) => {
               setFormData(formData)


### PR DESCRIPTION
[Jira](https://sagebionetworks.jira.com/browse/SWC-5724)

When a schema author defines an enumeration using `anyOf`, the client-side validator doesn't recognize that it's an enumeration, so the error message when making an invalid selection is verbose and hard to understand. This change tries to recognize when we see errors that represent this situation, and transforms the errors to simplify what we show the user.

Before:
![image](https://user-images.githubusercontent.com/17580037/131905120-b7aa7377-1fa5-49ff-910b-cbcb1a1d27c0.png)

After:
![image](https://user-images.githubusercontent.com/17580037/131905037-0ebcb200-d375-4f59-9053-bb89f10ca2cc.png)
