### PR TITLE
SWC-5839

### DIFF
--- a/src/__tests__/lib/utils/hooks/useGetIsAllSelectedInfiniteList.test.ts
+++ b/src/__tests__/lib/utils/hooks/useGetIsAllSelectedInfiniteList.test.ts
@@ -1,0 +1,297 @@
+import { getIsAllSelectedFromInfiniteList } from '../../../../lib/utils/hooks/useGetIsAllSelectedInfiniteList'
+import { Map } from 'immutable'
+import { EntityHeader, EntityType } from '../../../../lib/utils/synapseTypes'
+
+const ALL_TYPES = Object.values(EntityType)
+const mockFetchNextPage = jest.fn()
+
+describe('getIsAllSelectedInifiniteList tests', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+  it('Is false when no entities are selected', () => {
+    const fetchedEntities: EntityHeader[] = [
+      {
+        id: 'syn123',
+        name: 'A File Entity',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+    ]
+    const selectedEntities: Map<string, number> = Map()
+    expect(
+      getIsAllSelectedFromInfiniteList(
+        fetchedEntities,
+        selectedEntities,
+        ALL_TYPES,
+        false,
+        mockFetchNextPage,
+        false,
+      ),
+    ).toBe(false)
+  })
+  it('Is false where no entities are present in the current list', () => {
+    const fetchedEntities: EntityHeader[] = []
+    const selectedEntities: Map<string, number> = Map({ syn123: 1 })
+    expect(
+      getIsAllSelectedFromInfiniteList(
+        fetchedEntities,
+        selectedEntities,
+        ALL_TYPES,
+        false,
+        mockFetchNextPage,
+        false,
+      ),
+    ).toBe(false)
+  })
+  it('Is true when all of the entities in the list are selected', () => {
+    const fetchedEntities: EntityHeader[] = [
+      {
+        id: 'syn123',
+        name: 'A File Entity',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+    ]
+    const selectedEntities: Map<string, number> = Map({ syn123: 1 })
+    expect(
+      getIsAllSelectedFromInfiniteList(
+        fetchedEntities,
+        selectedEntities,
+        ALL_TYPES,
+        false,
+        mockFetchNextPage,
+        false,
+      ),
+    ).toBe(true)
+  })
+  it('Is false when some, but not all, of the entities in the list are selected', () => {
+    const fetchedEntities: EntityHeader[] = [
+      {
+        id: 'syn123',
+        name: 'A File Entity',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+      {
+        id: 'syn456',
+        name: 'A File Entity',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+    ]
+    const selectedEntities: Map<string, number> = Map({ syn123: 1 })
+    expect(
+      getIsAllSelectedFromInfiniteList(
+        fetchedEntities,
+        selectedEntities,
+        ALL_TYPES,
+        false,
+        mockFetchNextPage,
+        false,
+      ),
+    ).toBe(false)
+  })
+  it('Is false when all of the entities in the list are unselectable', () => {
+    const fetchedEntities: EntityHeader[] = [
+      {
+        id: 'syn123',
+        name: 'A File Entity',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+      {
+        id: 'syn456',
+        name: 'A Folder',
+        type: 'org.sagebionetworks.repo.model.Folder',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+    ]
+    const selectedEntities: Map<string, number> = Map({ syn999: 1 })
+    expect(
+      getIsAllSelectedFromInfiniteList(
+        fetchedEntities,
+        selectedEntities,
+        [EntityType.PROJECT], // can only select projects
+        false,
+        mockFetchNextPage,
+        false,
+      ),
+    ).toBe(false)
+  })
+  it('Will fetch the next page when we have only retrieved selected entities and there is a next page', () => {
+    const fetchedEntities: EntityHeader[] = [
+      {
+        id: 'syn123',
+        name: 'A File Entity',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+      {
+        id: 'syn456',
+        name: 'A Folder',
+        type: 'org.sagebionetworks.repo.model.Folder',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+    ]
+    const selectedEntities: Map<string, number> = Map({ syn123: 1, syn456: 1 })
+    expect(
+      getIsAllSelectedFromInfiniteList(
+        fetchedEntities,
+        selectedEntities,
+        ALL_TYPES,
+        true, // There is a next page
+        mockFetchNextPage,
+        false,
+      ),
+    ).toBe(false)
+
+    expect(mockFetchNextPage).toBeCalledTimes(1)
+  })
+
+  it('Will fetch the next page when we have only retrieved unselectable entities and there is a next page', () => {
+    const fetchedEntities: EntityHeader[] = [
+      {
+        id: 'syn123',
+        name: 'A File Entity',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+      {
+        id: 'syn456',
+        name: 'A Folder',
+        type: 'org.sagebionetworks.repo.model.Folder',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+    ]
+    const selectedEntities: Map<string, number> = Map({ syn986: 1, syn987: 1 })
+    expect(
+      getIsAllSelectedFromInfiniteList(
+        fetchedEntities,
+        selectedEntities,
+        [EntityType.DATASET], // Can only select Datasets
+        true, // There is a next page
+        mockFetchNextPage,
+        false,
+      ),
+    ).toBe(false)
+
+    expect(mockFetchNextPage).toBeCalledTimes(1)
+  })
+
+  it('Will not fetch the next page is isFetching is true', () => {
+    const fetchedEntities: EntityHeader[] = [
+      {
+        id: 'syn123',
+        name: 'A File Entity',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+      {
+        id: 'syn456',
+        name: 'A Folder',
+        type: 'org.sagebionetworks.repo.model.Folder',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+    ]
+    const selectedEntities: Map<string, number> = Map({ syn123: 1, syn456: 1 })
+    expect(
+      getIsAllSelectedFromInfiniteList(
+        fetchedEntities,
+        selectedEntities,
+        ALL_TYPES,
+        true, // There is a next page
+        mockFetchNextPage,
+        true, // isFetching
+      ),
+    ).toBe(false)
+
+    expect(mockFetchNextPage).not.toBeCalled()
+  })
+
+  it('Will not fetch fetch the next page if a selectable entity is unselected', () => {
+    const fetchedEntities: EntityHeader[] = [
+      {
+        id: 'syn123',
+        name: 'A File Entity',
+        type: 'org.sagebionetworks.repo.model.FileEntity',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+      {
+        id: 'syn456',
+        name: 'A Folder',
+        type: 'org.sagebionetworks.repo.model.Folder',
+        benefactorId: 123,
+        createdOn: '',
+        modifiedOn: '',
+        createdBy: '',
+        modifiedBy: '',
+      },
+    ]
+    const selectedEntities: Map<string, number> = Map({ syn986: 1, syn987: 1 })
+    expect(
+      getIsAllSelectedFromInfiniteList(
+        fetchedEntities,
+        selectedEntities,
+        [EntityType.FILE], // Can only select Files
+        true, // There is a next page
+        mockFetchNextPage,
+        false,
+      ),
+    ).toBe(false)
+
+    expect(mockFetchNextPage).not.toBeCalled()
+  })
+})

--- a/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
+++ b/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
@@ -13,7 +13,7 @@ import { EntityChildrenDetails } from './configurations/EntityChildrenDetails'
 import { FavoritesDetails } from './configurations/FavoritesDetails'
 import { ProjectListDetails } from './configurations/ProjectListDetails'
 import { SearchDetails } from './configurations/SearchDetails'
-import { getIsAllSelectedFromInfiniteList } from './configurations/useGetIsAllSelectedInfiniteList'
+import { getIsAllSelectedFromInfiniteList } from '../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 import { DetailsView } from './view/DetailsView'
 
 export enum EntityDetailsListDataConfigurationType {

--- a/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
@@ -5,7 +5,7 @@ import { useGetEntityChildrenInfinite } from '../../../../utils/hooks/SynapseAPI
 import { Direction, SortBy } from '../../../../utils/synapseTypes'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import { DetailsView } from '../view/DetailsView'
-import useGetIsAllSelectedFromInfiniteList from './useGetIsAllSelectedInfiniteList'
+import useGetIsAllSelectedFromInfiniteList from '../../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 
 type EntityChildrenDetailsProps = EntityDetailsListSharedProps & {
   parentContainerId: string

--- a/src/lib/containers/entity_finder/details/configurations/FavoritesDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/FavoritesDetails.tsx
@@ -4,7 +4,7 @@ import { toError } from '../../../../utils/ErrorUtils'
 import { useGetFavoritesInfinite } from '../../../../utils/hooks/SynapseAPI/useFavorites'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import { DetailsView } from '../view/DetailsView'
-import useGetIsAllSelectedFromInfiniteList from './useGetIsAllSelectedInfiniteList'
+import useGetIsAllSelectedFromInfiniteList from '../../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 
 type FavoritesDetailsProps = EntityDetailsListSharedProps
 

--- a/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
@@ -5,7 +5,7 @@ import { useGetProjectsInfinite } from '../../../../utils/hooks/SynapseAPI/usePr
 import { GetProjectsParameters } from '../../../../utils/synapseTypes/GetProjectsParams'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import { DetailsView } from '../view/DetailsView'
-import useGetIsAllSelectedFromInfiniteList from './useGetIsAllSelectedInfiniteList'
+import useGetIsAllSelectedFromInfiniteList from '../../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 
 type ProjectListDetailsProps = EntityDetailsListSharedProps & {
   projectsParams: GetProjectsParameters

--- a/src/lib/utils/hooks/useGetIsAllSelectedInfiniteList.ts
+++ b/src/lib/utils/hooks/useGetIsAllSelectedInfiniteList.ts
@@ -50,8 +50,8 @@ export function getIsAllSelectedFromInfiniteList<T>(
       fetchNextPage()
       return false
     } else {
-      if (hasNextPage || isFetchingNextPage) {
-        // We are waiting on the next page to be retrieved
+      if (isFetchingNextPage) {
+        // Wait for the next page to be retrieved
         return false
       }
 

--- a/src/lib/utils/hooks/useGetIsAllSelectedInfiniteList.ts
+++ b/src/lib/utils/hooks/useGetIsAllSelectedInfiniteList.ts
@@ -1,14 +1,10 @@
 import { Map } from 'immutable'
 import { useEffect, useState } from 'react'
 import { FetchNextPageOptions, InfiniteQueryObserverResult } from 'react-query'
-import { getEntityTypeFromHeader } from '../../../../utils/functions/EntityTypeUtils'
-import { SynapseClientError } from '../../../../utils/SynapseClient'
-import {
-  EntityHeader,
-  EntityType,
-  ProjectHeader,
-} from '../../../../utils/synapseTypes'
-import { Hit } from '../../../../utils/synapseTypes/Search'
+import { getEntityTypeFromHeader } from '../functions/EntityTypeUtils'
+import { SynapseClientError } from '../SynapseClient'
+import { EntityHeader, EntityType, ProjectHeader } from '../synapseTypes'
+import { Hit } from '../synapseTypes/Search'
 
 /**
  * Given a list of entities and a map of which are selected, return a boolean indicating if all of the entities that can be selected
@@ -39,27 +35,34 @@ export function getIsAllSelectedFromInfiniteList<T>(
   if (entities.length === 0 || selected.size === 0) {
     return false
   } else {
-    const allFetchedChildrenAreSelected = entities.every(
+    const allSelectableFetchedChildrenAreSelected = entities.every(
       e =>
         selected.has(e.id) ||
         !selectableTypes.includes(getEntityTypeFromHeader(e)),
     )
     if (
-      allFetchedChildrenAreSelected &&
+      allSelectableFetchedChildrenAreSelected &&
       hasNextPage &&
       fetchNextPage &&
       !isFetchingNextPage
     ) {
+      // We don't yet know if the checkbox should be true or false, so get the next page
       fetchNextPage()
       return false
-    } else if (
-      allFetchedChildrenAreSelected &&
-      !hasNextPage &&
-      !isFetchingNextPage
-    ) {
-      return true
     } else {
-      return false
+      if (hasNextPage || isFetchingNextPage) {
+        // We are waiting on the next page to be retrieved
+        return false
+      }
+
+      // At this point, we've fetched all of the pages or encountered an unselected entity
+      // The checkbox should be true if there are no unselected entities, and there's at least one selectable entity
+      const selectableEntitiesArePresent = entities.some(e =>
+        selectableTypes.includes(getEntityTypeFromHeader(e)),
+      )
+      return (
+        allSelectableFetchedChildrenAreSelected && selectableEntitiesArePresent
+      )
     }
   }
 }


### PR DESCRIPTION
[Jira](https://sagebionetworks.jira.com/browse/SWC-5839)

Fixes a bug where the Entity Finder's select all checkbox would be checked if at least one item was selected and the user fetched a list consisting entirely of unselectable entities (e.g. folders when you can only select files)