### PR TITLE
SWC-5776

### DIFF
--- a/src/__tests__/lib/containers/EntityBadgeIcons.test.tsx
+++ b/src/__tests__/lib/containers/EntityBadgeIcons.test.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../lib/utils/SynapseConstants'
 import { EntityType } from '../../../lib/utils/synapseTypes'
 import { mockSchemaValidationResults } from '../../../mocks/mockSchema'
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
 
 const defaultProps: EntityBadgeIconsProps = {
   entityId: MOCK_FILE_ENTITY_ID,
@@ -39,6 +40,7 @@ function renderComponent(wrapperProps?: SynapseContextType) {
   render(<EntityBadgeIcons {...defaultProps} />, {
     wrapper: createWrapper(wrapperProps),
   })
+  mockAllIsIntersecting(true)
 }
 
 describe('EntityBadgeIcons tests', () => {

--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -48,6 +48,8 @@ export type EntityFinderProps = {
   initialContainer: string | 'root' | null
   /** Whether or not versions may be specified when selecting applicable entities */
   showVersionSelection?: boolean
+  /** For versionable entities, require the user to select a numbered version of an entity. This disallows selecting 'Always Latest Version'. Note that the latest version may still be mutable. Default true. */
+  mustSelectVersionNumber?: boolean
   /** The entity types to show in the details view (right pane). Any types specified in `selectableTypes` will automatically be included. */
   visibleTypesInList?: EntityType[]
   /** The entity types that may be selected. Types in `visibleTypesInList` that are not in `selectableTypes` will appear as disabled options. Only the types in `selectableTypes` will appear in search */
@@ -67,6 +69,7 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
   selectMultiple,
   onSelectedChange,
   showVersionSelection = true,
+  mustSelectVersionNumber = false,
   selectableTypes = Object.values(EntityType),
   visibleTypesInList = Object.values(EntityType),
   visibleTypesInTree = DEFAULT_VISIBLE_TYPES,
@@ -170,7 +173,7 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
 
   useEffect(() => {
     if (searchTerms?.length === 1) {
-      const synIdMatch = searchTerms[0].match(SYNAPSE_ENTITY_ID_REGEX)
+      const synIdMatch = SYNAPSE_ENTITY_ID_REGEX.exec(searchTerms[0])
       if (synIdMatch) {
         SynapseClient.getEntityHeaders(
           [
@@ -290,6 +293,7 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                     }
               }
               showVersionSelection={showVersionSelection}
+              mustSelectVersionNumber={mustSelectVersionNumber}
               selectColumnType={selectMultiple ? 'checkbox' : 'none'}
               selected={selectedEntities}
               visibleTypes={selectableTypes}
@@ -344,6 +348,7 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                         <ReflexElement className="DetailsViewReflexElement">
                           <EntityDetailsList
                             configuration={configFromTreeView}
+                            mustSelectVersionNumber={mustSelectVersionNumber}
                             showVersionSelection={showVersionSelection}
                             selected={selectedEntities}
                             visibleTypes={selectableAndVisibleTypesInList}

--- a/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
+++ b/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
@@ -41,6 +41,7 @@ export type EntityDetailsListDataConfiguration = {
  */
 export type EntityDetailsListSharedProps = {
   showVersionSelection: boolean
+  mustSelectVersionNumber: boolean
   selectColumnType: 'checkbox' | 'none'
   visibleTypes: EntityType[]
   selected: Reference[]

--- a/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
@@ -12,12 +12,7 @@ type EntityChildrenDetailsProps = EntityDetailsListSharedProps & {
 
 export const EntityChildrenDetails: React.FunctionComponent<EntityChildrenDetailsProps> = ({
   parentContainerId,
-  visibleTypes: includeTypes,
-  showVersionSelection,
-  selectColumnType,
-  selected,
-  selectableTypes,
-  toggleSelection,
+  ...sharedProps
 }) => {
   const [sortBy, setSortBy] = useState<SortBy>(SortBy.NAME)
   const [sortDirection, setSortDirection] = useState<Direction>(Direction.ASC)
@@ -33,7 +28,7 @@ export const EntityChildrenDetails: React.FunctionComponent<EntityChildrenDetail
     error,
   } = useGetEntityChildrenInfinite({
     parentId: parentContainerId,
-    includeTypes: includeTypes,
+    includeTypes: sharedProps.visibleTypes,
     sortBy: sortBy,
     sortDirection: sortDirection,
   })
@@ -56,12 +51,7 @@ export const EntityChildrenDetails: React.FunctionComponent<EntityChildrenDetail
         setSortBy(newSortBy)
         setSortDirection(newSortDirection)
       }}
-      showVersionSelection={showVersionSelection}
-      selectColumnType={selectColumnType}
-      selected={selected}
-      visibleTypes={includeTypes}
-      selectableTypes={selectableTypes}
-      toggleSelection={toggleSelection}
+      {...sharedProps}
     />
   )
 }

--- a/src/lib/containers/entity_finder/details/configurations/FavoritesDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/FavoritesDetails.tsx
@@ -8,12 +8,7 @@ import { DetailsView } from '../view/DetailsView'
 type FavoritesDetailsProps = EntityDetailsListSharedProps
 
 export const FavoritesDetails: React.FunctionComponent<FavoritesDetailsProps> = ({
-  showVersionSelection,
-  selectColumnType,
-  selected,
-  visibleTypes: includeTypes,
-  selectableTypes,
-  toggleSelection,
+  ...sharedProps
 }) => {
   const { data, status, isFetching, isError, error } = useGetFavorites()
   const handleError = useErrorHandler()
@@ -30,12 +25,7 @@ export const FavoritesDetails: React.FunctionComponent<FavoritesDetailsProps> = 
       queryStatus={status}
       queryIsFetching={isFetching}
       hasNextPage={false}
-      showVersionSelection={showVersionSelection}
-      selectColumnType={selectColumnType}
-      selected={selected}
-      visibleTypes={includeTypes}
-      selectableTypes={selectableTypes}
-      toggleSelection={toggleSelection}
+      {...sharedProps}
     />
   )
 }

--- a/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
@@ -12,12 +12,7 @@ type ProjectListDetailsProps = EntityDetailsListSharedProps & {
 
 export const ProjectListDetails: React.FunctionComponent<ProjectListDetailsProps> = ({
   projectsParams,
-  showVersionSelection,
-  selectColumnType,
-  selected,
-  visibleTypes: includeTypes,
-  selectableTypes,
-  toggleSelection,
+  ...sharedProps
 }) => {
   const {
     data,
@@ -43,12 +38,7 @@ export const ProjectListDetails: React.FunctionComponent<ProjectListDetailsProps
       queryIsFetching={isFetching}
       hasNextPage={hasNextPage}
       fetchNextPage={fetchNextPage}
-      showVersionSelection={showVersionSelection}
-      selectColumnType={selectColumnType}
-      selected={selected}
-      visibleTypes={includeTypes}
-      selectableTypes={selectableTypes}
-      toggleSelection={toggleSelection}
+      {...sharedProps}
     />
   )
 }

--- a/src/lib/containers/entity_finder/details/configurations/SearchDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/SearchDetails.tsx
@@ -12,12 +12,7 @@ type SearchDetailsProps = EntityDetailsListSharedProps & {
 
 export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
   searchQuery,
-  showVersionSelection,
-  selectColumnType,
-  selected,
-  visibleTypes: includeTypes,
-  selectableTypes,
-  toggleSelection,
+  ...sharedProps
 }) => {
   const {
     data,
@@ -46,12 +41,6 @@ export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
         queryIsFetching={isFetching}
         hasNextPage={hasNextPage}
         fetchNextPage={fetchNextPage}
-        showVersionSelection={showVersionSelection}
-        selectColumnType={selectColumnType}
-        selected={selected}
-        visibleTypes={includeTypes}
-        selectableTypes={selectableTypes}
-        toggleSelection={toggleSelection}
         noResultsPlaceholder={
           <>
             <img
@@ -64,6 +53,7 @@ export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
             </p>
           </>
         }
+        {...sharedProps}
       />
     )
   } else {
@@ -73,12 +63,6 @@ export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
         queryStatus={'success'}
         queryIsFetching={false}
         hasNextPage={false}
-        showVersionSelection={showVersionSelection}
-        selectColumnType={selectColumnType}
-        selected={selected}
-        visibleTypes={includeTypes}
-        selectableTypes={selectableTypes}
-        toggleSelection={toggleSelection}
         noResultsPlaceholder={
           <>
             <img
@@ -89,6 +73,7 @@ export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
             <p>Enter a term or Synapse ID to start searching</p>
           </>
         }
+        {...sharedProps}
       />
     )
   }

--- a/src/lib/containers/entity_finder/details/view/DetailsView.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsView.tsx
@@ -48,6 +48,7 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
   hasNextPage,
   fetchNextPage,
   showVersionSelection,
+  mustSelectVersionNumber,
   selectColumnType,
   selected,
   visibleTypes,
@@ -181,6 +182,7 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
                       ?.targetVersionNumber
                   }
                   showVersionColumn={showVersionSelection}
+                  mustSelectVersionNumber={mustSelectVersionNumber}
                   selectButtonType={selectColumnType}
                   toggleSelection={toggleSelection}
                 />

--- a/src/lib/containers/entity_finder/details/view/DetailsViewRow.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsViewRow.tsx
@@ -81,7 +81,7 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
   // We can't use IntersectionObserver via ref on a div within a <select> input
   // It might make more sense to use react-select here
   const { data: versionData } = useGetVersionsInfinite(entityHeader.id, {
-    enabled: inView && isVersionableEntity,
+    enabled: inView && isVersionableEntity && showVersionColumn,
     staleTime: 60 * 1000, // 60 seconds
   })
 

--- a/src/lib/containers/entity_finder/details/view/DetailsViewRow.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsViewRow.tsx
@@ -1,27 +1,26 @@
+import { isEmpty } from 'lodash-es'
 import moment from 'moment'
-import React, { useEffect, useState } from 'react'
+import React, { SyntheticEvent, useEffect, useState } from 'react'
 import { Form } from 'react-bootstrap'
 import { useErrorHandler } from 'react-error-boundary'
 import { useInView } from 'react-intersection-observer'
-import { SynapseClient } from '../../../../utils'
+import { toError } from '../../../../utils/ErrorUtils'
 import { formatDate } from '../../../../utils/functions/DateFormatter'
 import {
   getEntityTypeFromHeader,
   isVersionableEntityType,
 } from '../../../../utils/functions/EntityTypeUtils'
+import { useGetVersionsInfinite } from '../../../../utils/hooks/SynapseAPI/useEntity'
 import useGetEntityBundle from '../../../../utils/hooks/SynapseAPI/useEntityBundle'
 import { SMALL_USER_CARD } from '../../../../utils/SynapseConstants'
-import { useSynapseContext } from '../../../../utils/SynapseContext'
 import {
   EntityHeader,
   ProjectHeader,
   Reference,
 } from '../../../../utils/synapseTypes'
 import { Hit } from '../../../../utils/synapseTypes/Search'
-import { VersionInfo } from '../../../../utils/synapseTypes/VersionInfo'
 import { EntityBadgeIcons } from '../../../EntityBadgeIcons'
 import { EntityTypeIcon } from '../../../EntityIcon'
-import { toError } from '../../../../utils/ErrorUtils'
 import UserCard from '../../../UserCard'
 import { Checkbox } from '../../../widgets/Checkbox'
 
@@ -35,6 +34,7 @@ export type DetailsViewRowProps = {
   entityHeader: EntityHeader | ProjectHeader | Hit
   appearance: DetailsViewRowAppearance
   showVersionColumn: boolean
+  mustSelectVersionNumber: boolean
   selectButtonType: 'checkbox' | 'none'
   selectedVersion?: number
   toggleSelection: (entity: Reference) => void
@@ -44,28 +44,26 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
   entityHeader,
   appearance,
   showVersionColumn,
+  mustSelectVersionNumber,
   selectButtonType,
   selectedVersion,
   toggleSelection,
 }) => {
-  const { accessToken } = useSynapseContext()
   const isSelected = appearance === 'selected'
   const isDisabled = appearance === 'disabled'
   const isHidden = appearance === 'hidden'
 
-  const [versions, setVersions] = useState<VersionInfo[]>()
-  const [currentSelectedVersion, setCurrentSelectedVersion] = useState<number>(
-    selectedVersion ?? -1,
-  )
+  const entityType = getEntityTypeFromHeader(entityHeader)
+  const isVersionableEntity = isVersionableEntityType(entityType)
+
+  const [currentSelectedVersion, setCurrentSelectedVersion] = useState<
+    number | undefined
+  >(selectedVersion)
 
   const handleError = useErrorHandler()
 
   // We won't load the entity bundle unless the row is visible
   const { ref, inView } = useInView()
-
-  const isVersionableEntity = isVersionableEntityType(
-    getEntityTypeFromHeader(entityHeader),
-  )
 
   const { data: bundle, isError, error } = useGetEntityBundle(
     entityHeader.id,
@@ -79,24 +77,35 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
     },
   )
 
+  // TODO: Handle pagination, preferably with an IntersectionObserver
+  // We can't use IntersectionObserver via ref on a div within a <select> input
+  // It might make more sense to use react-select here
+  const { data: versionData } = useGetVersionsInfinite(entityHeader.id, {
+    enabled: inView && isVersionableEntity,
+    staleTime: 60 * 1000, // 60 seconds
+  })
+
+  const versions = versionData?.pages.flatMap(page => page.results) ?? []
+
+  /**
+   * For versionable entities, this effect ensures that a version number is auto-selected
+   * if mustSelectVersionNumber is true.
+   */
+  useEffect(() => {
+    if (
+      mustSelectVersionNumber &&
+      !isEmpty(versions) &&
+      currentSelectedVersion == null
+    ) {
+      setCurrentSelectedVersion(versions[0].versionNumber)
+    }
+  }, [currentSelectedVersion, mustSelectVersionNumber, versionData, versions])
+
   useEffect(() => {
     if (isError && error) {
       handleError(toError(error))
     }
   }, [isError, error, handleError])
-
-  useEffect(() => {
-    if (isSelected && versions === undefined) {
-      SynapseClient.getEntityVersions(entityHeader.id, accessToken).then(
-        response => {
-          setVersions(response.results)
-        },
-        err => {
-          handleError(err)
-        },
-      )
-    }
-  }, [isSelected, versions, accessToken, entityHeader.id, handleError])
 
   return (
     <tr
@@ -136,12 +145,7 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
 
       <td className="EntityIconColumn">
         <div>
-          {
-            <EntityTypeIcon
-              type={getEntityTypeFromHeader(entityHeader)}
-              style={{ margin: '5px auto' }}
-            />
-          }
+          {<EntityTypeIcon type={entityType} style={{ margin: '5px auto' }} />}
         </div>
       </td>
 
@@ -163,41 +167,40 @@ export const DetailsViewRow: React.FunctionComponent<DetailsViewRowProps> = ({
       {showVersionColumn && (
         <td className="VersionColumn" aria-label="version">
           <div>
-            {isSelected &&
-              isVersionableEntity &&
-              versions &&
-              versions.length > 0 && (
-                <Form.Control
-                  role="listbox"
-                  size="sm"
-                  as="select"
-                  value={currentSelectedVersion}
-                  onClick={(event: any) => {
-                    event.stopPropagation()
-                  }}
-                  onChange={event => {
-                    event.stopPropagation()
-                    const version = parseInt(event.target.value)
-                    setCurrentSelectedVersion(version)
-                    toggleSelection({
-                      targetId: entityHeader.id,
-                      targetVersionNumber: version === -1 ? undefined : version,
-                    })
-                  }}
-                >
+            {isSelected && versions && versions.length > 0 && (
+              <Form.Control
+                role="listbox"
+                size="sm"
+                as="select"
+                value={currentSelectedVersion}
+                onClick={(event: SyntheticEvent<HTMLSelectElement>) => {
+                  event.stopPropagation()
+                }}
+                onChange={event => {
+                  event.stopPropagation()
+                  const version = parseInt(event.target.value)
+                  setCurrentSelectedVersion(version)
+                  toggleSelection({
+                    targetId: entityHeader.id,
+                    targetVersionNumber: version === -1 ? undefined : version,
+                  })
+                }}
+              >
+                {!mustSelectVersionNumber && (
                   <option value={-1}>Always Latest Version</option>
-                  {versions?.map(version => {
-                    return (
-                      <option
-                        key={version.versionNumber}
-                        value={version.versionNumber}
-                      >
-                        Version {version.versionNumber}
-                      </option>
-                    )
-                  })}
-                </Form.Control>
-              )}
+                )}
+                {versions.map(version => {
+                  return (
+                    <option
+                      key={version.versionNumber}
+                      value={version.versionNumber}
+                    >
+                      Version {version.versionNumber}
+                    </option>
+                  )
+                })}
+              </Form.Control>
+            )}
           </div>
         </td>
       )}

--- a/src/lib/containers/entity_finder/tree/TreeNode.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeNode.tsx
@@ -160,17 +160,13 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
           <span>{nodeName}</span>
         </div>
         {appearance === NodeAppearance.SELECT && (
-          <div>
-            {nodeInView && (
-              <EntityBadgeIcons
-                entityId={nodeId}
-                showHasDiscussionThread={false}
-                showHasWiki={false}
-                showUnlink={false}
-                canOpenModal={false}
-              />
-            )}
-          </div>
+          <EntityBadgeIcons
+            entityId={nodeId}
+            showHasDiscussionThread={false}
+            showHasWiki={false}
+            showUnlink={false}
+            canOpenModal={false}
+          />
         )}
       </div>
       <div className={'NodeChildren'} aria-hidden={!isExpanded}>

--- a/src/lib/style/components/entity_finder/_details-view.scss
+++ b/src/lib/style/components/entity_finder/_details-view.scss
@@ -67,7 +67,8 @@
     color: $-selected-color;
     background-color: $-selected-background-color;
     .UserCardSmall {
-      color: $-selected-color;
+      color: $-selected-color !important;
+      border-color: $-selected-color !important;
     }
   }
 

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -1069,11 +1069,11 @@ export const removeUserFavorite = (
  * Get a list of challenges for which the given user is registered.
  * see http://rest-docs.synapse.org/rest/GET/challenge.html
  */
- export const getUserChallenges = (
+export const getUserChallenges = (
   accessToken: string | undefined,
   userId: string | number,
   offset: string | number = 0,
-  limit: string | number = 200
+  limit: string | number = 200,
 ): Promise<ChallengePagedResults> => {
   const url = `/repo/v1/challenge?participantId=${userId}&offset=${offset}&limit=${limit}`
   return doGet(
@@ -1093,8 +1093,8 @@ export const getUserTeamList = (
   accessToken: string | undefined,
   userId: string | number,
   offset: string | number = 0,
-  limit: string | number = 200
-):Promise<PaginatedResults<Team>> => {
+  limit: string | number = 200,
+): Promise<PaginatedResults<Team>> => {
   const url = `/repo/v1/user/${userId}/team?offset=${offset}&limit=${limit}`
   return doGet(
     url,
@@ -2699,7 +2699,6 @@ export const getMyProjects = (
   )
 }
 
-
 // http://rest-docs.synapse.org/rest/GET/projects/user/principalId.html
 export const getUserProjects = (
   userId: string,
@@ -2728,10 +2727,14 @@ export const getEntityPath = (entityId: string, accessToken?: string) => {
 }
 
 // https://rest-docs.synapse.org/rest/GET/entity/id/version.html
-// TODO: Pagination
-export const getEntityVersions = (entityId: string, accessToken?: string) => {
+export const getEntityVersions = (
+  entityId: string,
+  accessToken?: string,
+  offset: number = 0,
+  limit: number = 200,
+) => {
   return doGet<PaginatedResults<VersionInfo>>(
-    `/repo/v1/entity/${entityId}/version?offset=0&limit=200`,
+    `/repo/v1/entity/${entityId}/version?offset=${offset}&limit=${limit}`,
     accessToken,
     undefined,
     BackendDestinationEnum.REPO_ENDPOINT,

--- a/src/lib/utils/functions/EntityTypeUtils.ts
+++ b/src/lib/utils/functions/EntityTypeUtils.ts
@@ -93,6 +93,11 @@ export function convertToEntityType(
   }
 }
 
+/**
+ * https://docs.synapse.org/rest/org/sagebionetworks/repo/model/VersionableEntity.html
+ * @param type
+ * @returns
+ */
 export function isVersionableEntityType(type: EntityType): boolean {
   switch (type) {
     case EntityType.PROJECT:

--- a/src/lib/utils/synapseTypes/Entity.ts
+++ b/src/lib/utils/synapseTypes/Entity.ts
@@ -36,6 +36,21 @@ export interface Entity {
   uri?: string
 }
 
+export interface Versionable {
+  /* The version number issued to this version on the object */
+  versionNumber?: number
+}
+
+export interface VersionableEntity extends Entity, Versionable {
+  /* The version label for this entity */
+  versionLabel?: string
+  /* The version comment for this entity */
+  versionComment?: string
+  /* If this is the latest version of the object */
+  isLatestVersion?: boolean
+}
+
+
 // Possible value types in an entity JSON object.
 export type EntityJsonValue =
   | string

--- a/src/lib/utils/synapseTypes/FileEntity.ts
+++ b/src/lib/utils/synapseTypes/FileEntity.ts
@@ -1,14 +1,9 @@
-import { Entity } from './Entity'
+import { Entity, VersionableEntity } from './Entity'
 import { AssertionError } from 'assert'
 
 // https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/FileEntity.html
-export interface FileEntity extends Entity {
+export interface FileEntity extends VersionableEntity {
   concreteType: 'org.sagebionetworks.repo.model.FileEntity'
-  versionNumber?: number // 	The version number issued to this version on the object.
-  versionLabel?: string // 	The version label for this entity
-  versionComment?: string // 	The version comment for this entity
-  versionUrl?: string // 	The full URL of this exect version. This URL is provided by Synapse.
-  versions?: string // 	The URL to get all versions of this entity. This URL is provided by Synapse.
   dataFileHandleId: string // 	ID of the file associated with this entity.
   fileNameOverride?: string // 	An optional replacement for the name of the uploaded file. This is distinct from the entity name. If omitted the file will retain its original name.
 }

--- a/src/lib/utils/synapseTypes/VersionInfo.ts
+++ b/src/lib/utils/synapseTypes/VersionInfo.ts
@@ -1,12 +1,13 @@
 // https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/VersionInfo.html
 export type VersionInfo = {
-    id: string
-    versionNumber: number
-    versionLabel: string
-    versionComment: string
-    modifiedBy: string
-    contentSize: string
-    contentMd5: string
-    modifiedByPrincipalId: string
-    modifiedOn: string
+  id: string
+  versionNumber: number
+  versionLabel: string
+  versionComment: string
+  modifiedBy: string
+  contentSize: string
+  contentMd5: string
+  modifiedByPrincipalId: string
+  modifiedOn: string
+  isLatestVersion: boolean
 }


### PR DESCRIPTION
Directly addresses [SWC-5776](https://sagebionetworks.jira.com/browse/SWC-5776), which is a subtask of [SWC-5769](https://sagebionetworks.jira.com/browse/SWC-5769)
- Type updates
  - Add Versionable, VersionableEntity, update Entity and FileEntity to utilize hierarchy
  - Add field isLatestVersion to VersionInfo
- [SWC-5776](https://sagebionetworks.jira.com/browse/SWC-5776): Add `mustSelectVersionNumber` prop to Entity Finder, which forces the user to select a version number for versionable entities
- Fix user card text color when selected in entity finder
- EntityBadgeIcons: Use IntersectionObserver to check if the component is in view before fetching any data.

Below is a video demonstrating `mustSelectVersionNumber`. Note how 'Always Latest Version' is not an option.

https://user-images.githubusercontent.com/17580037/133303437-c9e5c1d4-fa20-4691-bf3f-8fb4d53cf8dc.mov

