### PR TITLE
PORTALS-2002

### DIFF
--- a/src/__tests__/lib/containers/GenericCard.test.tsx
+++ b/src/__tests__/lib/containers/GenericCard.test.tsx
@@ -363,7 +363,7 @@ describe('it renders the UI correctly', () => {
 })
 
 describe('it makes the correct URL for the secondary labels', () => {
-  const renderLabel = GenericCardPackage.renderLabel
+  const renderLabel = GenericCardPackage.SynapseCardLabel
   const DATASETS = 'datasets'
   const datasetBaseURL = 'Explore/Datasets'
   const labelLinkConfig: LabelLinkConfig = [

--- a/src/__tests__/lib/containers/SynapseTable.test.tsx
+++ b/src/__tests__/lib/containers/SynapseTable.test.tsx
@@ -20,7 +20,7 @@ import { SynapseConstants } from '../../../lib'
 import { QueryWrapperChildProps } from '../../../lib/containers/QueryWrapper'
 import { getColumnIndiciesWithType } from '../../../lib/containers/synapse_table_functions/getColumnIndiciesWithType'
 import { getUniqueEntities } from '../../../lib/containers/synapse_table_functions/getUniqueEntities'
-import { renderTableCell } from '../../../lib/containers/synapse_table_functions/renderTableCell'
+import { SynapseTableCell } from '../../../lib/containers/synapse_table_functions/SynapseTableCell'
 
 import SynapseTable, {
   SORT_STATE,
@@ -639,7 +639,7 @@ describe('basic functionality', () => {
       it('renders an entity link', () => {
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               colIndex: ENTITYID_INDEX,
               columnValue: mockEntityLinkValue,
@@ -652,7 +652,7 @@ describe('basic functionality', () => {
       it('renders a link for all authenticated users', () => {
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               colIndex: USERID_INDEX,
               columnValue: mockAllAuthenticatedUsersValue,
@@ -670,7 +670,7 @@ describe('basic functionality', () => {
       it('renders a link for a team', () => {
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               mapUserIdToHeader,
               colIndex: USERID_INDEX,
@@ -686,7 +686,7 @@ describe('basic functionality', () => {
       it('renders a user card link', () => {
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               mapUserIdToHeader,
               colIndex: USERID_INDEX,
@@ -700,7 +700,7 @@ describe('basic functionality', () => {
         const mockMarkdownColumnValue = '# column markdown'
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               colIndex: USERID_INDEX,
               columnValue: mockMarkdownColumnValue,
@@ -723,7 +723,7 @@ describe('basic functionality', () => {
       it('renders a standard value', () => {
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               colIndex: USERID_INDEX,
               columnValue: mockColumnValue,
@@ -737,7 +737,7 @@ describe('basic functionality', () => {
       it('renders a date value', () => {
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               colIndex: DATE_INDEX,
               columnValue: mockDateValue,
@@ -753,7 +753,7 @@ describe('basic functionality', () => {
       it('renders a date list value', () => {
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               colIndex: DATE_LIST_INDEX,
               columnValue: MOCKED_DATE_LIST,
@@ -769,7 +769,7 @@ describe('basic functionality', () => {
       it('renders a integer list value', () => {
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               colIndex: INTEGER_LIST_INDEX,
               columnValue: MOCKED_INTEGER_LIST,
@@ -784,7 +784,7 @@ describe('basic functionality', () => {
       it('renders a boolean list value', () => {
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               colIndex: BOOLEAN_LIST_INDEX,
               columnValue: MOCKED_BOOLEAN_LIST,
@@ -799,7 +799,7 @@ describe('basic functionality', () => {
       it('renders an empty cell for null date', () => {
         const tableCell = shallow(
           <div>
-            {renderTableCell({
+            {SynapseTableCell({
               ...tableCellProps,
               colIndex: DATE_INDEX,
               isMarkdownColumn: false,

--- a/src/__tests__/lib/containers/SynapseTable.test.tsx
+++ b/src/__tests__/lib/containers/SynapseTable.test.tsx
@@ -1,38 +1,37 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { shallow, mount } from 'enzyme'
-import { EntityLink } from '../../../lib/containers/EntityLink'
-import MarkdownSynapse from '../../../lib/containers/MarkdownSynapse'
-import { EnumFacetFilter } from '../../../lib/containers/widgets/query-filter/EnumFacetFilter'
-import UserCard from '../../../lib/containers/UserCard'
-import { unCamelCase } from '../../../lib/utils/functions/unCamelCase'
-import { AUTHENTICATED_USERS } from '../../../lib/utils/SynapseConstants'
-import {
-  EntityHeader,
-  UserGroupHeader,
-  UserProfile,
-  QueryResultBundle,
-  Row,
-  QueryBundleRequest,
-  EntityColumnType,
-} from '../../../lib/utils/synapseTypes/'
+import { mount, shallow } from 'enzyme'
+import { cloneDeep } from 'lodash-es'
 import * as React from 'react'
 import { SynapseConstants } from '../../../lib'
+import { EntityLink } from '../../../lib/containers/EntityLink'
+import HasAccess from '../../../lib/containers/HasAccess'
+import MarkdownSynapse from '../../../lib/containers/MarkdownSynapse'
 import { QueryWrapperChildProps } from '../../../lib/containers/QueryWrapper'
 import { getColumnIndiciesWithType } from '../../../lib/containers/synapse_table_functions/getColumnIndiciesWithType'
 import { getUniqueEntities } from '../../../lib/containers/synapse_table_functions/getUniqueEntities'
 import { SynapseTableCell } from '../../../lib/containers/synapse_table_functions/SynapseTableCell'
-
 import SynapseTable, {
+  Dictionary,
   SORT_STATE,
   SynapseTableProps,
-  Dictionary,
 } from '../../../lib/containers/table/SynapseTable'
-import syn16787123Json from '../../../mocks/query/syn16787123.json'
-import { cloneDeep } from 'lodash-es'
-import HasAccess from '../../../lib/containers/HasAccess'
 import { NOT_SET_DISPLAY_VALUE } from '../../../lib/containers/table/SynapseTableConstants'
+import UserCard from '../../../lib/containers/UserCard'
+import { EnumFacetFilter } from '../../../lib/containers/widgets/query-filter/EnumFacetFilter'
+import { unCamelCase } from '../../../lib/utils/functions/unCamelCase'
+import { AUTHENTICATED_USERS } from '../../../lib/utils/SynapseConstants'
 import { SynapseContextProvider } from '../../../lib/utils/SynapseContext'
+import {
+  EntityColumnType,
+  EntityHeader,
+  QueryBundleRequest,
+  QueryResultBundle,
+  Row,
+  UserGroupHeader,
+  UserProfile,
+} from '../../../lib/utils/synapseTypes/'
 import { MOCK_CONTEXT_VALUE } from '../../../mocks/MockSynapseContext'
+import syn16787123Json from '../../../mocks/query/syn16787123.json'
 
 const createShallowComponent = (
   props: SynapseTableProps & QueryWrapperChildProps,
@@ -638,27 +637,23 @@ describe('basic functionality', () => {
 
       it('renders an entity link', () => {
         const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              colIndex: ENTITYID_INDEX,
-              columnValue: mockEntityLinkValue,
-              mapEntityIdToHeader,
-            })}
-          </div>,
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={ENTITYID_INDEX}
+            columnValue={mockEntityLinkValue}
+            mapEntityIdToHeader={mapEntityIdToHeader}
+          />,
         )
         expect(tableCell.find(EntityLink)).toHaveLength(1)
       })
       it('renders a link for all authenticated users', () => {
         const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              colIndex: USERID_INDEX,
-              columnValue: mockAllAuthenticatedUsersValue,
-              mapUserIdToHeader,
-            })}
-          </div>,
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={USERID_INDEX}
+            columnValue={mockAllAuthenticatedUsersValue}
+            mapUserIdToHeader={mapUserIdToHeader}
+          />,
         )
         expect(tableCell.find('span').text().trim()).toEqual(
           '<FontAwesomeIcon /> All registered Synapse users',
@@ -669,14 +664,12 @@ describe('basic functionality', () => {
       })
       it('renders a link for a team', () => {
         const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              mapUserIdToHeader,
-              colIndex: USERID_INDEX,
-              columnValue: mockTeamValue,
-            })}
-          </div>,
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={USERID_INDEX}
+            columnValue={mockTeamValue}
+            mapUserIdToHeader={mapUserIdToHeader}
+          />,
         )
         expect(tableCell.find('a').text().trim()).toEqual(
           `<FontAwesomeIcon /> ${teamName}`,
@@ -685,36 +678,32 @@ describe('basic functionality', () => {
       })
       it('renders a user card link', () => {
         const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              mapUserIdToHeader,
-              colIndex: USERID_INDEX,
-              columnValue: mockUserCardValue,
-            })}
-          </div>,
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={USERID_INDEX}
+            columnValue={mockUserCardValue}
+            mapUserIdToHeader={mapUserIdToHeader}
+          />,
         )
         expect(tableCell.find(UserCard)).toHaveLength(1)
       })
       it('renders a markdown value', () => {
         const mockMarkdownColumnValue = '# column markdown'
-        const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              colIndex: USERID_INDEX,
-              columnValue: mockMarkdownColumnValue,
-              mapUserIdToHeader,
-              columnLinkConfig: {
-                isMarkdown: true,
-                matchColumnName: 'a',
-              },
-              columnName: 'a',
-              selectColumns: [
-                { columnType: EntityColumnType.STRING, name: 'a', id: '' },
-              ],
-            })}
-          </div>,
+        const tableCell = mount(
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={USERID_INDEX}
+            columnValue={mockMarkdownColumnValue}
+            mapUserIdToHeader={mapUserIdToHeader}
+            columnLinkConfig={{
+              isMarkdown: true,
+              matchColumnName: 'a',
+            }}
+            columnName={'a'}
+            selectColumns={[
+              { columnType: EntityColumnType.STRING, name: 'a', id: '' },
+            ]}
+          />,
         )
         expect(tableCell.find(MarkdownSynapse).props().markdown).toEqual(
           mockMarkdownColumnValue,
@@ -722,28 +711,24 @@ describe('basic functionality', () => {
       })
       it('renders a standard value', () => {
         const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              colIndex: USERID_INDEX,
-              columnValue: mockColumnValue,
-              mapUserIdToHeader,
-            })}
-          </div>,
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={USERID_INDEX}
+            columnValue={mockColumnValue}
+            mapUserIdToHeader={mapUserIdToHeader}
+          />,
         )
         expect(tableCell.find('p').text().trim()).toEqual(mockColumnValue)
       })
 
       it('renders a date value', () => {
         const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              colIndex: DATE_INDEX,
-              columnValue: mockDateValue,
-              mapUserIdToHeader,
-            })}
-          </div>,
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={DATE_INDEX}
+            columnValue={mockDateValue}
+            mapUserIdToHeader={mapUserIdToHeader}
+          />,
         )
         expect(tableCell.find('p').text().trim()).toEqual(
           new Date(Number(mockDateValue)).toLocaleString(),
@@ -752,14 +737,12 @@ describe('basic functionality', () => {
 
       it('renders a date list value', () => {
         const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              colIndex: DATE_LIST_INDEX,
-              columnValue: MOCKED_DATE_LIST,
-              mapUserIdToHeader,
-            })}
-          </div>,
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={DATE_LIST_INDEX}
+            columnValue={MOCKED_DATE_LIST}
+            mapUserIdToHeader={mapUserIdToHeader}
+          />,
         )
         expect(tableCell.find('span').text().trim()).toEqual(
           new Date(Number(MOCK_DATE_VALUE)).toLocaleString(),
@@ -768,14 +751,12 @@ describe('basic functionality', () => {
 
       it('renders a integer list value', () => {
         const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              colIndex: INTEGER_LIST_INDEX,
-              columnValue: MOCKED_INTEGER_LIST,
-              mapUserIdToHeader,
-            })}
-          </div>,
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={INTEGER_LIST_INDEX}
+            columnValue={MOCKED_INTEGER_LIST}
+            mapUserIdToHeader={mapUserIdToHeader}
+          />,
         )
         expect(tableCell.find('span').first().text().trim()).toEqual('10,')
         expect(tableCell.find('span').last().text().trim()).toEqual('11')
@@ -783,14 +764,12 @@ describe('basic functionality', () => {
 
       it('renders a boolean list value', () => {
         const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              colIndex: BOOLEAN_LIST_INDEX,
-              columnValue: MOCKED_BOOLEAN_LIST,
-              mapUserIdToHeader,
-            })}
-          </div>,
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={BOOLEAN_LIST_INDEX}
+            columnValue={MOCKED_BOOLEAN_LIST}
+            mapUserIdToHeader={mapUserIdToHeader}
+          />,
         )
         expect(tableCell.find('span').first().text().trim()).toEqual('true,')
         expect(tableCell.find('span').last().text().trim()).toEqual('false')
@@ -798,13 +777,11 @@ describe('basic functionality', () => {
 
       it('renders an empty cell for null date', () => {
         const tableCell = shallow(
-          <div>
-            {SynapseTableCell({
-              ...tableCellProps,
-              colIndex: DATE_INDEX,
-              isMarkdownColumn: false,
-            })}
-          </div>,
+          <SynapseTableCell
+            {...tableCellProps}
+            colIndex={DATE_INDEX}
+            isMarkdownColumn={false}
+          />,
         )
         expect(tableCell.find('p').first().text().trim()).toEqual(
           NOT_SET_DISPLAY_VALUE,

--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -1,25 +1,26 @@
-import * as React from 'react'
+import React from 'react'
+import { Button } from 'react-bootstrap'
+import useGetInfoFromIds from '../utils/hooks/useGetInfoFromIds'
 import {
   DATASET,
+  DEFAULT_PAGE_SIZE,
   FUNDER,
   GENERIC_CARD,
   MEDIUM_USER_CARD,
-  DEFAULT_PAGE_SIZE,
 } from '../utils/SynapseConstants'
 import {
+  EntityHeader,
   QueryBundleRequest,
   QueryResultBundle,
-  EntityHeader,
+  Row,
 } from '../utils/synapseTypes/'
 import { CardConfiguration } from './CardContainerLogic'
 import GenericCard from './GenericCard'
+import loadingScreen from './LoadingScreen'
 import { Dataset, Funder } from './row_renderers'
+import SearchResultsNotFound from './table/SearchResultsNotFound'
 import TotalQueryResults from './TotalQueryResults'
 import UserCardList from './UserCardList'
-import useGetInfoFromIds from '../utils/hooks/useGetInfoFromIds'
-import loadingScreen from './LoadingScreen'
-import { Button } from 'react-bootstrap'
-import SearchResultsNotFound from './table/SearchResultsNotFound'
 
 export type CardContainerProps = {
   data?: QueryResultBundle
@@ -27,7 +28,7 @@ export type CardContainerProps = {
   isAlignToLeftNav?: boolean
   title?: string
   executeQueryRequest?: (param: QueryBundleRequest) => void
-  facetAliases?: {}
+  facetAliases?: Record<string, string>
   getLastQueryRequest?: () => QueryBundleRequest
   getNextPageOfData?: (queryRequest: QueryBundleRequest) => void
   isLoading?: boolean
@@ -96,14 +97,17 @@ export const CardContainer = (props: CardContainerProps) => {
       return <SearchResultsNotFound />
     }
     // else show "no results" UI (see PORTALS-1497)
-    return <>
-      <p className="SRC-no-results-title">
-        There is currently no content here.
-      </p>
-      <p className="SRC-no-results-description">
-        Information is always being updated, so check back later to see if content has been added.
-      </p>
-    </>
+    return (
+      <>
+        <p className="SRC-no-results-title">
+          There is currently no content here.
+        </p>
+        <p className="SRC-no-results-description">
+          Information is always being updated, so check back later to see if
+          content has been added.
+        </p>
+      </>
+    )
   }
   const schema = {}
   data.queryResult.queryResults.headers.forEach((element, index) => {
@@ -135,28 +139,32 @@ export const CardContainer = (props: CardContainerProps) => {
   } else {
     // render the cards
     const cardsData = data.queryResult.queryResults.rows
-    cards = cardsData.length ? cardsData.map((rowData: any, index) => {
-      const key = JSON.stringify(rowData.values)
-      const propsForCard = {
-        key,
-        type,
-        schema,
-        isHeader,
-        secondaryLabelLimit,
-        data: rowData.values,
-        selectColumns: data.selectColumns,
-        columnModels: data.columnModels,
-        tableEntityConcreteType:
-          tableEntityConcreteType[0] && tableEntityConcreteType[0].type,
-        tableId: props.data?.queryResult.queryResults.tableId,
-        ...rest,
-      }
-      return renderCard(propsForCard, type)
-    }) : <></>
+    cards = cardsData.length ? (
+      cardsData.map((rowData: Row) => {
+        const key = JSON.stringify(rowData.values)
+        const propsForCard = {
+          key,
+          type,
+          schema,
+          isHeader,
+          secondaryLabelLimit,
+          data: rowData.values,
+          selectColumns: data.selectColumns,
+          columnModels: data.columnModels,
+          tableEntityConcreteType:
+            tableEntityConcreteType[0] && tableEntityConcreteType[0].type,
+          tableId: props.data?.queryResult.queryResults.tableId,
+          ...rest,
+        }
+        return renderCard(propsForCard, type)
+      })
+    ) : (
+      <></>
+    )
   }
 
   return (
-    <div role='list'>
+    <div role="list">
       {title && <h2 className="SRC-card-overview-title">{title}</h2>}
       {!title && unitDescription && showBarChart && (
         <TotalQueryResults

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -68,7 +68,7 @@ export type DescriptionConfig = {
 }
 
 // Specify the indices in the values [] that should be rendered specially
-export type LabelLinkConfig = (MarkdownLink | CardLink)[]
+export type LabelLinkConfig = (MarkdownLink | CardLink | ColumnSpecifiedLink)[]
 
 export type ColumnIconConfigs = {
   columns: {

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -25,6 +25,18 @@ import { IconSvgOptions } from './IconSvg'
  * See here: https://github.com/enzymejs/enzyme/issues/1553
  */
 
+/**
+ *  Used when a column value should link to an external URL defined by a value in another column.
+ *  Currently only works in SynapseTable (not cards!)
+ */
+export interface ColumnSpecifiedLink {
+  isMarkdown: false
+  /* The column which should have the displayed value */
+  matchColumnName: string
+  /* The column which has the link. If the link is empty, the value will be displayed without a link. */
+  linkColumnName: string
+}
+
 export interface CardLink {
   baseURL: string
   // the key that will go into the url

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -1,32 +1,30 @@
+import { cloneDeep, isEqual } from 'lodash-es'
 import * as React from 'react'
 import { SynapseClient, SynapseConstants } from '../utils'
 import { getNextPageOfData } from '../utils/functions/queryUtils'
 import {
   insertConditionsFromSearchParams,
   KeyValue,
-  SQLOperator,
   parseEntityIdFromSqlStatement,
+  SQLOperator,
 } from '../utils/functions/sqlFunctions'
+import { DEFAULT_PAGE_SIZE } from '../utils/SynapseConstants'
 import { QueryBundleRequest, QueryResultBundle } from '../utils/synapseTypes/'
 import CardContainer from './CardContainer'
 import { GenericCardSchema, IconOptions } from './GenericCard'
+import { IconSvgOptions } from './IconSvg'
 
 /**
  * TODO: SWC-5612 - Replace token prop with SynapseContext.accessToken
- * 
+ *
  * This wasn't done because Enzyme's shallow renderer is not currently
  * compatible with the `contextType` field in the React 16+ context API.
- * 
+ *
  * This can be fixed by rewriting tests to not rely on the shallow renderer.
- * 
+ *
  * See here: https://github.com/enzymejs/enzyme/issues/1553
  */
 
-// TODO: this import nearly doubles the package size of SRC as a UMD build by ~400KB
-// will have to find a way to use individual lodash packages instead of the entire thing
-import { cloneDeep, isEqual } from 'lodash-es'
-import { IconSvgOptions } from './IconSvg'
-import { DEFAULT_PAGE_SIZE } from '../utils/SynapseConstants'
 export interface CardLink {
   baseURL: string
   // the key that will go into the url
@@ -62,8 +60,8 @@ export type LabelLinkConfig = (MarkdownLink | CardLink)[]
 
 export type ColumnIconConfigs = {
   columns: {
-    [index:string]: {
-      [index:string]: IconSvgOptions
+    [index: string]: {
+      [index: string]: IconSvgOptions
     }
   }
 }
@@ -92,7 +90,7 @@ export type CardContainerLogicProps = {
   sqlOperator?: SQLOperator
   searchParams?: KeyValue
   facet?: string
-  facetAliases?: {}  
+  facetAliases?: Record<string, string>
   rgbIndex?: number
   isHeader?: boolean
   isAlignToLeftNav?: boolean
@@ -248,9 +246,7 @@ export default class CardContainerLogic extends React.Component<
           SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
           SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
           SynapseConstants.BUNDLE_MASK_QUERY_RESULTS
-        const hasMoreData =
-          data.queryResult.queryResults.rows.length ===
-          limit
+        const hasMoreData = data.queryResult.queryResults.rows.length === limit
         const newState = {
           hasMoreData,
           data,

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -29,6 +29,7 @@ import { SMALL_USER_CARD } from '../utils/SynapseConstants'
 import UserCard from './UserCard'
 import { SynapseContext } from '../utils/SynapseContext'
 import { PRODUCTION_ENDPOINT_CONFIG } from '../utils/functions/getEndpoint'
+import { isEmpty } from 'lodash-es'
 
 export type KeyToAlias = {
   key: string
@@ -264,6 +265,11 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
       return <>{value}</>
     } else {
       const href = row.values[linkIndex]
+
+      if (isEmpty(href)) {
+        return <>{value}</>
+      }
+
       return (
         <>
           {split.map((el, index) => {

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -270,7 +270,14 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
           {split.map((el, index) => {
             return (
               <React.Fragment key={el}>
-                <a href={href} key={el} className={newClassName} style={style}>
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  key={el}
+                  className={newClassName}
+                  style={style}
+                >
                   {el}
                 </a>
                 {index < split.length - 1 && (

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -137,7 +137,7 @@ export const getValueOrMultiValue = ({
   return { str: value, columnModelType: selectedColumnOrUndefined?.columnType }
 }
 
-export const renderLabel = (args: {
+type SynapseCardLabelProps = {
   value: string
   columnName: string
   labelLink: CardLink | MarkdownLink | undefined
@@ -145,7 +145,9 @@ export const renderLabel = (args: {
   columnModels: ColumnModel[] | undefined
   isHeader: boolean
   className?: string
-}) => {
+}
+
+export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
   const {
     value,
     columnName,
@@ -154,9 +156,9 @@ export const renderLabel = (args: {
     columnModels,
     isHeader,
     className,
-  } = args
+  } = props
   if (!value) {
-    return value
+    return <>{value}</>
   }
   const { strList, str, columnModelType } = getValueOrMultiValue({
     columnName,
@@ -167,7 +169,7 @@ export const renderLabel = (args: {
 
   if (!str) {
     // the array came back empty
-    return str
+    return <>{str}</>
   }
 
   let newClassName = className
@@ -177,18 +179,28 @@ export const renderLabel = (args: {
   }
   // PORTALS-1913: special rendering for user ID lists
   if (columnModelType === 'USERID_LIST' && strList) {
-    return strList.map((val: string, index: number) => {
-      return (
-        <span key={val}>
-          <UserCard ownerId={val} size={SMALL_USER_CARD} className={newClassName}/>
-          {/* \u00a0 is a nbsp; */}
-          {index < strList.length - 1 && ',\u00a0\u00a0'}
-        </span>
-      )
-    })
+    return (
+      <>
+        {strList.map((val: string, index: number) => {
+          return (
+            <span key={val}>
+              <UserCard
+                ownerId={val}
+                size={SMALL_USER_CARD}
+                className={newClassName}
+              />
+              {/* \u00a0 is a nbsp; */}
+              {index < strList.length - 1 && ',\u00a0\u00a0'}
+            </span>
+          )
+        })}
+      </>
+    )
   }
   if (columnModelType === 'USERID' && str) {
-    return <UserCard ownerId={str} size={SMALL_USER_CARD} className={newClassName}/>
+    return (
+      <UserCard ownerId={str} size={SMALL_USER_CARD} className={newClassName} />
+    )
   }
 
   if (!labelLink) {
@@ -207,39 +219,49 @@ export const renderLabel = (args: {
       )
     } else {
       // they don't need a link
-      return str
+      return <>{str}</>
     }
   }
 
   if (labelLink.isMarkdown) {
     if (strList) {
-      return strList.map((el, index) => {
-        return (
-          <span key={el}>
-            <MarkdownSynapse key={el} renderInline={true} markdown={el} />
-            {/* \u00a0 is a nbsp; */}
-            {index < strList.length - 1 && ',\u00a0\u00a0'}
-          </span>
-        )
-      })
+      return (
+        <>
+          {strList.map((el, index) => {
+            return (
+              <span key={el}>
+                <MarkdownSynapse key={el} renderInline={true} markdown={el} />
+                {/* \u00a0 is a nbsp; */}
+                {index < strList.length - 1 && ',\u00a0\u00a0'}
+              </span>
+            )
+          })}
+        </>
+      )
     } else {
       return <MarkdownSynapse renderInline={true} markdown={value} />
     }
   }
   const split = strList ? strList : str.split(',')
-  return split.map((el, index) => {
-    const { baseURL, URLColumnName, wrapValueWithParens } = labelLink
-    const value = wrapValueWithParens ? `(${el})` : el
-    const href = `/${baseURL}?${URLColumnName}=${value}`
-    return (
-      <React.Fragment key={el}>
-        <a href={href} key={el} className={newClassName} style={style}>
-          {el}
-        </a>
-        {index < split.length - 1 && <span style={{ marginRight: 4 }}>, </span>}
-      </React.Fragment>
-    )
-  })
+  return (
+    <>
+      {split.map((el, index) => {
+        const { baseURL, URLColumnName, wrapValueWithParens } = labelLink
+        const value = wrapValueWithParens ? `(${el})` : el
+        const href = `/${baseURL}?${URLColumnName}=${value}`
+        return (
+          <React.Fragment key={el}>
+            <a href={href} key={el} className={newClassName} style={style}>
+              {el}
+            </a>
+            {index < split.length - 1 && (
+              <span style={{ marginRight: 4 }}>, </span>
+            )}
+          </React.Fragment>
+        )
+      })}
+    </>
+  )
 }
 
 type ValueOrMultiValue = {
@@ -426,7 +448,7 @@ export default class GenericCard extends React.Component<
         const labelLink = labelLinkConfig?.find(
           el => el.matchColumnName === columnName,
         )
-        value = renderLabel({
+        value = SynapseCardLabel({
           value,
           columnName,
           labelLink,

--- a/src/lib/containers/HeaderCard.tsx
+++ b/src/lib/containers/HeaderCard.tsx
@@ -6,11 +6,11 @@ import React, { useState, useEffect } from 'react'
 export type IconOptions = {
   [index: string]: string
 }
-export type HeaderCardProps = {  
+export type HeaderCardProps = {
   rgbIndex?: number
   type: string
   title: string
-  subTitle: string
+  subTitle?: string
   description: string
   secondaryLabelLimit?: number
   values?: string[][]
@@ -24,7 +24,7 @@ export type HeaderCardProps = {
 const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
   type,
   title,
-  subTitle,
+  subTitle = '',
   description,
   values,
   secondaryLabelLimit,
@@ -63,7 +63,7 @@ const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
   })
 
   return (
-    <div      
+    <div
       className={`SRC-portalCard SRC-portalCardHeader ${
         isAlignToLeftNav ? 'isAlignToLeftNav' : ''
       }`}
@@ -73,10 +73,7 @@ const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
         <div className="SRC-cardContent">
           <div className="SRC-type">{type}</div>
           <div>
-            <h3
-              className="SRC-boldText"
-              style={{ margin: 'none' }}
-            >
+            <h3 className="SRC-boldText" style={{ margin: 'none' }}>
               {href ? (
                 <a target={target} href={href} className="highlight-link">
                   {title}
@@ -113,7 +110,7 @@ const HeaderCard: React.FunctionComponent<HeaderCardProps> = ({
           </div>
         </div>
       </div>
-    </div>    
+    </div>
   )
 }
 

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -69,7 +69,6 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
     searchConfiguration,
     limit = DEFAULT_PAGE_SIZE,
     downloadCartPageUrl,
-    ...rest
   } = props
   let sqlUsed = sql
   if (searchParams) {
@@ -100,7 +99,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
       <SynapseContextConsumer>
         {context => (
           <QueryWrapper
-            {...rest}
+            {...props}
             token={context?.accessToken}
             initQueryRequest={initQueryRequest}
           >
@@ -114,7 +113,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
               sql={sqlUsed}
               hideDownload={hideDownload}
             />
-            <QueryFilter {...rest} />
+            <QueryFilter {...props} />
             <QueryFilterToggleButton />
             <FacetNav facetsToPlot={facetsToPlot} showNotch={false} />
             <FilterAndView

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -33,7 +33,7 @@ type OwnProps = {
   facetsToPlot?: string[]
   facetsToFilter?: string[]
   visibleColumnCount?: number
-  facetAliases?: {}
+  facetAliases?: Record<string, string>
   hideDownload?: boolean
   defaultColumn?: string
   defaultShowFacetVisualization?: boolean
@@ -106,9 +106,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = p
           >
             <SearchV2 {...searchConfiguration} />
             <ErrorBanner />
-            <DownloadConfirmation
-              downloadCartPageUrl={downloadCartPageUrl}
-            />
+            <DownloadConfirmation downloadCartPageUrl={downloadCartPageUrl} />
             <TopLevelControls
               showColumnSelection={tableConfiguration !== undefined}
               name={name}

--- a/src/lib/containers/row_renderers/Dataset.tsx
+++ b/src/lib/containers/row_renderers/Dataset.tsx
@@ -7,7 +7,7 @@ import { SelectColumn, ColumnModel } from '../../utils/synapseTypes'
 import { Button } from 'react-bootstrap'
 import { PRODUCTION_ENDPOINT_CONFIG } from '../../utils/functions/getEndpoint'
 
-type DatasetProps = {
+export type DatasetProps = {
   data?: any
   schema?: any
   secondaryLabelLimit?: number
@@ -25,7 +25,10 @@ class Dataset extends React.Component<DatasetProps, {}> {
     event: React.MouseEvent<HTMLButtonElement>,
   ) => {
     event.preventDefault()
-    window.open(`${PRODUCTION_ENDPOINT_CONFIG.PORTAL}#!Synapse:${link}`, '_blank')
+    window.open(
+      `${PRODUCTION_ENDPOINT_CONFIG.PORTAL}#!Synapse:${link}`,
+      '_blank',
+    )
   }
 
   public render() {

--- a/src/lib/containers/row_renderers/Funder.tsx
+++ b/src/lib/containers/row_renderers/Funder.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Button } from 'react-bootstrap'
 
-type FunderProps = {
+export type FunderProps = {
   data?: any
   schema?: any
 }

--- a/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
+++ b/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
@@ -7,12 +7,17 @@ import UserCard from '../UserCard'
 import { ElementWithTooltip } from '../widgets/ElementWithTooltip'
 import { AUTHENTICATED_USERS } from '../../utils/SynapseConstants'
 import { noop } from 'lodash-es'
-import { MarkdownLink, CardLink } from '../CardContainerLogic'
+import {
+  MarkdownLink,
+  CardLink,
+  ColumnSpecifiedLink,
+} from '../CardContainerLogic'
 import { SynapseCardLabel } from '../GenericCard'
 import {
   SelectColumn,
   ColumnModel,
   FileHandleAssociateType,
+  Row,
 } from '../../utils/synapseTypes'
 import { NOT_SET_DISPLAY_VALUE } from '../table/SynapseTableConstants'
 import DirectDownload from '../DirectDownload'
@@ -33,12 +38,13 @@ type SynapseTableCellProps = {
   isBold: string
   mapEntityIdToHeader: Dictionary<EntityHeader>
   mapUserIdToHeader: Dictionary<any>
-  columnLinkConfig?: MarkdownLink | CardLink
+  columnLinkConfig?: MarkdownLink | CardLink | ColumnSpecifiedLink
   rowIndex?: number
   columnName: string
   selectColumns: SelectColumn[] | undefined
   columnModels: ColumnModel[] | undefined
   tableEntityId?: string
+  row: Row
 }
 
 // Render table cell, supports Entity's and User Icons
@@ -62,6 +68,7 @@ export const SynapseTableCell: React.FC<SynapseTableCellProps> = ({
   selectColumns,
   columnModels,
   tableEntityId,
+  row,
 }) => {
   const isShortString = (s: string, maxCharCount = 20): boolean => {
     return !s || s.length <= maxCharCount
@@ -80,6 +87,7 @@ export const SynapseTableCell: React.FC<SynapseTableCellProps> = ({
         columnModels={columnModels}
         isHeader={false}
         labelLink={columnLinkConfig}
+        row={row}
       />
     )
   }

--- a/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
+++ b/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
@@ -8,38 +8,18 @@ import { ElementWithTooltip } from '../widgets/ElementWithTooltip'
 import { AUTHENTICATED_USERS } from '../../utils/SynapseConstants'
 import { noop } from 'lodash-es'
 import { MarkdownLink, CardLink } from '../CardContainerLogic'
-import { renderLabel } from '../GenericCard'
+import { SynapseCardLabel } from '../GenericCard'
 import {
   SelectColumn,
-  ColumnModel, FileHandleAssociateType,
+  ColumnModel,
+  FileHandleAssociateType,
 } from '../../utils/synapseTypes'
 import { NOT_SET_DISPLAY_VALUE } from '../table/SynapseTableConstants'
 import DirectDownload from '../DirectDownload'
 import EntityIdList from '../EntityIdList'
 import { PRODUCTION_ENDPOINT_CONFIG } from '../../utils/functions/getEndpoint'
 
-// Render table cell, supports Entity's and User Icons
-export const renderTableCell = ({
-  entityColumnIndicies,
-  userColumnIndicies,
-  dateColumnIndicies,
-  dateListColumnIndicies,
-  booleanListColumnIndicies,
-  fileHandleIdColumnIndicies,
-  entityIdListColumnIndicies,
-  otherListColumnIndicies,
-  colIndex,
-  columnValue,
-  isBold,
-  mapEntityIdToHeader,
-  mapUserIdToHeader,
-  columnLinkConfig,
-  rowIndex,
-  columnName,
-  selectColumns,
-  columnModels,
-  tableEntityId,
-}: {
+type SynapseTableCellProps = {
   entityColumnIndicies: number[]
   userColumnIndicies: number[]
   dateColumnIndicies: number[]
@@ -59,25 +39,49 @@ export const renderTableCell = ({
   selectColumns: SelectColumn[] | undefined
   columnModels: ColumnModel[] | undefined
   tableEntityId?: string
-}): React.ReactNode => {
-  const isShortString = (
-    s: string,
-    maxCharCount = 20,
-  ): boolean => {
-    return (!s || s.length <= maxCharCount)
+}
+
+// Render table cell, supports Entity's and User Icons
+export const SynapseTableCell: React.FC<SynapseTableCellProps> = ({
+  entityColumnIndicies,
+  userColumnIndicies,
+  dateColumnIndicies,
+  dateListColumnIndicies,
+  booleanListColumnIndicies,
+  fileHandleIdColumnIndicies,
+  entityIdListColumnIndicies,
+  otherListColumnIndicies,
+  colIndex,
+  columnValue,
+  isBold,
+  mapEntityIdToHeader,
+  mapUserIdToHeader,
+  columnLinkConfig,
+  rowIndex,
+  columnName,
+  selectColumns,
+  columnModels,
+  tableEntityId,
+}) => {
+  const isShortString = (s: string, maxCharCount = 20): boolean => {
+    return !s || s.length <= maxCharCount
   }
   if (!columnValue) {
-    return <p className="SRC-center-text SRC-inactive"> {NOT_SET_DISPLAY_VALUE}</p>
+    return (
+      <p className="SRC-center-text SRC-inactive"> {NOT_SET_DISPLAY_VALUE}</p>
+    )
   }
   if (columnLinkConfig) {
-    return renderLabel({
-      value: columnValue,
-      columnName,
-      selectColumns,
-      columnModels,
-      isHeader: false,
-      labelLink: columnLinkConfig,
-    })
+    return (
+      <SynapseCardLabel
+        value={columnValue}
+        columnName={columnName}
+        selectColumns={selectColumns}
+        columnModels={columnModels}
+        isHeader={false}
+        labelLink={columnLinkConfig}
+      />
+    )
   }
   if (
     entityColumnIndicies.includes(colIndex) &&
@@ -92,59 +96,69 @@ export const renderTableCell = ({
   }
   if (dateListColumnIndicies.includes(colIndex)) {
     const jsonData: number[] = JSON.parse(columnValue)
-    return <p>{jsonData.map((val: number, index: number) => {
-      return (
-        <span key={index} className={isBold}>
-          {new Date(val).toLocaleString()}
-          {index !== jsonData.length - 1 ? ', ' : ''}
-        </span>
-      )
-    })} </p>
+    return (
+      <p>
+        {jsonData.map((val: number, index: number) => {
+          return (
+            <span key={index} className={isBold}>
+              {new Date(val).toLocaleString()}
+              {index !== jsonData.length - 1 ? ', ' : ''}
+            </span>
+          )
+        })}{' '}
+      </p>
+    )
   }
   if (booleanListColumnIndicies.includes(colIndex)) {
     const jsonData: boolean[] = JSON.parse(columnValue)
-    return <p>{jsonData.map((val: boolean, index: number) => {
-      return (
-        <span key={index} className={isBold}>
-          {val ? 'true' : 'false'}
-          {index !== jsonData.length - 1 ? ', ' : ''}
-        </span>
-      )
-    })}</p>
+    return (
+      <p>
+        {jsonData.map((val: boolean, index: number) => {
+          return (
+            <span key={index} className={isBold}>
+              {val ? 'true' : 'false'}
+              {index !== jsonData.length - 1 ? ', ' : ''}
+            </span>
+          )
+        })}
+      </p>
+    )
   }
 
   // If it's a file from a table view
-  if (fileHandleIdColumnIndicies.includes(colIndex)){
-    return <>
-      <DirectDownload
-        associatedObjectId={tableEntityId!}
-        associatedObjectType={FileHandleAssociateType.TableEntity}
-        fileHandleId={columnValue}
-        displayFileName={true}
-      />
-    </>
+  if (fileHandleIdColumnIndicies.includes(colIndex)) {
+    return (
+      <>
+        <DirectDownload
+          associatedObjectId={tableEntityId!}
+          associatedObjectType={FileHandleAssociateType.TableEntity}
+          fileHandleId={columnValue}
+          displayFileName={true}
+        />
+      </>
+    )
   }
 
   // If it's a list of entity ids
-  if (entityIdListColumnIndicies.includes(colIndex)){
+  if (entityIdListColumnIndicies.includes(colIndex)) {
     const jsonData: string[] = JSON.parse(columnValue)
-    return(
-      <EntityIdList
-        entityIdList={jsonData}
-      />
-    )
+    return <EntityIdList entityIdList={jsonData} />
   }
 
   if (otherListColumnIndicies.includes(colIndex)) {
     const jsonData: string[] = JSON.parse(columnValue)
-    return <p>{jsonData.map((val: string, index: number) => {
-      return (
-        <span key={val} className={isBold}>
-          {val}
-          {index !== jsonData.length - 1 ? ', ' : ''}
-        </span>
-      )
-    })}</p>
+    return (
+      <p>
+        {jsonData.map((val: string, index: number) => {
+          return (
+            <span key={val} className={isBold}>
+              {val}
+              {index !== jsonData.length - 1 ? ', ' : ''}
+            </span>
+          )
+        })}
+      </p>
+    )
   }
   if (dateColumnIndicies.includes(colIndex)) {
     return (

--- a/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
+++ b/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
@@ -44,7 +44,7 @@ type SynapseTableCellProps = {
   selectColumns: SelectColumn[] | undefined
   columnModels: ColumnModel[] | undefined
   tableEntityId?: string
-  row: Row
+  rowData: string[]
 }
 
 // Render table cell, supports Entity's and User Icons
@@ -68,7 +68,7 @@ export const SynapseTableCell: React.FC<SynapseTableCellProps> = ({
   selectColumns,
   columnModels,
   tableEntityId,
-  row,
+  rowData,
 }) => {
   const isShortString = (s: string, maxCharCount = 20): boolean => {
     return !s || s.length <= maxCharCount
@@ -87,7 +87,7 @@ export const SynapseTableCell: React.FC<SynapseTableCellProps> = ({
         columnModels={columnModels}
         isHeader={false}
         labelLink={columnLinkConfig}
-        rowData={row.values}
+        rowData={rowData}
       />
     )
   }

--- a/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
+++ b/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
@@ -87,7 +87,7 @@ export const SynapseTableCell: React.FC<SynapseTableCellProps> = ({
         columnModels={columnModels}
         isHeader={false}
         labelLink={columnLinkConfig}
-        row={row}
+        rowData={row.values}
       />
     )
   }

--- a/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
+++ b/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
@@ -1,28 +1,27 @@
-import * as React from 'react'
-import { Dictionary } from '../table/SynapseTable'
-import { EntityHeader } from '../../utils/synapseTypes/EntityHeader'
-import { EntityLink } from '../EntityLink'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import UserCard from '../UserCard'
-import { ElementWithTooltip } from '../widgets/ElementWithTooltip'
-import { AUTHENTICATED_USERS } from '../../utils/SynapseConstants'
 import { noop } from 'lodash-es'
+import React from 'react'
+import { PRODUCTION_ENDPOINT_CONFIG } from '../../utils/functions/getEndpoint'
+import { AUTHENTICATED_USERS } from '../../utils/SynapseConstants'
 import {
-  MarkdownLink,
-  CardLink,
-  ColumnSpecifiedLink,
-} from '../CardContainerLogic'
-import { SynapseCardLabel } from '../GenericCard'
-import {
-  SelectColumn,
   ColumnModel,
   FileHandleAssociateType,
-  Row,
+  SelectColumn,
 } from '../../utils/synapseTypes'
-import { NOT_SET_DISPLAY_VALUE } from '../table/SynapseTableConstants'
+import { EntityHeader } from '../../utils/synapseTypes/EntityHeader'
+import {
+  CardLink,
+  ColumnSpecifiedLink,
+  MarkdownLink,
+} from '../CardContainerLogic'
 import DirectDownload from '../DirectDownload'
 import EntityIdList from '../EntityIdList'
-import { PRODUCTION_ENDPOINT_CONFIG } from '../../utils/functions/getEndpoint'
+import { EntityLink } from '../EntityLink'
+import { SynapseCardLabel } from '../GenericCard'
+import { Dictionary } from '../table/SynapseTable'
+import { NOT_SET_DISPLAY_VALUE } from '../table/SynapseTableConstants'
+import UserCard from '../UserCard'
+import { ElementWithTooltip } from '../widgets/ElementWithTooltip'
 
 type SynapseTableCellProps = {
   entityColumnIndicies: number[]

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -829,7 +829,7 @@ export default class SynapseTable extends React.Component<
                     columnModels={columnModels}
                     columnName={columnName}
                     tableEntityId={tableEntityId}
-                    row={row}
+                    rowData={row.values}
                   />
                 )}
               </td>

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -29,7 +29,7 @@ import TotalQueryResults from '../TotalQueryResults'
 import { unCamelCase } from './../../utils/functions/unCamelCase'
 import { ICON_STATE } from './SynapseTableConstants'
 import NoData from '../../assets/icons/file-dotted.svg'
-import { renderTableCell } from '../synapse_table_functions/renderTableCell'
+import { SynapseTableCell } from '../synapse_table_functions/SynapseTableCell'
 import { getUniqueEntities } from '../synapse_table_functions/getUniqueEntities'
 import { getColumnIndiciesWithType } from '../synapse_table_functions/getColumnIndiciesWithType'
 import { Checkbox } from '../widgets/Checkbox'
@@ -191,7 +191,7 @@ export default class SynapseTable extends React.Component<
     if (!data || this.state.isFetchingEntityVersion) {
       return
     }
-    
+
     const currentTableId = data?.queryResult.queryResults.tableId
     const previousTableId = prevProps.data?.queryResult.queryResults.tableId
     if (currentTableId && previousTableId !== currentTableId) {
@@ -203,7 +203,9 @@ export default class SynapseTable extends React.Component<
       // PORTALS-1973:  To simplify logic, only show special file view columns (like direct
       // download, or adding a file to the download cart) if the View selects Files _only_.
       // http://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/EntityView.html
-      const isFileView = isEntityView ? (entityData as any).viewTypeMask === 1 : false
+      const isFileView = isEntityView
+        ? (entityData as any).viewTypeMask === 1
+        : false
       this.setState({
         isEntityView: isEntityView,
         isFileView: isFileView,
@@ -308,9 +310,7 @@ export default class SynapseTable extends React.Component<
     }
     if (userPorfileIds.length > 0) {
       try {
-        const data = await getUserProfileWithProfilePicAttached(
-          userPorfileIds,
-        )
+        const data = await getUserProfileWithProfilePicAttached(userPorfileIds)
         data.list.forEach((el: UserProfile) => {
           mapUserIdToHeader[el.ownerId] = el
         })
@@ -808,28 +808,29 @@ export default class SynapseTable extends React.Component<
                   </a>
                 )}
 
-                {!isCountColumn &&
-                  renderTableCell({
-                    entityColumnIndicies,
-                    userColumnIndicies,
-                    dateColumnIndicies,
-                    dateListColumnIndicies,
-                    booleanListColumnIndicies,
-                    fileHandleIdColumnIndicies,
-                    entityIdListColumnIndicies,
-                    otherListColumnIndicies,
-                    colIndex,
-                    columnValue,
-                    isBold,
-                    mapEntityIdToHeader,
-                    mapUserIdToHeader,
-                    columnLinkConfig,
-                    rowIndex,
-                    selectColumns,
-                    columnModels,
-                    columnName,
-                    tableEntityId,
-                  })}
+                {!isCountColumn && (
+                  <SynapseTableCell
+                    entityColumnIndicies={entityColumnIndicies}
+                    userColumnIndicies={userColumnIndicies}
+                    dateColumnIndicies={dateColumnIndicies}
+                    dateListColumnIndicies={dateListColumnIndicies}
+                    booleanListColumnIndicies={booleanListColumnIndicies}
+                    fileHandleIdColumnIndicies={fileHandleIdColumnIndicies}
+                    entityIdListColumnIndicies={entityIdListColumnIndicies}
+                    otherListColumnIndicies={otherListColumnIndicies}
+                    colIndex={colIndex}
+                    columnValue={columnValue}
+                    isBold={isBold}
+                    mapEntityIdToHeader={mapEntityIdToHeader}
+                    mapUserIdToHeader={mapUserIdToHeader}
+                    columnLinkConfig={columnLinkConfig}
+                    rowIndex={rowIndex}
+                    selectColumns={selectColumns}
+                    columnModels={columnModels}
+                    columnName={columnName}
+                    tableEntityId={tableEntityId}
+                  />
+                )}
               </td>
             )
           }

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -829,6 +829,7 @@ export default class SynapseTable extends React.Component<
                     columnModels={columnModels}
                     columnName={columnName}
                     tableEntityId={tableEntityId}
+                    row={row}
                   />
                 )}
               </td>


### PR DESCRIPTION
- Adds `ColumnSpecifiedLink` type, which allows you to format a SynapseTableCell with a link defined by another column. 
  - Works for both cards and tables
- Convert function `renderLabel` to component `SynapseCardLabel`
- Convert function `renderTableCell` to component `SynapseTableCell`
- Typing cleanup in various card components

Screenshot working in the AD Portal. The first two rows have an empty `link` field

![image](https://user-images.githubusercontent.com/17580037/133676491-5cbf74df-d018-424a-bad2-524dd6a41301.png)
