### PR TITLE
Target es2019 to get rid of horrific concat.apply

### DIFF
--- a/src/lib/containers/download_list_v2/DownloadListActionsRequired.tsx
+++ b/src/lib/containers/download_list_v2/DownloadListActionsRequired.tsx
@@ -4,7 +4,11 @@ import { toError } from '../../utils/ErrorUtils'
 import { useGetDownloadListActionsRequiredInfinite } from '../../utils/hooks/SynapseAPI/useGetDownloadListActionsRequired'
 import { useInView } from 'react-intersection-observer'
 import { SynapseSpinner } from '../LoadingScreen'
-import { ActionRequiredCount, MeetAccessRequirement, RequestDownload } from '../../utils/synapseTypes/DownloadListV2/ActionRequiredCount'
+import {
+  ActionRequiredCount,
+  MeetAccessRequirement,
+  RequestDownload,
+} from '../../utils/synapseTypes/DownloadListV2/ActionRequiredCount'
 import { MeetAccessRequirementCard } from './MeetAccessRequirementCard'
 import { RequestDownloadCard } from './RequestDownloadCard'
 
@@ -40,34 +44,33 @@ export default function DownloadListActionsRequired() {
     }
   }, [status, isFetching, hasNextPage, fetchNextPage, inView])
 
-  const allRows = data
-    ? ([] as ActionRequiredCount[]).concat.apply(
-        [],
-        data.pages.map(
-          p => p.page,
-        ),
-      )
-    : []
+  const allRows = data?.pages.flatMap(page => page.page) ?? []
 
-      /**
+  /**
    * Returns rendering for the ActionRequiredCount.
    *
    * @param {ActionRequiredCount} actionRequiredCount actionRequiredCount being rendered
    */
