### PR TITLE
`useListState`: Use React's state type to allow functions in `setList`

### DIFF
--- a/src/lib/utils/hooks/useListState.ts
+++ b/src/lib/utils/hooks/useListState.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { Dispatch, SetStateAction, useState } from 'react'
 
 export interface ListStateReturn<T> {
   // initial state of the list
@@ -10,7 +10,7 @@ export interface ListStateReturn<T> {
   // generates a function to append to the end of the list
   appendToList: (...newItem: T[]) => void
   //changes the entire list state
-  setList: (list: T[]) => void
+  setList: Dispatch<SetStateAction<T[]>>
 }
 /**
  * This is used when a component's state uses a List<T> and has child components
@@ -57,7 +57,7 @@ export interface ListStateReturn<T> {
  * @returns an ListStateReturn object containing the useState value and additonal change/remove/push hnndlers. Use object destructuring
  */
 export const useListState = <T>(initialState: T[]): ListStateReturn<T> => {
-  const [list, setList] = useState(initialState)
+  const [list, setList] = useState<T[]>(initialState)
 
   const handleListChange = (index: number) => (changedValue: T): void => {
     const modifiedList = [...list]


### PR DESCRIPTION
`Dispatch<SetStateAction<T[]>>` also lets you call `useState`'s setter with a function, e.g.

```tsx
const [number, setNumber] = useState(0);

function increment() {
	setNumber(n => n + 1);
}
```

Before this change, this would result in a compile-time type error.