### PR TITLE
SWC-5724, SWC-5684, SWC-5762

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@rjsf/core": "^3.0.0",
-    "@sage-bionetworks/rjsf-core": "^3.1.3",
+    "@sage-bionetworks/rjsf-core": "^3.1.4",
     "@upsetjs/react": "^1.6.2",
     "animate.css": "^4.1.1",
     "bootstrap": "^4.6.0",

--- a/src/__tests__/lib/containers/entity/annotations/AnnotationEditorUtils.test.ts
+++ b/src/__tests__/lib/containers/entity/annotations/AnnotationEditorUtils.test.ts
@@ -1,0 +1,122 @@
+import { AjvError } from '@rjsf/core'
+import {
+  dropNullishArrayValues,
+  getFriendlyPropertyName,
+  transformErrors,
+} from '../../../../../lib/containers/entity/annotations/AnnotationEditorUtils'
+
+describe('AnnotationEditorUtils tests', () => {
+  describe('dropNullishArrayValues', () => {
+    it('will remove an empty array from the formData', () => {
+      const formData = {
+        array: [],
+      }
+      const expected = {}
+      expect(dropNullishArrayValues(formData)).toEqual(expected)
+    })
+    it('will remove nullish values from an array', () => {
+      const formData = {
+        array: [1, null, 2, undefined, 3],
+      }
+      const expected = { array: [1, 2, 3] }
+      expect(dropNullishArrayValues(formData)).toEqual(expected)
+    })
+    it('will remove an array containing only nullish values from an array', () => {
+      const formData = {
+        array: [null, undefined],
+      }
+      const expected = {}
+      expect(dropNullishArrayValues(formData)).toEqual(expected)
+    })
+  })
+
+  describe('getFriendlyPropertyName', () => {
+    it('strips the leading period from a schema-defined property', () => {
+      const error = {
+        property: '.study[0]',
+      }
+
+      const expected = 'study[0]'
+
+      expect(getFriendlyPropertyName(error)).toEqual(expected)
+    })
+    it('parses additionalProperties from an error', () => {
+      const error = {
+        property: "['myProperty']",
+      }
+
+      const expected = 'myProperty'
+
+      expect(getFriendlyPropertyName(error)).toEqual(expected)
+    })
+  })
+
+  describe('transformErrors', () => {
+    it('combines errors caused by an enumeration defined using anyOf', () => {
+      const errors: AjvError[] = [
+        {
+          name: 'type',
+          property: '.study[0]',
+          message: 'should be string',
+          params: { type: 'string' },
+          stack: '.study[0] should be string',
+        },
+        {
+          name: 'const',
+          property: '.study[0]',
+          message: 'should be equal to constant',
+          params: { allowedValue: 'VMC' },
+          stack: '.study[0] should be equal to constant',
+        },
+        {
+          name: 'const',
+          property: '.study[0]',
+          message: 'should be equal to constant',
+          params: { allowedValue: 'WGBS Pilot' },
+          stack: '.study[0] should be equal to constant',
+        },
+        {
+          name: 'const',
+          property: '.study[0]',
+          message: 'should be equal to constant',
+          params: { allowedValue: 'Yale-ASD' },
+          stack: '.study[0] should be equal to constant',
+        },
+        {
+          name: 'anyOf',
+          property: '.study[0]',
+          message: 'should match some schema in anyOf',
+          params: {},
+          stack: '.study[0] should match some schema in anyOf',
+        },
+      ]
+      const expected = expect.arrayContaining([
+        expect.objectContaining({
+          message: 'should be equal to one of the allowed values',
+        }),
+      ])
+
+      expect(transformErrors(errors)).toEqual(expected)
+    })
+
+    it('returns a custom message when using a key that collides with a reserved property', () => {
+      const errors: AjvError[] = [
+        {
+          name: 'not',
+          property: "['name']",
+          message: 'should NOT be valid',
+          params: {},
+          stack: "['name'] should NOT be valid",
+        },
+      ]
+
+      const expected = expect.arrayContaining([
+        expect.objectContaining({
+          message: '"name" is a reserved internal key and cannot be used.',
+        }),
+      ])
+
+      expect(transformErrors(errors)).toEqual(expected)
+    })
+  })
+})

