### PR TITLE
SWC-5845 and SWC-5840

### DIFF
--- a/src/__tests__/lib/containers/entity_finder/EntityFinder.test.tsx
+++ b/src/__tests__/lib/containers/entity_finder/EntityFinder.test.tsx
@@ -392,7 +392,7 @@ describe('EntityFinder tests', () => {
   })
 
   it('handles searching for terms', async () => {
-    renderComponent()
+    renderComponent({ selectableTypes: [EntityType.FILE] })
 
     const query = 'my search terms '
     const queryTerms = ['my', 'search', 'terms']
@@ -408,6 +408,35 @@ describe('EntityFinder tests', () => {
             type: EntityDetailsListDataConfigurationType.ENTITY_SEARCH,
             query: {
               queryTerm: queryTerms,
+              // Verify that at least one of the omitted types is excluded from the search
+              booleanQuery: expect.arrayContaining([
+                {
+                  key: 'node_type',
+                  value: 'project',
+                  not: true,
+                },
+              ]),
+            },
+          },
+        }),
+        {},
+      ),
+    )
+    await waitFor(() =>
+      expect(mockDetailsList).toBeCalledWith(
+        expect.objectContaining({
+          configuration: {
+            type: EntityDetailsListDataConfigurationType.ENTITY_SEARCH,
+            query: {
+              queryTerm: queryTerms,
+              // The lone selectable type should not have been excluded
+              booleanQuery: expect.not.arrayContaining([
+                {
+                  key: 'node_type',
+                  value: 'file',
+                  not: true,
+                },
+              ]),
             },
           },
         }),

--- a/src/__tests__/lib/containers/entity_finder/details/DetailsView.test.tsx
+++ b/src/__tests__/lib/containers/entity_finder/details/DetailsView.test.tsx
@@ -6,16 +6,14 @@ import React from 'react'
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
 import {
   DetailsView,
-  DetailsViewProps
+  DetailsViewProps,
 } from '../../../../../lib/containers/entity_finder/details/view/DetailsView'
 import { NO_VERSION_NUMBER } from '../../../../../lib/containers/entity_finder/EntityFinder'
 import { createWrapper } from '../../../../../lib/testutils/TestingLibraryUtils'
-import {
-  ENTITY_ID_VERSIONS
-} from '../../../../../lib/utils/APIConstants'
+import { ENTITY_ID_VERSIONS } from '../../../../../lib/utils/APIConstants'
 import {
   BackendDestinationEnum,
-  getEndpoint
+  getEndpoint,
 } from '../../../../../lib/utils/functions/getEndpoint'
 import { SynapseContextType } from '../../../../../lib/utils/SynapseContext'
 import {
@@ -23,14 +21,17 @@ import {
   EntityHeader,
   EntityType,
   PaginatedResults,
-  SortBy
+  SortBy,
 } from '../../../../../lib/utils/synapseTypes'
 import { VersionInfo } from '../../../../../lib/utils/synapseTypes/VersionInfo'
 import { rest, server } from '../../../../../mocks/msw/server'
 
 // Having trouble mocking the AutoResizer in react-base-table. It just uses this under the hood:
-jest.mock('react-virtualized-auto-sizer', () => ({ children }) =>
-  children({ height: 600, width: 1200 }),
+jest.mock(
+  'react-virtualized-auto-sizer',
+  () =>
+    ({ children }) =>
+      children({ height: 600, width: 1200 }),
 )
 
 const mockToggleSelection = jest.fn()
@@ -130,7 +131,6 @@ const defaultProps: DetailsViewProps = {
   noResultsPlaceholder: <></>,
   mustSelectVersionNumber: false,
   enableSelectAll: true,
-  autoSizeWidth: true,
 }
 
 function renderComponent(
@@ -195,10 +195,6 @@ describe('DetailsView tests', () => {
         // Nothing is disabled
         expect(rows[FILE_INDEX]).not.toBeDisabled()
         expect(rows[PROJECT_INDEX]).not.toBeDisabled()
-
-        // Nothing is hidden
-        expect(rows[FILE_INDEX]).toHaveAttribute('aria-hidden', 'false')
-        expect(rows[PROJECT_INDEX]).toHaveAttribute('aria-hidden', 'false')
       })
 
       it('Creates a row with the selected appearance', async () => {
@@ -216,10 +212,6 @@ describe('DetailsView tests', () => {
         // Nothing is disabled
         expect(rows[FILE_INDEX]).toHaveAttribute('aria-disabled', 'false')
         expect(rows[PROJECT_INDEX]).toHaveAttribute('aria-disabled', 'false')
-
-        // Nothing is hidden
-        expect(rows[FILE_INDEX]).toHaveAttribute('aria-hidden', 'false')
-        expect(rows[PROJECT_INDEX]).toHaveAttribute('aria-hidden', 'false')
       })
 
       it('Creates a row with the disabled appearance', async () => {
@@ -239,32 +231,6 @@ describe('DetailsView tests', () => {
         // One row is disabled (the file)
         expect(rows[FILE_INDEX]).toHaveAttribute('aria-disabled', 'true')
         expect(rows[PROJECT_INDEX]).toHaveAttribute('aria-disabled', 'false')
-
-        // Nothing is hidden
-        expect(rows[FILE_INDEX]).toHaveAttribute('aria-hidden', 'false')
-        expect(rows[PROJECT_INDEX]).toHaveAttribute('aria-hidden', 'false')
-      })
-
-      it('Creates a row with the hidden appearance', () => {
-        renderComponent({
-          selected: Map(),
-          visibleTypes: [EntityType.FILE], // !
-          selectableTypes: Object.values(EntityType),
-        })
-
-        // Nothing is selected
-        expect(
-          screen.queryByRole('row', { selected: true }),
-        ).not.toBeInTheDocument()
-
-        const rows = screen.getAllByRole('row', { hidden: true })
-        // Nothing is disabled
-        expect(rows[FILE_INDEX]).toHaveAttribute('aria-disabled', 'false')
-        expect(rows[PROJECT_INDEX]).toHaveAttribute('aria-disabled', 'false')
-
-        // One row is hidden--the project
-        expect(rows[FILE_INDEX]).toHaveAttribute('aria-hidden', 'false')
-        expect(rows[PROJECT_INDEX]).toHaveAttribute('aria-hidden', 'true')
       })
     })
   })

--- a/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
+++ b/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
@@ -50,95 +50,94 @@ export type EntityDetailsListSharedProps = {
   selected: Map<string, number>
   selectableTypes: EntityType[]
   toggleSelection: (entity: Reference | Reference[]) => void
-  autoSizeWidth: boolean
 }
 
 export type EntityDetailsListProps = EntityDetailsListSharedProps & {
   configuration: EntityDetailsListDataConfiguration
 }
 
-export const EntityDetailsList: React.FunctionComponent<EntityDetailsListProps> = ({
-  configuration,
-  ...sharedProps
-}) => {
-  /**
-   * This component simply uses the data configuration prop to determine which configuration component
-   * to use. Each configuration component has its own logic to utilize different Synapse APIs.
-   * The configuration components also manage view props that are more tightly-coupled with data,
-   * such as pagination and sorting.
-   *
-   * In the future, if we wanted to reuse this in other contexts (e.g. not selecting entities), we should consider refactoring
-   * to support different 'Row' components, determining the correct one determined at this level.
-   */
+export const EntityDetailsList: React.FunctionComponent<EntityDetailsListProps> =
+  ({ configuration, ...sharedProps }) => {
+    /**
+     * This component simply uses the data configuration prop to determine which configuration component
+     * to use. Each configuration component has its own logic to utilize different Synapse APIs.
+     * The configuration components also manage view props that are more tightly-coupled with data,
+     * such as pagination and sorting.
+     *
+     * In the future, if we wanted to reuse this in other contexts (e.g. not selecting entities), we should consider refactoring
+     * to support different 'Row' components, determining the correct one determined at this level.
+     */
 
-  const [component, setComponent] = useState(<></>)
+    const [component, setComponent] = useState(<></>)
 
-  useDeepCompareEffect(() => {
-    const getComponentFromConfiguration = (
-      config: EntityDetailsListDataConfiguration,
-    ) => {
-      switch (config.type) {
-        case EntityDetailsListDataConfigurationType.PARENT_CONTAINER:
-          return (
-            <EntityChildrenDetails
-              parentContainerId={config.parentContainerId!}
-              {...sharedProps}
-            />
-          )
+    useDeepCompareEffect(() => {
+      const getComponentFromConfiguration = (
+        config: EntityDetailsListDataConfiguration,
+      ) => {
+        switch (config.type) {
+          case EntityDetailsListDataConfigurationType.PARENT_CONTAINER:
+            return (
+              <EntityChildrenDetails
+                parentContainerId={config.parentContainerId!}
+                {...sharedProps}
+              />
+            )
 
-        case EntityDetailsListDataConfigurationType.HEADER_LIST:
-          return (
-            <DetailsView
-              entities={config.headerList as (EntityHeader | ProjectHeader)[]}
-              isLoading={false}
-              hasNextPage={false}
-              {...sharedProps}
-              enableSelectAll={sharedProps.enableSelectAll}
-              selectAllIsChecked={getIsAllSelectedFromInfiniteList(
-                (config.headerList as (EntityHeader | ProjectHeader)[]) ?? [],
-                sharedProps.selected,
-                sharedProps.selectableTypes,
-              )}
-            />
-          )
-        case EntityDetailsListDataConfigurationType.USER_FAVORITES:
-          return <FavoritesDetails {...sharedProps} />
-        case EntityDetailsListDataConfigurationType.ENTITY_SEARCH:
-          return <SearchDetails searchQuery={config.query!} {...sharedProps} />
+          case EntityDetailsListDataConfigurationType.HEADER_LIST:
+            return (
+              <DetailsView
+                entities={config.headerList as (EntityHeader | ProjectHeader)[]}
+                isLoading={false}
+                hasNextPage={false}
+                {...sharedProps}
+                enableSelectAll={sharedProps.enableSelectAll}
+                selectAllIsChecked={getIsAllSelectedFromInfiniteList(
+                  (config.headerList as (EntityHeader | ProjectHeader)[]) ?? [],
+                  sharedProps.selected,
+                  sharedProps.selectableTypes,
+                )}
+              />
+            )
+          case EntityDetailsListDataConfigurationType.USER_FAVORITES:
+            return <FavoritesDetails {...sharedProps} />
+          case EntityDetailsListDataConfigurationType.ENTITY_SEARCH:
+            return (
+              <SearchDetails searchQuery={config.query!} {...sharedProps} />
+            )
 
-        case EntityDetailsListDataConfigurationType.USER_PROJECTS:
-          return (
-            <ProjectListDetails
-              projectsParams={config.getProjectParams!}
-              {...sharedProps}
-            />
-          )
-        case EntityDetailsListDataConfigurationType.PROMPT:
-          return (
-            <DetailsView
-              entities={[]}
-              isLoading={false}
-              noResultsPlaceholder={
-                <div>
-                  Use the left panel to browse Synapse, then make a selection in
-                  this panel
-                </div>
-              }
-              {...sharedProps}
-              enableSelectAll={false}
-            />
-          )
+          case EntityDetailsListDataConfigurationType.USER_PROJECTS:
+            return (
+              <ProjectListDetails
+                projectsParams={config.getProjectParams!}
+                {...sharedProps}
+              />
+            )
+          case EntityDetailsListDataConfigurationType.PROMPT:
+            return (
+              <DetailsView
+                entities={[]}
+                isLoading={false}
+                noResultsPlaceholder={
+                  <div>
+                    Use the left panel to browse Synapse, then make a selection
+                    in this panel
+                  </div>
+                }
+                {...sharedProps}
+                enableSelectAll={false}
+              />
+            )
 
-        default:
-          console.warn(
-            'The configuration type does not map to a known view type. No Details view will be rendered. Invalid configuration: ',
-            config,
-          )
-          return <></>
+          default:
+            console.warn(
+              'The configuration type does not map to a known view type. No Details view will be rendered. Invalid configuration: ',
+              config,
+            )
+            return <></>
+        }
       }
-    }
-    setComponent(getComponentFromConfiguration(configuration))
-  }, [configuration, sharedProps])
+      setComponent(getComponentFromConfiguration(configuration))
+    }, [configuration, sharedProps])
 
-  return component
-}
+    return component
+  }


### PR DESCRIPTION
Fixes [SWC-5840](https://sagebionetworks.jira.com/browse/SWC-5840) and [SWC-5845](https://sagebionetworks.jira.com/browse/SWC-5845)

SWC-5840 is a bug where the entity finder doesn't utilize the full width if the viewport is wide enough. This is fixed by always autosizing with a min width, rather than disabling autosize in certain situations.

SWC-5845 is a bug where hidden items take up space in the Entity Finder's DetailsView table. The simple fix is to exclude hidden items from the table data. Before, were hiding them with CSS, and the row virtualization technique would still create a space for the hidden row.

I discovered SWC-5845 while testing search, so also added an optimization where we will only search for entity types that can be selected. This should make searching more efficient in all cases where not all entity types can be selected.