### PR TITLE
PORTALS-2013 - fix for input collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-plotlyjs-ts": "^2.2.1",
     "react-query": "^3.9.8",
     "react-reflex": "^4.0.0",
-    "react-router-dom": "5.1.2",
+    "react-router-dom": "5.3.0",
     "react-scripts": "^4.0.3",
     "react-select": "^4.3.1",
     "react-sizeme": "^2.6.12",

--- a/src/__tests__/lib/containers/widgets/Checkbox.test.tsx
+++ b/src/__tests__/lib/containers/widgets/Checkbox.test.tsx
@@ -12,7 +12,6 @@ const mockCallback = jest.fn()
 function createTestProps(overrides?: CheckboxProps): CheckboxProps {
   return {
     label: 'checkboxLabel',
-    id: 'c1',
     checked: true,
     className: 'checkboxClass',
     onChange: mockCallback,
@@ -36,7 +35,7 @@ describe('basic function', () => {
     expect(wrapper).toBeDefined()
     expect(wrapper.find('label').text()).toBe(props.label)
     expect(checkboxProps.checked).toBe(true)
-    expect(checkboxProps.id).toBe(props.id)
+    expect(checkboxProps.id!.startsWith('src-checkbox-')).toBe(true)
     expect(wrapper.find('div').at(0).hasClass('checkboxClass')).toBe(true)
   })
 

--- a/src/__tests__/lib/containers/widgets/EnumFacetFilter.test.tsx
+++ b/src/__tests__/lib/containers/widgets/EnumFacetFilter.test.tsx
@@ -8,7 +8,7 @@ import {
   FacetColumnResultValueCount,
   ColumnType,
 } from '../../../../lib/utils/synapseTypes'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen, waitFor } from '@testing-library/react'
 import { act } from 'react-dom/test-utils'
 import { SynapseConstants } from '../../../../lib'
 import { SynapseTestContext } from '../../../../mocks/MockSynapseContext'
@@ -103,31 +103,31 @@ beforeEach(() => init())
 
 describe('initialization', () => {
   it('should render as a dropdown if containerAs = Dropdown', async () => {
-    await act(
-      async () =>
-        await init({
-          containerAs: 'Dropdown',
-        }),
+    act(() =>
+      init({
+        containerAs: 'Dropdown',
+      }),
     )
     expect(container.querySelector('.dropdown')).toBeDefined()
   })
   it('should render as a dropdown if containerAs = Collapsible', async () => {
-    await act(
-      async () =>
-        await init({
-          containerAs: 'Collapsible',
-        }),
+    act(() =>
+      init({
+        containerAs: 'Collapsible',
+      }),
     )
     expect(container.querySelector('div.FacetFilterHeader')).toBeDefined()
   })
 
   it('should initiate selected items correctly', async () => {
-    const checkboxes = container.querySelectorAll<HTMLInputElement>(
-      'input[type="checkbox"]:not(#select_all)',
-    )
-    expect(checkboxes).toHaveLength(3)
+    const checkboxes = (await screen.findAllByRole(
+      'checkbox',
+    )) as HTMLInputElement[]
+    expect(checkboxes).toHaveLength(4)
+
+    expect(checkboxes).toHaveLength(4)
     checkboxes.forEach((checkbox, i) => {
-      if (i === 1) {
+      if (i === 2) {
         expect(checkbox.checked).toBe(true)
       } else {
         expect(checkbox.checked).toBe(false)
@@ -172,23 +172,26 @@ describe('initialization', () => {
   })
 
   describe('label initialization', () => {
-    it('should set labels correctly for STRING type', async () => {
+    it('should set labels correctly for STRING type', () => {
       const labels = container.querySelectorAll<HTMLSpanElement>(
-        'input[type="checkbox"]:not(#select_all) ~ label',
+        'input[type="checkbox"] ~ label',
       )
       const counts = container.querySelectorAll<HTMLDivElement>(
         '.EnumFacetFilter__count',
       )
-      expect(labels).toHaveLength(3)
-      labels.forEach((label, i) => {
-        if (i !== 2) {
-          expect(label.textContent).toBe(`${stringFacetValues[i].value}`)
-          expect(counts[i].textContent).toBe(`${stringFacetValues[i].count}`)
-        } else {
-          expect(label.textContent).toBe(`Not Assigned`)
-          expect(counts[i].textContent).toBe(`${stringFacetValues[i].count}`)
-        }
-      })
+      expect(labels).toHaveLength(4)
+      expect(counts).toHaveLength(3)
+
+      expect(labels[0].textContent).toBe('All')
+
+      expect(labels[1].textContent).toBe(`${stringFacetValues[0].value}`)
+      expect(counts[0].textContent).toBe(`${stringFacetValues[0].count}`)
+
+      expect(labels[2].textContent).toBe(`${stringFacetValues[1].value}`)
+      expect(counts[1].textContent).toBe(`${stringFacetValues[1].count}`)
+
+      expect(labels[3].textContent).toBe(`Not Assigned`)
+      expect(counts[2].textContent).toBe(`${stringFacetValues[2].count}`)
     })
 
     it('should hide > 5 items if items with index >=5 not selected', async () => {
@@ -216,9 +219,9 @@ describe('initialization', () => {
       })
 
       const labels = container.querySelectorAll(
-        'input[type="checkbox"]:not(#select_all) ~ label',
+        'input[type="checkbox"] ~ label',
       )
-      expect(labels).toHaveLength(20)
+      expect(labels).toHaveLength(facetValues.length + 1)
     })
 
     it('should set labels correctly for ENTITYID type', async () => {
@@ -234,67 +237,79 @@ describe('initialization', () => {
         columnModel: entityColumnModel,
       }
 
-      await act(async () => await init(updatedProps))
+      act(() => init(updatedProps))
       const labels = container.querySelectorAll<HTMLInputElement>(
-        'input:not(#select_all) ~ label',
+        'input[type="checkbox"] ~ label',
       )
       const counts = container.querySelectorAll<HTMLDivElement>(
         '.EnumFacetFilter__count',
       )
-      expect(labels.item(0).textContent).toBe(`Not Assigned`)
+      expect(labels.item(1).textContent).toBe(`Not Assigned`)
       expect(counts.item(0).textContent).toBe(
         `${userEntityFacetValues[0].count}`,
       )
-      expect(labels.item(1).textContent).toBe(`Entity1`)
+
+      // Wait for the entity info to populate and replace the ID
+      await waitFor(() => expect(labels.item(2).textContent).toBe(`Entity1`))
       expect(counts.item(1).textContent).toBe(
         `${userEntityFacetValues[1].count}`,
       )
-      expect(labels.item(2).textContent).toBe(`Entity2`)
+
+      await waitFor(() => expect(labels.item(3).textContent).toBe(`Entity2`))
+      expect(counts.item(2).textContent).toBe(
+        `${userEntityFacetValues[2].count}`,
+      )
+    })
+
+    it('should set labels correctly for USERID type', async () => {
+      const userColumnModel: ColumnModel = {
+        ...columnModel,
+        columnType: ColumnType.USERID,
+        name: 'Users',
+      }
+
+      const updatedProps = {
+        ...props,
+        facetValues: userEntityFacetValues,
+        columnModel: userColumnModel,
+      }
+
+      act(() => init(updatedProps))
+      const labels = container.querySelectorAll<HTMLSpanElement>(
+        'input[type="checkbox"] ~ label',
+      )
+      const counts = container.querySelectorAll<HTMLDivElement>(
+        '.EnumFacetFilter__count',
+      )
+      expect(labels).toHaveLength(4)
+      // First item (0) is select all
+
+      expect(labels.item(1).textContent).toBe(`Not Assigned`)
+      expect(counts.item(0).textContent).toBe(
+        `${userEntityFacetValues[0].count}`,
+      )
+
+      // Wait for the user info to populate and replace the ID
+      await waitFor(() => expect(labels.item(2).textContent).toBe(`somename`))
+      expect(counts.item(1).textContent).toBe(
+        `${userEntityFacetValues[1].count}`,
+      )
+
+      await waitFor(() => expect(labels.item(3).textContent).toBe(`somename2`))
       expect(counts.item(2).textContent).toBe(
         `${userEntityFacetValues[2].count}`,
       )
     })
   })
-
-  it('should set labels correctly for USERID type', async () => {
-    const userColumnModel: ColumnModel = {
-      ...columnModel,
-      columnType: ColumnType.USERID,
-      name: 'Users',
-    }
-
-    const updatedProps = {
-      ...props,
-      facetValues: userEntityFacetValues,
-      columnModel: userColumnModel,
-    }
-
-    await act(async () => await init(updatedProps))
-    const labels = container.querySelectorAll<HTMLSpanElement>(
-      'input[type="checkbox"]:not(#select_all) ~ label',
-    )
-    const counts = container.querySelectorAll<HTMLDivElement>(
-      '.EnumFacetFilter__count',
-    )
-    expect(labels).toHaveLength(3)
-    expect(labels.item(0).textContent).toBe(`Not Assigned`)
-    expect(counts.item(0).textContent).toBe(`${userEntityFacetValues[0].count}`)
-    expect(labels.item(1).textContent).toBe(`somename`)
-    expect(counts.item(1).textContent).toBe(`${userEntityFacetValues[1].count}`)
-    expect(labels.item(2).textContent).toBe(`somename2`)
-    expect(counts.item(2).textContent).toBe(`${userEntityFacetValues[2].count}`)
-  })
 })
 
 describe('callbacks', () => {
   it('should trigger callback on checkbox change after delay', () => {
-    const checkboxes = container.querySelectorAll<HTMLInputElement>(
-      'input[type="checkbox"]:not(#select_all)',
-    )
+    const individualFacetCheckboxes = screen.getAllByRole('checkbox').slice(1)
 
     jest.useFakeTimers()
-    fireEvent.click(checkboxes.item(0))
-    fireEvent.click(checkboxes.item(1))
+    fireEvent.click(individualFacetCheckboxes[0])
+    fireEvent.click(individualFacetCheckboxes[1])
     expect(setTimeout).toHaveBeenCalledTimes(2)
     jest.runOnlyPendingTimers()
     expect(mockCallback).toHaveBeenCalledWith({
@@ -304,11 +319,8 @@ describe('callbacks', () => {
   })
 
   it('should trigger callback on clear', () => {
-    const clear = container.querySelector<HTMLInputElement>(
-      'input[type="checkbox"]#select_all',
-    )
-
-    fireEvent.click(clear!)
+    const selectAllCheckbox = screen.getByLabelText('All')
+    fireEvent.click(selectAllCheckbox)
     expect(mockOnClear).toHaveBeenCalled()
   })
 })

--- a/src/lib/containers/entity_finder/details/view/DetailsViewRow.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsViewRow.tsx
@@ -123,7 +123,6 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
             {!isDisabled && selectButtonType === 'checkbox' && (
               <Checkbox
                 label=""
-                id=""
                 className="SRC-pointer-events-none"
                 checked={isSelected}
                 onChange={() => {

--- a/src/lib/containers/personal_access_token/CreateAccessTokenModal.tsx
+++ b/src/lib/containers/personal_access_token/CreateAccessTokenModal.tsx
@@ -139,7 +139,6 @@ export const CreateAccessTokenModal: React.FunctionComponent<CreateAccessTokenMo
                 </FormLabel>
                 <Checkbox
                   label={scopeDescriptions.view.displayName}
-                  id="view"
                   checked={viewAccess}
                   onChange={() => setViewAccess(!viewAccess)}
                 >
@@ -150,7 +149,6 @@ export const CreateAccessTokenModal: React.FunctionComponent<CreateAccessTokenMo
                 </Checkbox>
                 <Checkbox
                   label={scopeDescriptions.download.displayName}
-                  id="download"
                   checked={downloadAccess}
                   onChange={() => setDownloadAccess(!downloadAccess)}
                 >
@@ -160,7 +158,6 @@ export const CreateAccessTokenModal: React.FunctionComponent<CreateAccessTokenMo
                 </Checkbox>
                 <Checkbox
                   label={scopeDescriptions.modify.displayName}
-                  id="modify"
                   checked={modifyAccess}
                   onChange={() => setModifyAccess(!modifyAccess)}
                 >

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -878,7 +878,6 @@ export default class SynapseTable extends React.Component<
           <td key={`(${rowIndex},rowSelectColumn)`} className="SRC_noBorderTop">
             <Checkbox
               label=""
-              id={`(${rowIndex},rowSelectColumnCheckbox)`}
               checked={selectedRowIndices.includes(rowIndex)}
               onChange={(checked: boolean) => {
                 const cloneSelectedRowIndices = [...selectedRowIndices]

--- a/src/lib/containers/widgets/Checkbox.tsx
+++ b/src/lib/containers/widgets/Checkbox.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import { useState, useEffect } from 'react'
+import { uniqueId as _uniqueId } from 'lodash-es'
+import React, { useEffect, useState } from 'react'
+
 export type CheckboxProps = {
   label: string
-  id: string
   checked?: boolean
   className?: string
   onChange: (newValue: boolean) => void
@@ -21,6 +21,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
     disabled = false,
   } = props
   const [checked, setChecked] = useState<boolean>(propsChecked)
+  const [uniqueId] = useState(_uniqueId('src-checkbox-'))
 
   useEffect(() => {
     setChecked(propsChecked)
@@ -49,11 +50,11 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
       <input
         type="checkbox"
         checked={checked}
-        id={props.id}
+        id={uniqueId}
         onChange={handleCheckboxChange}
         disabled={disabled}
       />
-      <label htmlFor={props.id}>{props.label}</label>
+      <label htmlFor={uniqueId}>{props.label}</label>
       {props.children ?? <></>}
     </div>
   )

--- a/src/lib/containers/widgets/RadioGroup.tsx
+++ b/src/lib/containers/widgets/RadioGroup.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { uniqueId as _uniqueId } from 'lodash-es'
 
 export type RadioGroupProps = {
   options: { label: string; value: string }[]
@@ -42,16 +43,16 @@ type RadioOptionProps = {
 const RadioOption: React.FunctionComponent<RadioOptionProps> = (
   props: RadioOptionProps,
 ) => {
-  const id = `${props.groupId}-${props.label}`
+  const [uniqueId] = useState(_uniqueId('src-radio-'))
   return (
     <div onClick={() => props.onChange(props.value)}>
       <input
-        id={id}
+        id={uniqueId}
         type="radio"
         checked={props.currentValue === props.value}
         value={props.value}
       />
-      <label htmlFor={id}>{props.label}</label>
+      <label htmlFor={uniqueId}>{props.label}</label>
     </div>
   )
 }

--- a/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
@@ -1,21 +1,20 @@
-import * as React from 'react'
-import { Dropdown } from 'react-bootstrap'
-import {
-  FacetColumnResultValueCount,
-  ColumnModel,
-} from '../../../utils/synapseTypes/Table'
-import { Checkbox } from '../Checkbox'
-import { SynapseConstants } from '../../../utils'
-import { useState } from 'react'
-import { EntityHeader } from '../../../utils/synapseTypes/EntityHeader'
-import { UserProfile } from '../../../utils/synapseTypes'
-import useGetInfoFromIds from '../../../utils/hooks/useGetInfoFromIds'
+import React, { useState } from 'react'
+import { library } from '@fortawesome/fontawesome-svg-core'
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { FacetFilterHeader } from './FacetFilterHeader'
-import { ElementWithTooltip } from '../../../containers/widgets/ElementWithTooltip'
+import { Dropdown } from 'react-bootstrap'
 import useDeepCompareEffect from 'use-deep-compare-effect'
+import { ElementWithTooltip } from '../../../containers/widgets/ElementWithTooltip'
+import { SynapseConstants } from '../../../utils'
+import useGetInfoFromIds from '../../../utils/hooks/useGetInfoFromIds'
+import { UserProfile } from '../../../utils/synapseTypes'
+import { EntityHeader } from '../../../utils/synapseTypes/EntityHeader'
+import {
+  ColumnModel,
+  FacetColumnResultValueCount,
+} from '../../../utils/synapseTypes/Table'
+import { Checkbox } from '../Checkbox'
+import { FacetFilterHeader } from './FacetFilterHeader'
 
 library.add(faArrowLeft)
 
@@ -213,7 +212,6 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
               key="select_all"
               checked={allIsSelected}
               label="All"
-              id="select_all"
               isSelectAll={true}
             ></Checkbox>
             <button
@@ -400,7 +398,6 @@ function EnumFacetFilterOption({
         key={id + index}
         checked={isSelected}
         label={label}
-        id={id}
       ></Checkbox>
       {isDropdown && <span className="EnumFacetFilter__count">({count})</span>}
       {!isDropdown && <div className="EnumFacetFilter__count">{count}</div>}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,6 +2127,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.13":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.13.10", "@babel/runtime@^7.13.8", "@babel/runtime@^7.9.6":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
@@ -12131,10 +12138,10 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-mini-create-react-context@^0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.3.3.tgz"
-  integrity sha512-TtF6hZE59SGmS4U8529qB+jJFeW6asTLDIpPgvPLSCsooAwJS7QprHIFTqv9/Qh3NdLwQxFYgiHX5lqb6jqzPA==
+mini-create-react-context@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
   dependencies:
     "@babel/runtime" "^7.12.1"
     tiny-warning "^1.0.3"
@@ -15125,29 +15132,29 @@ react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-router-dom@5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz"
-  integrity sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==
+react-router-dom@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.0.tgz#da1bfb535a0e89a712a93b97dd76f47ad1f32363"
+  integrity sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==
   dependencies:
-    "@babel/runtime" "^7.1.2"
+    "@babel/runtime" "^7.12.13"
     history "^4.9.0"
     loose-envify "^1.3.1"
     prop-types "^15.6.2"
-    react-router "5.1.2"
+    react-router "5.2.1"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.1.2.tgz"
-  integrity sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==
+react-router@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"
+  integrity sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==
   dependencies:
-    "@babel/runtime" "^7.1.2"
+    "@babel/runtime" "^7.12.13"
     history "^4.9.0"
     hoist-non-react-statics "^3.1.0"
     loose-envify "^1.3.1"
-    mini-create-react-context "^0.3.0"
+    mini-create-react-context "^0.4.0"
     path-to-regexp "^1.7.0"
     prop-types "^15.6.2"
     react-is "^16.6.0"


### PR DESCRIPTION
[Jira](https://sagebionetworks.jira.com/browse/PORTALS-2013)

Bug in portals was caused by rendering two QueryWrapperPlotNavs with some identical EnumFacetFilter options. The checkboxes in the facet filter component had identical IDs, which would cause the browser to act as if you checked the first box in the page with that ID.

The simple fix is to generate unique IDs for all of our custom inputs.