--- a/src/lib/containers/entity/annotations/AdditionalPropertiesSchemaField.tsx
+++ b/src/lib/containers/entity/annotations/AdditionalPropertiesSchemaField.tsx
@@ -222,6 +222,7 @@ export function AdditionalPropertiesSchemaField<T>(
           placeholder={props.placeholder ?? ''}
           options={{}}
           formContext={props.formContext as T}
+          onFocus={props.onFocus}
           onBlur={(id, value) => {
             setList(transformDataFromPropertyType(list, propertyType))
             props.onBlur(id, value)

--- a/src/lib/containers/entity/annotations/AnnotationEditorUtils.ts
+++ b/src/lib/containers/entity/annotations/AnnotationEditorUtils.ts
@@ -1,0 +1,38 @@
+import { AjvError } from "@sage-bionetworks/rjsf-core"
+
+/**
+ * Strips null values from arrays in the provided form data. If the array is empty after
+ * removing null values, the key is removed from the form data.
+ *
+ * This allows users to submit forms with empty array fields (SWC-5762)
+ */
+export function dropNullishArrayValues(
+  formData: Record<string, unknown>,
+): Record<string, unknown> {
+  const newFormData: Record<string, unknown> = {}
+  Object.keys(formData).forEach(key => {
+    let value = formData[key]
+    if (Array.isArray(value)) {
+      value = (value as Array<any>).filter((item: any) => item != null)
+      if (!isEmpty(value)) {
+        newFormData[key] = value
+      }
+    } else {
+      newFormData[key] = value
+    }
+  })
+  return newFormData
+}
+
+
+export function getFriendlyPropertyName(error: AjvError) {
+    if (error.property.startsWith('[')) {
+      // Additional properties are surrounded by brackets and quotations, so let's remove them
+      return error.property.substring(2, error.property.length - 2)
+    } else if (error.property.startsWith('.')) {
+      return error.property.substring(1)
+    } else {
+      return error.property
+    }
+  }
+  

--- a/src/lib/containers/entity/annotations/AnnotationEditorUtils.ts
+++ b/src/lib/containers/entity/annotations/AnnotationEditorUtils.ts
@@ -75,7 +75,7 @@ export function transformErrors(errors: AjvError[]): AjvError[] {
 
     // If it's an anyOf enum error, we just modify the first message and drop the rest
     if (isEnumError && errorGroup.length > 0) {
-      errorGroup[0].message = 'should match one of the enumerated values'
+      errorGroup[0].message = 'should be equal to one of the allowed values'
       grouped[property] = [errorGroup[0]]
     }
   })

--- a/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
+++ b/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
@@ -42,7 +42,7 @@ export function CustomArrayFieldTemplate<T>(props: ArrayFieldTemplateProps<T>) {
           {props.items.map((element, index) => (
             <div key={element.key} className="array-item">
               {element.children}
-              {props.items.length > 1 && (
+              {(isAdditionalProperty || props.items.length > 1) && (
                 <Button
                   aria-label={`Remove ${props.title}-${index}`}
                   variant="transparent-primary-500"

--- a/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
+++ b/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
@@ -29,12 +29,16 @@ export function CustomArrayFieldTemplate<T>(props: ArrayFieldTemplateProps<T>) {
           {props.required && <span className="required">*</span>}
         </FormLabel>
         {!isAdditionalProperty && (
-          <HelpOutline
-            className="HelpButton SRC-primary-text-color"
-            onClick={() => {
+          <button
+            aria-label="More Info"
+            aria-expanded={showDetails}
+            onClick={e => {
+              e.preventDefault()
               setShowDetails(!showDetails)
             }}
-          />
+          >
+            <HelpOutline className="HelpButton SRC-primary-text-color" />
+          </button>
         )}
       </div>
       {props.items && (
@@ -44,7 +48,7 @@ export function CustomArrayFieldTemplate<T>(props: ArrayFieldTemplateProps<T>) {
               {element.children}
               {(isAdditionalProperty || props.items.length > 1) && (
                 <Button
-                  aria-label={`Remove ${props.title}-${index}`}
+                  aria-label={`Remove ${props.title}[${index}]`}
                   variant="transparent-primary-500"
                   className="RemoveButton"
                   disabled={props.disabled}

--- a/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
+++ b/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
@@ -1,7 +1,8 @@
-import { Add, Close } from '@material-ui/icons'
+import { Add, Close, HelpOutline } from '@material-ui/icons'
 import { ArrayFieldTemplateProps } from '@sage-bionetworks/rjsf-core'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Button, FormGroup, FormLabel } from 'react-bootstrap'
+import FieldDescriptionTable from './FieldDescriptionTable'
 
 /**
  * Custom field template for array properties in a react-jsonschema-form component.
@@ -9,32 +10,45 @@ import { Button, FormGroup, FormLabel } from 'react-bootstrap'
  */
 export function CustomArrayFieldTemplate<T>(props: ArrayFieldTemplateProps<T>) {
   const { DescriptionField } = props
+
+  useEffect(() => {
+    if (props.items.length === 0) {
+      props.onAddClick()
+    }
+  }, [props])
+
+  const [showDetails, setShowDetails] = useState(false)
+
   return (
     <FormGroup className={props.className}>
-      <FormLabel>
-        {props.title}
-        {props.required && <span className="required">*</span>}
-      </FormLabel>
-      {props.schema.description && (
-        <DescriptionField
-          id={`${props.idSchema.$id}__description`}
-          description={props.schema.description}
+      <div className="LabelContainer">
+        <FormLabel>
+          {props.title}
+          {props.required && <span className="required">*</span>}
+        </FormLabel>
+        <HelpOutline
+          className="HelpButton SRC-primary-text-color"
+          onClick={() => {
+            setShowDetails(!showDetails)
+          }}
         />
-      )}
+      </div>
       {props.items && (
         <>
           {props.items.map((element, index) => (
             <div key={element.key} className="array-item">
               {element.children}
-              <Button
-                aria-label={`Remove ${props.title}-${index}`}
-                variant="transparent-primary-500"
-                className="RemoveButton"
-                disabled={props.disabled}
-                onClick={element.onDropIndexClick(element.index)}
-              >
-                <Close />
-              </Button>
+              {props.items.length > 1 && (
+                <Button
+                  aria-label={`Remove ${props.title}-${index}`}
+                  variant="transparent-primary-500"
+                  className="RemoveButton"
+                  disabled={props.disabled}
+                  onClick={element.onDropIndexClick(element.index)}
+                >
+                  <Close />
+                </Button>
+              )}
               {props.canAdd && index === props.items.length - 1 && (
                 <Button
                   aria-label={`Add new ${props.title}`}
@@ -63,6 +77,17 @@ export function CustomArrayFieldTemplate<T>(props: ArrayFieldTemplateProps<T>) {
           )}
         </>
       )}
+      <FieldDescriptionTable
+        required={props.required}
+        type={props.schema.type as string}
+        description={
+          <DescriptionField
+            id={`${props.idSchema.$id}__description`}
+            description={props.schema.description}
+          />
+        }
+        show={showDetails}
+      />
     </FormGroup>
   )
 }

--- a/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
+++ b/src/lib/containers/entity/annotations/CustomArrayFieldTemplate.tsx
@@ -1,5 +1,5 @@
 import { Add, Close, HelpOutline } from '@material-ui/icons'
-import { ArrayFieldTemplateProps } from '@sage-bionetworks/rjsf-core'
+import { ArrayFieldTemplateProps, utils } from '@sage-bionetworks/rjsf-core'
 import React, { useEffect, useState } from 'react'
 import { Button, FormGroup, FormLabel } from 'react-bootstrap'
 import FieldDescriptionTable from './FieldDescriptionTable'
@@ -10,6 +10,8 @@ import FieldDescriptionTable from './FieldDescriptionTable'
  */
 export function CustomArrayFieldTemplate<T>(props: ArrayFieldTemplateProps<T>) {
   const { DescriptionField } = props
+
+  const isAdditionalProperty = props.schema[utils.ADDITIONAL_PROPERTY_FLAG]
 
   useEffect(() => {
     if (props.items.length === 0) {
@@ -26,12 +28,14 @@ export function CustomArrayFieldTemplate<T>(props: ArrayFieldTemplateProps<T>) {
           {props.title}
           {props.required && <span className="required">*</span>}
         </FormLabel>
-        <HelpOutline
-          className="HelpButton SRC-primary-text-color"
-          onClick={() => {
-            setShowDetails(!showDetails)
-          }}
-        />
+        {!isAdditionalProperty && (
+          <HelpOutline
+            className="HelpButton SRC-primary-text-color"
+            onClick={() => {
+              setShowDetails(!showDetails)
+            }}
+          />
+        )}
       </div>
       {props.items && (
         <>
@@ -83,7 +87,7 @@ export function CustomArrayFieldTemplate<T>(props: ArrayFieldTemplateProps<T>) {
         description={
           <DescriptionField
             id={`${props.idSchema.$id}__description`}
-            description={props.schema.description}
+            description={props.schema.description ?? ''}
           />
         }
         show={showDetails}

--- a/src/lib/containers/entity/annotations/CustomDefaultTemplate.tsx
+++ b/src/lib/containers/entity/annotations/CustomDefaultTemplate.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
-import { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { FormLabel } from 'react-bootstrap'
 import { FieldTemplateProps } from '@sage-bionetworks/rjsf-core'
+import { HelpOutline } from '@material-ui/icons'
+import FieldDescriptionTable from './FieldDescriptionTable'
 
 export function CustomDefaultTemplate<T>(
   props: FieldTemplateProps<T> & {
@@ -14,7 +15,6 @@ export function CustomDefaultTemplate<T>(
     children,
     errors,
     help,
-    description,
     hidden,
     required,
     displayLabel,
@@ -22,6 +22,9 @@ export function CustomDefaultTemplate<T>(
     onChange,
     schema,
   } = props
+
+  let description = props.description ?? props.schema.description
+  const [showDetails, setShowDetails] = useState(false)
 
   // The formData that we get may be an array (for example, if it was an additionalProperty, but then the key was added to the schema)
   // If the object passes through this template, then it should no longer be an array, so we coerce it to a string.
@@ -42,16 +45,27 @@ export function CustomDefaultTemplate<T>(
   return (
     <>
       {/* RJSF hides labels for boolean checkboxes, but since we replaced checkboxes with a custom component, we want to show them */}
-      {(displayLabel || schema.type === 'boolean') && (
-        <FormLabel htmlFor={id}>
-          {label}
-          {required && <span className="required">*</span>}
-        </FormLabel>
+      {label && (displayLabel || schema.type === 'boolean') && (
+        <div className="LabelContainer">
+          <FormLabel htmlFor={id}>
+            {label}
+            {required && <span className="required">*</span>}
+          </FormLabel>
+          <HelpOutline
+            className="HelpButton SRC-primary-text-color"
+            onClick={() => {
+              setShowDetails(!showDetails)
+            }}
+          />
+        </div>
       )}
-      {(displayLabel || schema.type === 'boolean') && description
-        ? description
-        : null}
       {children}
+      <FieldDescriptionTable
+        required={required}
+        type={schema.type as string}
+        description={description}
+        show={showDetails}
+      />
       {errors}
       {help}
     </>

--- a/src/lib/containers/entity/annotations/CustomDefaultTemplate.tsx
+++ b/src/lib/containers/entity/annotations/CustomDefaultTemplate.tsx
@@ -51,12 +51,16 @@ export function CustomDefaultTemplate<T>(
             {label}
             {required && <span className="required">*</span>}
           </FormLabel>
-          <HelpOutline
-            className="HelpButton SRC-primary-text-color"
-            onClick={() => {
+          <button
+            aria-label="More Info"
+            aria-expanded={showDetails}
+            onClick={e => {
+              e.preventDefault()
               setShowDetails(!showDetails)
             }}
-          />
+          >
+            <HelpOutline className="HelpButton SRC-primary-text-color" />
+          </button>
         </div>
       )}
       {children}

--- a/src/lib/containers/entity/annotations/CustomTextWidget.tsx
+++ b/src/lib/containers/entity/annotations/CustomTextWidget.tsx
@@ -5,9 +5,7 @@ import React from 'react'
  * This TextWidget is almost identical to the rjsf TextWidget, except we handle numbers like strings to prevent issues if
  * the actual annotation data is not a string.
  */
-export const CustomTextWidget = (
-  props: WidgetProps & { registry: { widgets: { [name: string]: Widget } } },
-) => {
+export const CustomTextWidget: Widget = (props: WidgetProps) => {
   const { BaseInput } = props.registry.widgets
 
   // options.inputType will override the input type determined via schema

--- a/src/lib/containers/entity/annotations/FieldDescriptionTable.tsx
+++ b/src/lib/containers/entity/annotations/FieldDescriptionTable.tsx
@@ -1,0 +1,38 @@
+import { Collapse } from '@material-ui/core'
+import React from 'react'
+
+export type FieldDescriptionTableProps = {
+  type: string
+  required: boolean
+  description: React.ReactNode
+  show: boolean
+}
+
+export default function FieldDescriptionTable(
+  props: FieldDescriptionTableProps,
+) {
+  const { description, required, type, show } = props
+
+  return (
+    <Collapse className="field-description" in={show}>
+      <table className="FieldDescriptionTable">
+        <tbody>
+          {description && (
+            <tr>
+              <th>Description</th>
+              <td>{description}</td>
+            </tr>
+          )}
+          <tr>
+            <th>Type</th>
+            <td>{type}</td>
+          </tr>
+          <tr>
+            <th>Required</th>
+            <td>{required ? 'Yes' : 'No'}</td>
+          </tr>
+        </tbody>
+      </table>
+    </Collapse>
+  )
+}

--- a/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
+++ b/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
@@ -23,6 +23,10 @@ import { SynapseClientError } from '../../../utils/SynapseClient'
 import { entityJsonKeys } from '../../../utils/synapseTypes'
 import { SynapseSpinner } from '../../LoadingScreen'
 import { AdditionalPropertiesSchemaField } from './AdditionalPropertiesSchemaField'
+import {
+  dropNullishArrayValues,
+  getFriendlyPropertyName,
+} from './AnnotationEditorUtils'
 import { CustomAdditionalPropertiesFieldTemplate } from './CustomAdditionalPropertiesFieldTemplate'
 import { CustomArrayFieldTemplate } from './CustomArrayFieldTemplate'
 import { CustomBooleanWidget } from './CustomBooleanWidget'
@@ -47,41 +51,6 @@ export type SchemaDrivenAnnotationEditorModalProps = {
   entityId: string
   show: boolean
   onHide: () => void
-}
-
-/**
- * Strips null values from arrays in the provided form data. If the array is empty after
- * removing null values, the key is removed from the form data.
- *
- * This allows users to submit forms with empty array fields (SWC-5762)
- */
-function dropNullishArrayValues(
-  formData: Record<string, unknown>,
-): Record<string, unknown> {
-  const newFormData: Record<string, unknown> = {}
-  Object.keys(formData).forEach(key => {
-    let value = formData[key]
-    if (Array.isArray(value)) {
-      value = (value as Array<any>).filter((item: any) => item != null)
-      if (!isEmpty(value)) {
-        newFormData[key] = value
-      }
-    } else {
-      newFormData[key] = value
-    }
-  })
-  return newFormData
-}
-
-function getFriendlyPropertyName(error: AjvError) {
-  if (error.property.startsWith('[')) {
-    // Additional properties are surrounded by brackets and quotations, so let's remove them
-    return error.property.substring(2, error.property.length - 2)
-  } else if (error.property.startsWith('.')) {
-    return error.property.substring(1)
-  } else {
-    return error.property
-  }
 }
 
 // patternProperties lets us define how to treat additionalProperties in a JSON schema by property name
@@ -232,7 +201,7 @@ export const SchemaDrivenAnnotationEditor: React.FunctionComponent<SchemaDrivenA
               variant="info"
               transition={false}
             >
-              <b>{entityJson.name as string}</b> has no annotations. Click the{' '}
+              <b>{entityJson.name}</b> has no annotations. Click the{' '}
               <AddToList /> button to annotate.
             </Alert>
           )}

--- a/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
+++ b/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
@@ -49,6 +49,30 @@ export type SchemaDrivenAnnotationEditorModalProps = {
   onHide: () => void
 }
 
+/**
+ * Strips null values from arrays in the provided form data. If the array is empty after
+ * removing null values, the key is removed from the form data.
+ *
+ * This allows users to submit forms with empty array fields (SWC-5762)
+ */
+function dropNullishArrayValues(
+  formData: Record<string, unknown>,
+): Record<string, unknown> {
+  const newFormData: Record<string, unknown> = {}
+  Object.keys(formData).forEach(key => {
+    let value = formData[key]
+    if (Array.isArray(value)) {
+      value = (value as Array<any>).filter((item: any) => item != null)
+      if (!isEmpty(value)) {
+        newFormData[key] = value
+      }
+    } else {
+      newFormData[key] = value
+    }
+  })
+  return newFormData
+}
+
 function getFriendlyPropertyName(error: AjvError) {
   if (error.property.startsWith('[')) {
     // Additional properties are surrounded by brackets and quotations, so let's remove them
@@ -155,7 +179,7 @@ export const SchemaDrivenAnnotationEditor: React.FunctionComponent<SchemaDrivenA
 
   const mutation = useUpdateViaJson(
     entityId!,
-    { ...formData, ...entityJson },
+    { ...dropNullishArrayValues(formData ?? {}), ...entityJson },
     {
       onSuccess: () => {
         onSuccess()
@@ -183,8 +207,8 @@ export const SchemaDrivenAnnotationEditor: React.FunctionComponent<SchemaDrivenA
               variant="info"
               transition={false}
             >
-              <b>{entityJson.name as string}</b> requires scientific annotations
-              specified by <b>{schema.jsonSchemaVersionInfo.$id}</b>
+              <b>{entityJson.name}</b> requires scientific annotations specified
+              by <b>{schema.jsonSchemaVersionInfo.$id}</b>
               {'. '}
               <b>
                 <a

--- a/src/lib/style/components/_annotations.scss
+++ b/src/lib/style/components/_annotations.scss
@@ -73,10 +73,14 @@
       .array-item {
         display: grid;
         grid-template-columns: [input] auto [remove] 30px [add] 30px;
-        grid-template-rows: [description] auto [widget] auto [errors] auto;
+        grid-template-rows: [widget] auto [description] auto [errors] auto;
 
         .field-description {
           grid-row-start: description;
+        }
+
+        .HelpButton {
+          display: none;
         }
 
         .form-control,
@@ -99,22 +103,50 @@
           grid-column-start: remove;
         }
       }
-
-      label {
-        color: SRC.$gray-deemphasized;
-        font-weight: normal;
-        span.required {
-          color: SRC.$red-required;
-          margin-left: 2px;
+      .LabelContainer {
+        display: flex;
+        label {
+          color: SRC.$gray-deemphasized;
+          font-weight: normal;
+          flex-grow: 1;
+          span.required {
+            color: SRC.$red-required;
+            margin-left: 2px;
+          }
         }
       }
-
       select {
         background-color: SRC.$gray-light;
       }
 
       .field-array > .array-item > label.form-label {
         display: none;
+      }
+
+      .HelpButton {
+        float: right;
+        margin: 0 0 0.5rem;
+        cursor: pointer;
+      }
+
+      table.FieldDescriptionTable {
+        margin: 10px 0px 15px 10px;
+        tr {
+          th,
+          td {
+            padding: 3px 0px;
+            vertical-align: middle;
+
+            .field-description {
+              margin-bottom: 0;
+            }
+          }
+          th {
+            padding-right: 25px;
+            font-weight: 400;
+            color: SRC.$text-color-disabled;
+          }
+        }
       }
     }
   }

--- a/src/mocks/mockSchema.ts
+++ b/src/mocks/mockSchema.ts
@@ -42,6 +42,7 @@ export const mockValidationSchema: JSONSchema7 = {
   properties: {
     country: {
       enum: ['USA', 'CA'],
+      description: 'Test description for country property',
     },
     showStringArray: {
       type: 'boolean',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,10 +2998,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sage-bionetworks/rjsf-core@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@sage-bionetworks/rjsf-core/-/rjsf-core-3.1.3.tgz#d061656dead7997e7322e0f62ca9588321f9d396"
-  integrity sha512-sNR8HIMJG69jyDVKQkqa6AEMxEUTkxZe8JBt569i315ig3ZXKk6eJTErS+/HhiUEPeohChG4sc/BI6176bfSGg==
+"@sage-bionetworks/rjsf-core@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@sage-bionetworks/rjsf-core/-/rjsf-core-3.1.4.tgz#358c2355c9b0337e26ea327ae3c76a34dc13557e"
+  integrity sha512-iNAEyHu2HtbecF2zhOzhXfQ7t9IMy9M+tk7atdnw9sNWuvcoEgcOBS80bJFeuyNhkqrqPaEFlOHaJtIjIfW1ow==
   dependencies:
     "@types/json-schema" "^7.0.7"
     ajv "^6.7.0"


### PR DESCRIPTION
[SWC-5724](https://sagebionetworks.jira.com/browse/SWC-5724)

When a schema author defines an enumeration using `anyOf`, the client-side validator doesn't recognize that it's an enumeration, so the error message when making an invalid selection is verbose and hard to understand. This change tries to recognize when we see errors that represent this situation, and transforms the errors to simplify what we show the user.

Before:
![image](https://user-images.githubusercontent.com/17580037/131905120-b7aa7377-1fa5-49ff-910b-cbcb1a1d27c0.png)

After:
![image](https://user-images.githubusercontent.com/17580037/131905037-0ebcb200-d375-4f59-9053-bb89f10ca2cc.png)


[SWC-5684](https://sagebionetworks.jira.com/browse/SWC-5684) incorporates a collapsible description element from the Figma design:

https://user-images.githubusercontent.com/17580037/131906800-5c8bd4c8-6100-448b-97a7-849144c42198.mov


[SWC-5762](https://sagebionetworks.jira.com/browse/SWC-5762) initializes arrays as empty, rather than null, which allows users to immediately interact with the form, rather than having to click 'Add Value' for each array (in some complex schemas, this is a lot of fields). We make this work by stripping null-ish array values and then removing empty arrays when we submit a new set of annotations.