### PR TITLE
Use Toast in Styleguide, Use Collapse in FacetFilters

### DIFF
--- a/src/__tests__/lib/containers/widgets/EnumFacetFilter.test.tsx
+++ b/src/__tests__/lib/containers/widgets/EnumFacetFilter.test.tsx
@@ -136,11 +136,11 @@ describe('initialization', () => {
   })
 
   describe('collapsible behavior', () => {
-    it('should hide content when toggled', () => {
+    it('should hide content when toggled', async () => {
       init({ ...props, collapsed: false })
       expect(
-        container.getElementsByClassName('EnumFacetFilter')[0].style,
-      ).toHaveProperty('display', 'block')
+        container.getElementsByClassName('EnumFacetFilter')[0],
+      ).toHaveClass('MuiCollapse-entered')
 
       // toggle collapse via button
       const button = container.querySelector(
@@ -148,16 +148,18 @@ describe('initialization', () => {
       )
       fireEvent.click(button)
 
-      expect(
-        container.getElementsByClassName('EnumFacetFilter')[0].style,
-      ).toHaveProperty('display', 'none')
+      await waitFor(() =>
+        expect(
+          container.getElementsByClassName('EnumFacetFilter')[0],
+        ).toHaveClass('MuiCollapse-hidden'),
+      )
     })
 
-    it('should start collapsed when specified via prop', () => {
+    it('should start collapsed when specified via prop', async () => {
       init({ ...props, collapsed: true })
       expect(
-        container.getElementsByClassName('EnumFacetFilter')[0].style,
-      ).toHaveProperty('display', 'none')
+        container.getElementsByClassName('EnumFacetFilter')[0],
+      ).toHaveClass('MuiCollapse-hidden')
 
       // toggle collapse via button
       const button = container.querySelector(
@@ -165,9 +167,11 @@ describe('initialization', () => {
       )
       fireEvent.click(button)
 
-      expect(
-        container.getElementsByClassName('EnumFacetFilter')[0].style,
-      ).toHaveProperty('display', 'block')
+      await waitFor(() =>
+        expect(
+          container.getElementsByClassName('EnumFacetFilter')[0],
+        ).toHaveClass('MuiCollapse-entered'),
+      )
     })
   })
 

--- a/src/__tests__/lib/containers/widgets/RangeFacetFilter.test.tsx
+++ b/src/__tests__/lib/containers/widgets/RangeFacetFilter.test.tsx
@@ -99,9 +99,9 @@ describe('basic function', () => {
   describe('collapsible', () => {
     it('should hide content when toggled', () => {
       init({ ...props, collapsed: false })
-      expect(wrapper.childAt(0).childAt(1).get(0).props.style).toHaveProperty(
-        'display',
-        'block',
+      expect(wrapper.childAt(0).childAt(1).get(0).props).toHaveProperty(
+        'in',
+        true,
       )
 
       // toggle collapse via button
@@ -109,17 +109,17 @@ describe('basic function', () => {
         .find('button.FacetFilterHeader__collapseToggleBtn')
         .simulate('click')
 
-      expect(wrapper.childAt(0).childAt(1).get(0).props.style).toHaveProperty(
-        'display',
-        'none',
+      expect(wrapper.childAt(0).childAt(1).get(0).props).toHaveProperty(
+        'in',
+        false,
       )
     })
 
     it('should start collapsed when specified via prop', () => {
       init({ ...props, collapsed: true })
-      expect(wrapper.childAt(0).childAt(1).get(0).props.style).toHaveProperty(
-        'display',
-        'none',
+      expect(wrapper.childAt(0).childAt(1).get(0).props).toHaveProperty(
+        'in',
+        false,
       )
 
       // toggle collapse via button
@@ -127,9 +127,9 @@ describe('basic function', () => {
         .find('button.FacetFilterHeader__collapseToggleBtn')
         .simulate('click')
 
-      expect(wrapper.childAt(0).childAt(1).get(0).props.style).toHaveProperty(
-        'display',
-        'block',
+      expect(wrapper.childAt(0).childAt(1).get(0).props).toHaveProperty(
+        'in',
+        true,
       )
     })
   })

--- a/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../utils/synapseTypes/Table'
 import { Checkbox } from '../Checkbox'
 import { FacetFilterHeader } from './FacetFilterHeader'
+import { Collapse } from '@material-ui/core'
 
 library.add(faArrowLeft)
 
@@ -342,12 +343,9 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
           label={columnModel.name}
           onClick={(isCollapsed: boolean) => setIsCollapsed(isCollapsed)}
         />
-        <div
-          className="EnumFacetFilter"
-          style={{ display: isCollapsed ? 'none' : 'block' }}
-        >
+        <Collapse className="EnumFacetFilter" in={!isCollapsed}>
           {content}
-        </div>
+        </Collapse>
       </>
     )
   }

--- a/src/lib/containers/widgets/query-filter/RangeFacetFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/RangeFacetFilter.tsx
@@ -3,10 +3,14 @@ import { Range, RangeValues } from '../Range'
 import { RangeSlider } from '../RangeSlider'
 import { FacetColumnResultRange } from '../../../utils/synapseTypes/Table/FacetColumnResult'
 import { ColumnModel } from '../../../utils/synapseTypes/Table/ColumnModel'
-import { VALUE_NOT_SET, FRIENDLY_VALUE_NOT_SET } from '../../../utils/SynapseConstants'
+import {
+  VALUE_NOT_SET,
+  FRIENDLY_VALUE_NOT_SET,
+} from '../../../utils/SynapseConstants'
 import { FacetFilterHeader } from './FacetFilterHeader'
 import { RadioGroup } from '../RadioGroup'
 import { useState } from 'react'
+import { Collapse } from '@material-ui/core'
 
 export enum RadioValuesEnum {
   NOT_SET = 'org.sagebionetworks.UNDEFINED_NULL_NOTSET',
@@ -82,7 +86,7 @@ export const RangeFacetFilter: React.FunctionComponent<RangeFacetFilterProps> = 
         onClick={(isCollapsed: boolean) => setIsCollapsed(isCollapsed)}
         facetAliases={facetAliases}
       ></FacetFilterHeader>
-      <div style={{ display: isCollapsed ? 'none' : 'block' }}>
+      <Collapse in={!isCollapsed}>
         <RadioGroup
           value={radioValue}
           id="rangeSelector"
@@ -127,7 +131,7 @@ export const RangeFacetFilter: React.FunctionComponent<RangeFacetFilterProps> = 
               )}
             </>
           ))}
-      </div>
+      </Collapse>
     </div>
   )
   return result

--- a/styleguide.setup.js
+++ b/styleguide.setup.js
@@ -32,6 +32,11 @@ import {
 import React from 'react'
 import ReactDOM from 'react-dom'
 
+// Inject the ToastContainer so we can push toast notifications
+let toastContainerDiv = document.createElement('div')
+document.getElementsByTagName('body')[0].append(toastContainerDiv)
+ReactDOM.render(React.createElement(SynapseToastContainer), toastContainerDiv)
+
 global.currentUserProfile = false
 global.accessToken = false
 global.sessionChangeHandler = async () => {
@@ -44,8 +49,10 @@ global.sessionChangeHandler = async () => {
         if (accessToken) {
           getAuthenticatedOn(accessToken).then(authenticatedOn => {
             const date = moment(authenticatedOn.authenticatedOn).format('L LT')
-            alert(
+            displayToast(
               `You are currently logged in as ${profile.userName} (last authenticated at ${date})`,
+              'info',
+              { autoCloseInMs: 5000 },
             )
           })
         }
@@ -69,11 +76,6 @@ global.iconOptions = {
   'MODEL-AD': mouseSvg,
   'Resilience-AD': resilienceadSvg,
 }
-
-// Inject the ToastContainer so we can push toast notifications
-let toastContainerDiv = document.createElement('div')
-document.getElementsByTagName('body')[0].append(toastContainerDiv)
-ReactDOM.render(React.createElement(SynapseToastContainer), toastContainerDiv)
 
 global.SynapseContextConsumer = SynapseContextConsumer
 global.AVATAR = AVATAR


### PR DESCRIPTION
Toast just gets out of your way a little easier than `alert`, if you don't interact with it, it dismisses in 5s.

Using MUI's Collapse in the facet filters just adds a nice animation. No ticket for this, was just bothering me while I was looking into another potential issue and it's a simple change.

Toast:

https://user-images.githubusercontent.com/17580037/134222206-d4b772e8-2176-4e36-8f45-c288d6639687.mov


FacetFilter before:

https://user-images.githubusercontent.com/17580037/134222796-58dc7274-b1cc-4a93-a88b-11c2797c45b1.mov

FacetFilter after:


https://user-images.githubusercontent.com/17580037/134222827-1fe92c42-bf04-4aa1-b9dd-bf838344d1bd.mov