-  const renderActionRequired = (
-    actionRequiredCount: ActionRequiredCount,
-  ) => {
+  const renderActionRequired = (actionRequiredCount: ActionRequiredCount) => {
     switch (actionRequiredCount.action.concreteType) {
       case 'org.sagebionetworks.repo.model.download.MeetAccessRequirement': {
-        const meetARAction:MeetAccessRequirement = actionRequiredCount.action as MeetAccessRequirement
+        const meetARAction: MeetAccessRequirement = actionRequiredCount.action as MeetAccessRequirement
         return (
-          <MeetAccessRequirementCard key={meetARAction.accessRequirementId} accessRequirementId={meetARAction.accessRequirementId} count={actionRequiredCount.count} />
+          <MeetAccessRequirementCard
+            key={meetARAction.accessRequirementId}
+            accessRequirementId={meetARAction.accessRequirementId}
+            count={actionRequiredCount.count}
+          />
         )
       }
       case 'org.sagebionetworks.repo.model.download.RequestDownload': {
-        const requestDownloadAction:RequestDownload = actionRequiredCount.action as RequestDownload
+        const requestDownloadAction: RequestDownload = actionRequiredCount.action as RequestDownload
         return (
-          <RequestDownloadCard key={requestDownloadAction.benefactorId} entityId={`syn${requestDownloadAction.benefactorId}`} count={actionRequiredCount.count} />
+          <RequestDownloadCard
+            key={requestDownloadAction.benefactorId}
+            entityId={`syn${requestDownloadAction.benefactorId}`}
+            count={actionRequiredCount.count}
+          />
         )
       }
       // case not supported yet
@@ -78,16 +81,14 @@ export default function DownloadListActionsRequired() {
   return (
     <>
       {allRows.length > 0 && (
-        <div
-          className="DownloadListActionsRequired"
-        >
-            {allRows.map((item:ActionRequiredCount) => {
-              if (item) {
-                return renderActionRequired(item)
-              } else return false
-            })}
-            {/* To trigger loading the next page */}
-            <div ref={ref} />
+        <div className="DownloadListActionsRequired">
+          {allRows.map((item: ActionRequiredCount) => {
+            if (item) {
+              return renderActionRequired(item)
+            } else return false
+          })}
+          {/* To trigger loading the next page */}
+          <div ref={ref} />
         </div>
       )}
       {isFetching && (

--- a/src/lib/containers/download_list_v2/DownloadListTable.tsx
+++ b/src/lib/containers/download_list_v2/DownloadListTable.tsx
@@ -63,14 +63,7 @@ export default function DownloadListTable() {
     }
   }, [status, isFetching, hasNextPage, fetchNextPage, inView])
 
-  const allRows = data
-    ? ([] as DownloadListItemResult[]).concat.apply(
-        [],
-        data.pages.map(
-          p => p.page,
-        ),
-      )
-    : []
+  const allRows = data?.pages.flatMap(page => page.page) ?? []
 
   const getFilterDisplayText = (f: AvailableFilter) => {
     if (!f) {
@@ -120,29 +113,33 @@ export default function DownloadListTable() {
       )
     )
   }
-  const availableFiltersArray: AvailableFilter[] = [undefined, 'eligibleForPackaging', 'ineligibleForPackaging']
+  const availableFiltersArray: AvailableFilter[] = [
+    undefined,
+    'eligibleForPackaging',
+    'ineligibleForPackaging',
+  ]
   return (
     <>
       <div className="filterFilesContainer">
-          <span className="filterFilesByText">Filter Files By</span>
-          <Dropdown>
-            <Dropdown.Toggle variant="gray-primary-500" id="dropdown-basic">
-              {getFilterDisplayText(filter)}
-            </Dropdown.Toggle>
-            <Dropdown.Menu role="menu">
-            {availableFiltersArray.map(
-              (availableFilter) => (
+        <span className="filterFilesByText">Filter Files By</span>
+        <Dropdown>
+          <Dropdown.Toggle variant="gray-primary-500" id="dropdown-basic">
+            {getFilterDisplayText(filter)}
+          </Dropdown.Toggle>
+          <Dropdown.Menu role="menu">
+            {availableFiltersArray.map(availableFilter => (
               <Dropdown.Item
-                  role="menuitem"
-                  key={`${getFilterDisplayText(availableFilter)}-filter-option`}
-                  onClick={() => {
-                    setFilter(availableFilter)
-                  }}
-                >
-                  {getFilterDisplayText(availableFilter)}
-                </Dropdown.Item>),)}
-            </Dropdown.Menu>
-          </Dropdown>
+                role="menuitem"
+                key={`${getFilterDisplayText(availableFilter)}-filter-option`}
+                onClick={() => {
+                  setFilter(availableFilter)
+                }}
+              >
+                {getFilterDisplayText(availableFilter)}
+              </Dropdown.Item>
+            ))}
+          </Dropdown.Menu>
+        </Dropdown>
       </div>
       {allRows.length > 0 && (
         <>
@@ -186,14 +183,15 @@ export default function DownloadListTable() {
               </tr>
             </thead>
             <tbody>
-              {allRows.map((item:DownloadListItemResult) => {
+              {allRows.map((item: DownloadListItemResult) => {
                 if (item) {
                   const addedOn = moment(item.addedOn).format('L LT')
                   const createdOn = moment(item.createdOn).format('L LT')
                   return (
                     <tr key={item.fileEntityId}>
                       <td>
-                          {item.isEligibleForPackaging && <span
+                        {item.isEligibleForPackaging && (
+                          <span
                             data-for={`${item.fileEntityId}-eligible-tooltip`}
                             data-tip="Eligible for packaging"
                             className="eligibileIcon"
@@ -205,10 +203,17 @@ export default function DownloadListTable() {
                               effect="solid"
                               id={`${item.fileEntityId}-eligible-tooltip`}
                             />
-                            <IconSvg options={{icon: 'packagableFile', color: '#878E95' }} />
-                        </span>}
-                        {!item.isEligibleForPackaging && <span className="ineligibileIcon" />
-                        }
+                            <IconSvg
+                              options={{
+                                icon: 'packagableFile',
+                                color: '#878E95',
+                              }}
+                            />
+                          </span>
+                        )}
+                        {!item.isEligibleForPackaging && (
+                          <span className="ineligibileIcon" />
+                        )}
                         <a
                           target="_blank"
                           rel="noopener noreferrer"

--- a/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useErrorHandler } from 'react-error-boundary'
 import { useGetEntityChildrenInfinite } from '../../../../utils/hooks/SynapseAPI/useGetEntityChildren'
-import { Direction, EntityHeader, SortBy } from '../../../../utils/synapseTypes'
+import { Direction, SortBy } from '../../../../utils/synapseTypes'
 import { toError } from '../../../../utils/ErrorUtils'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import { DetailsView } from '../view/DetailsView'
@@ -46,14 +46,7 @@ export const EntityChildrenDetails: React.FunctionComponent<EntityChildrenDetail
 
   return (
     <DetailsView
-      entities={
-        data
-          ? ([] as EntityHeader[]).concat.apply(
-              [],
-              data.pages.map(page => page.page),
-            )
-          : []
-      }
+      entities={data?.pages.flatMap(page => page.page) ?? []}
       queryStatus={status}
       queryIsFetching={isFetching}
       hasNextPage={hasNextPage}

--- a/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect } from 'react'
 import { useErrorHandler } from 'react-error-boundary'
-import { useGetProjectsInfinite } from '../../../../utils/hooks/SynapseAPI/useProjects'
-import { ProjectHeader } from '../../../../utils/synapseTypes'
-import { GetProjectsParameters } from '../../../../utils/synapseTypes/GetProjectsParams'
 import { toError } from '../../../../utils/ErrorUtils'
+import { useGetProjectsInfinite } from '../../../../utils/hooks/SynapseAPI/useProjects'
+import { GetProjectsParameters } from '../../../../utils/synapseTypes/GetProjectsParams'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import { DetailsView } from '../view/DetailsView'
 
@@ -39,14 +38,7 @@ export const ProjectListDetails: React.FunctionComponent<ProjectListDetailsProps
 
   return (
     <DetailsView
-      entities={
-        data
-          ? ([] as ProjectHeader[]).concat.apply(
-              [],
-              data.pages.map(page => page.results),
-            )
-          : []
-      }
+      entities={data?.pages.flatMap(page => page.results) ?? []}
       queryStatus={status}
       queryIsFetching={isFetching}
       hasNextPage={hasNextPage}

--- a/src/lib/containers/entity_finder/details/configurations/SearchDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/SearchDetails.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { useErrorHandler } from 'react-error-boundary'
 import { useSearchInfinite } from '../../../../utils/hooks/SynapseAPI/useSearch'
-import { Hit, SearchQuery } from '../../../../utils/synapseTypes/Search'
+import { SearchQuery } from '../../../../utils/synapseTypes/Search'
 import { toError } from '../../../../utils/ErrorUtils'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import { DetailsView } from '../view/DetailsView'
@@ -41,14 +41,7 @@ export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
   if (searchQuery.queryTerm) {
     return (
       <DetailsView
-        entities={
-          data
-            ? ([] as Hit[]).concat.apply(
-                [],
-                data.pages.map(page => page.hits),
-              )
-            : []
-        }
+        entities={data?.pages.flatMap(page => page.hits) ?? []}
         queryStatus={status}
         queryIsFetching={isFetching}
         hasNextPage={hasNextPage}

--- a/src/lib/containers/entity_finder/tree/TreeNode.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeNode.tsx
@@ -106,12 +106,7 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
     if (isRootNode) {
       setEntityChildren(rootNodeConfiguration!.children)
     } else {
-      setEntityChildren(
-        ([] as EntityHeader[]).concat.apply(
-          [],
-          children?.pages.map(page => page.page) ?? [],
-        ),
-      )
+      setEntityChildren(children?.pages.flatMap(page => page.page) ?? [])
     }
   }, [isRootNode, children, rootNodeConfiguration])
 

--- a/src/lib/containers/entity_finder/tree/TreeView.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeView.tsx
@@ -164,12 +164,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
   useEffect(() => {
     if (useProjectData && isSuccessProjects) {
       if (projectData?.pages) {
-        setTopLevelEntities(
-          ([] as ProjectHeader[]).concat.apply(
-            [],
-            projectData.pages.map(page => page.results),
-          ),
-        )
+        setTopLevelEntities(projectData.pages.flatMap(page => page.results))
       }
     }
   }, [useProjectData, isSuccessProjects, projectData])

--- a/src/lib/containers/user_profile_links/UserChallenges.tsx
+++ b/src/lib/containers/user_profile_links/UserChallenges.tsx
@@ -11,7 +11,7 @@ export type UserChallengesProps = {
   userId: string
 }
 
-export default function UserChallenges({userId}:UserChallengesProps) {
+export default function UserChallenges({ userId }: UserChallengesProps) {
   const handleError = useErrorHandler()
   // Load the next page when this ref comes into view.
   const { ref, inView } = useInView()
@@ -43,20 +43,13 @@ export default function UserChallenges({userId}:UserChallengesProps) {
     }
   }, [status, isFetching, hasNextPage, fetchNextPage, inView])
 
-  const allRows = data
-    ? ([] as ChallengeWithProjectHeader[]).concat.apply(
-        [],
-        data.pages.map(
-          p => p.results,
-        ),
-      )
-    : []
+  const allRows = data?.pages.flatMap(page => page.results) ?? []
 
   return (
     <>
       {allRows.length > 0 && (
         <>
-          {allRows.map((item:ChallengeWithProjectHeader) => {
+          {allRows.map((item: ChallengeWithProjectHeader) => {
             if (item && item.challenge && item.projectHeader) {
               // another option may be to use an EntityLink
               return (
@@ -76,12 +69,8 @@ export default function UserChallenges({userId}:UserChallengesProps) {
           <div ref={ref} />
         </>
       )}
-      {!isFetching && allRows.length == 0 && (
-        <div>Empty</div>
-      )}
-      {isFetching && (
-        <SkeletonTable numRows={5} numCols={1} />
-      )}
+      {!isFetching && allRows.length == 0 && <div>Empty</div>}
+      {isFetching && <SkeletonTable numRows={5} numCols={1} />}
     </>
   )
 }

--- a/src/lib/containers/user_profile_links/UserProjects.tsx
+++ b/src/lib/containers/user_profile_links/UserProjects.tsx
@@ -12,7 +12,7 @@ export type UserProjectsProps = {
   userId: string
 }
 
-export default function UserProjects({userId}:UserProjectsProps) {
+export default function UserProjects({ userId }: UserProjectsProps) {
   const handleError = useErrorHandler()
   // Load the next page when this ref comes into view.
   const { ref, inView } = useInView()
@@ -45,20 +45,13 @@ export default function UserProjects({userId}:UserProjectsProps) {
     }
   }, [status, isFetching, hasNextPage, fetchNextPage, inView])
 
-  const allRows = data
-    ? ([] as ProjectHeader[]).concat.apply(
-        [],
-        data.pages.map(
-          p => p.results,
-        ),
-      )
-    : []
+  const allRows = data?.pages.flatMap(page => page.results) ?? []
 
   return (
     <>
       {allRows.length > 0 && (
         <>
-          {allRows.map((item:ProjectHeader) => {
+          {allRows.map((item: ProjectHeader) => {
             if (item) {
               // another option would be to use an EntityLink
               return (
@@ -78,12 +71,8 @@ export default function UserProjects({userId}:UserProjectsProps) {
           <div ref={ref} />
         </>
       )}
-      {!isFetching && allRows.length == 0 && (
-        <div>Empty</div>
-      )}
-      {isFetching && (
-        <SkeletonTable numRows={5} numCols={1} />
-      )}
+      {!isFetching && allRows.length == 0 && <div>Empty</div>}
+      {isFetching && <SkeletonTable numRows={5} numCols={1} />}
     </>
   )
 }

--- a/src/lib/containers/user_profile_links/UserTeams.tsx
+++ b/src/lib/containers/user_profile_links/UserTeams.tsx
@@ -11,7 +11,7 @@ export type UserTeamsProps = {
   userId: string
 }
 
-export default function UserTeams({userId}:UserTeamsProps) {
+export default function UserTeams({ userId }: UserTeamsProps) {
   const handleError = useErrorHandler()
   // Load the next page when this ref comes into view.
   const { ref, inView } = useInView()
@@ -43,20 +43,13 @@ export default function UserTeams({userId}:UserTeamsProps) {
     }
   }, [status, isFetching, hasNextPage, fetchNextPage, inView])
 
-  const allRows = data
-    ? ([] as Team[]).concat.apply(
-        [],
-        data.pages.map(
-          p => p.results,
-        ),
-      )
-    : []
+  const allRows = data?.pages.flatMap(page => page.results) ?? []
 
   return (
     <>
       {allRows.length > 0 && (
         <>
-          {allRows.map((item:Team) => {
+          {allRows.map((item: Team) => {
             if (item) {
               // another option would be to use an EntityLink
               return (
@@ -76,12 +69,8 @@ export default function UserTeams({userId}:UserTeamsProps) {
           <div ref={ref} />
         </>
       )}
-      {!isFetching && allRows.length == 0 && (
-        <div>Empty</div>
-      )}
-      {isFetching && (
-        <SkeletonTable numRows={5} numCols={1} />
-      )}
+      {!isFetching && allRows.length == 0 && <div>Empty</div>}
+      {isFetching && <SkeletonTable numRows={5} numCols={1} />}
     </>
   )
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,7 +8,7 @@
     "baseUrl": ".",
     "module": "commonjs",
     "target": "es5",
-    "lib": ["es6", "dom"],
+    "lib": ["es2019", "dom"],
     "sourceMap": true,
     "jsx": "react",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,7 @@
     "allowSyntheticDefaultImports": true,
     "module": "esnext",
     "target": "es5",
-    "lib": [
-      "es6",
-      "dom"
-    ],
+    "lib": ["es2019", "dom"],
     "sourceMap": true,
     "jsx": "react",
     "moduleResolution": "node",
@@ -40,7 +37,5 @@
     "jest",
     "setupTests.js"
   ],
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Assuming our rollup/babel configuration is working, we're transpiling and polyfilling down to es5, so this shouldn't cause any issues.

We can take advantage of ES2019's Array.prototype.flatMap to get rid of this ugly transform we've had to do whenever we call useInfiniteQuery