### PR TITLE
SWC-5784 - New design system color palettes and buttons

### DIFF
--- a/src/demo/containers/playground/ButtonDemo.tsx
+++ b/src/demo/containers/playground/ButtonDemo.tsx
@@ -6,32 +6,24 @@ import {
   DropdownButton,
   Table,
 } from 'react-bootstrap'
+import { Checkbox } from '../../../lib/containers/widgets/Checkbox'
 
 /**
  * A simple component that displays all of our reusable button styles
  */
 export const ButtonDemo: React.FunctionComponent = () => {
   const [buttonClass, setButtonClass] = useState('')
-  const [buttonVariant, setButtonVariant] = useState('primary-base')
+  const [buttonVariant, setButtonVariant] = useState('sds-primary')
+  const [isDisabled, setIsDisabled] = useState(false)
   const [buttonSize, setButtonSize] = useState<'sm' | 'lg' | undefined>(
     undefined,
   )
 
   const shapeClasses: string[] = ['', 'pill', 'pill-xl']
   const colorVariants: string[] = [
-    'primary-base',
-    'primary-active',
-    'primary-300',
-    'primary-500',
-    'primary-700',
-    'primary-900',
-    'light-primary-base',
-    'light-primary-active',
-    'light-primary-300',
-    'light-primary-500',
-    'light-primary-700',
-    'light-primary-900',
-    'gray-primary-500',
+    'sds-primary',
+    'outline',
+    'primary',
     'secondary',
     'light-secondary',
     'default',
@@ -88,12 +80,18 @@ export const ButtonDemo: React.FunctionComponent = () => {
             Large
           </Dropdown.Item>
         </DropdownButton>
+        <Checkbox
+          label="Is Disabled"
+          checked={isDisabled}
+          onChange={value => setIsDisabled(value)}
+        ></Checkbox>
       </>
 
       <Button
         className={buttonClass}
         size={buttonSize}
         variant={buttonVariant}
+        disabled={isDisabled}
         style={{ display: 'block', margin: '30px auto' }}
       >
         Custom Button

--- a/src/demo/style/DemoStyle.scss
+++ b/src/demo/style/DemoStyle.scss
@@ -1,7 +1,49 @@
-@use '../../lib/style/main.scss' with (
-    $primary-action-color: rgb(64, 123, 160),
-    $secondary-action-color: rgb(98, 172, 98),
-    $primary-bgcolor-rgba: rgba(64, 123, 160, 0.03),
+@use 'sass:map';
+
+// The color palettes used in Synapse should be maintained in the SWC project. They are copied here for demo purposes, and may not always be up-to-date.
+$synapse-primary-color-palette: (
+  100: #d7dee4,
+  200: #b0bdc9,
+  300: #889baf,
+  400: #617a94,
+  500: #395979,
+  600: #2e4761,
+  700: #223549,
+  800: #172430,
+  900: #0b1218,
 );
+
+$synapse-secondary-color-palette: (
+  100: #dae9e7,
+  200: #b5d3ce,
+  300: #90beb6,
+  400: #6ba89d,
+  500: #469285,
+  600: #38756a,
+  700: #2a6960,
+  800: #1c3a35,
+  900: #0e1d1b,
+);
+
+$synapse-tertiary-color-palette: (
+  100: #fbf4e0,
+  200: #f8e9c2,
+  300: #f4dda3,
+  400: #f1d285,
+  500: #edc766,
+  600: #be9f52,
+  700: #8e773d,
+  800: #5f5029,
+  900: #2f2814,
+);
+
+@use '../../lib/style/main.scss' with
+  (
+    $primary-action-color: map.get($synapse-primary-color-palette, 500),
+    $secondary-action-color: map.get($synapse-secondary-color-palette, 500),
+    $primary-color-palette: $synapse-primary-color-palette,
+    $secondary-color-palette: $synapse-secondary-color-palette,
+    $primary-bgcolor-rgba: rgba(64, 123, 160, 0.03)
+  );
 
 @use '../../lib/template_style/Index.scss';

--- a/src/lib/style/abstracts/_mixins.scss
+++ b/src/lib/style/abstracts/_mixins.scss
@@ -1,4 +1,5 @@
 @use './variables' as SRC;
+@use 'sass:map';
 // -----------------------------------------------------------------------------
 // This file contains all application-wide Sass mixins.
 // -----------------------------------------------------------------------------
@@ -48,9 +49,10 @@
 }
 
 @mixin sortable-table() {
-  thead>tr>th, thead:first-child>tr:first-child>th {
+  thead > tr > th,
+  thead:first-child > tr:first-child > th {
     padding: 10px 6px 5px 7px;
-    border: 1px solid #DDDDDF;
+    border: 1px solid #dddddf;
     color: #515359;
     span {
       display: inline-block;
@@ -111,10 +113,10 @@ $link-underline-color-default: adjust-color(
   color: SRC.$primary-action-color;
   text-decoration: none;
   font-weight: 700;
-  letter-spacing: .5px;
+  letter-spacing: 0.5px;
   border-bottom: 1px solid $link-underline-color-default;
   &:hover {
-    border-bottom: 2px solid SRC.$primary-action-color-700;
+    border-bottom: 2px solid map.get(SRC.$primary-color-palette, 700);
     margin-bottom: -1px;
   }
 }
@@ -124,9 +126,9 @@ $link-underline-color-default: adjust-color(
   text-decoration: none;
   font-weight: 700;
   border-bottom: 2px solid transparent;
-  letter-spacing: .5px;
+  letter-spacing: 0.5px;
   &:hover {
-    border-bottom: 2px solid SRC.$primary-action-color-700;
+    border-bottom: 2px solid map.get(SRC.$primary-color-palette, 700);
     margin-bottom: 0px;
   }
 }

--- a/src/lib/style/abstracts/_variables.scss
+++ b/src/lib/style/abstracts/_variables.scss
@@ -1,6 +1,28 @@
+@use 'sass:color';
+@use 'sass:map';
+
 // -----------------------------------------------------------------------------
 // This file contains all application-wide Sass variables.
 // -----------------------------------------------------------------------------
+
+// Colors defined by design: https://www.figma.com/file/0oPm5lLSUva8kyfVNMS6FA/Synapse-Style-%26-Component-Library?node-id=77%3A1232
+$colors: (
+  'gray-1000': #22252a,
+  'gray-900': #353a3f,
+  'gray-800': #4a5056,
+  'gray-700': #878e95,
+  'gray-600': #aeb5bc,
+  'gray-500': #d0d4d9,
+  'gray-400': #dfe2e6,
+  'gray-300': #eaecee,
+  'gray-200': #f1f3f5,
+  'gray-100': #fbfbfc,
+  'white': #ffffff,
+  'success': #32a330,
+  'info': #017fa5,
+  'warning': #cc9f00,
+  'error': #c13415,
+) !default;
 
 $gray-dark: #dcdcdc !default;
 $gray-light: #f9f9f9 !default;
@@ -51,37 +73,28 @@ $primary-action-color-active: adjust-color(
   $lightness: 0%
 ) !default;
 
-$primary-action-color-900: adjust-color(
-  $primary-action-color,
-  $saturation: 24%,
-  $lightness: -18%
-) !default;
-
-$primary-action-color-700: adjust-color(
-  $primary-action-color,
-  $saturation: 11%,
-  $lightness: -8%
-) !default;
-
-$primary-action-color-500: adjust-color(
-  $primary-action-color,
-  $saturation: 29%,
-  $lightness: -4%
-) !default;
-
-$primary-action-color-300: adjust-color(
-  $primary-action-color,
-  $saturation: -3%,
-  $lightness: 10%
-) !default;
-
 $primary-color-palette: (
-  base: $primary-action-color,
-  active: $primary-action-color-active,
-  300: $primary-action-color-300,
-  500: $primary-action-color-500,
-  700: $primary-action-color-700,
-  900: $primary-action-color-900,
+  100: adjust-color($primary-action-color, $saturation: -25%, $lightness: 50%),
+  200: adjust-color($primary-action-color, $saturation: -13%, $lightness: 20%),
+  300: adjust-color($primary-action-color, $saturation: -3%, $lightness: 10%),
+  400: adjust-color($primary-action-color, $saturation: -1%, $lightness: 5%),
+  500: $primary-action-color,
+  600: adjust-color($primary-action-color, $saturation: 5%, $lightness: -4%),
+  700: adjust-color($primary-action-color, $saturation: 11%, $lightness: -8%),
+  800: adjust-color($primary-action-color, $saturation: 18%, $lightness: -10%),
+  900: adjust-color($primary-action-color, $saturation: 24%, $lightness: -18%),
+) !default;
+
+$secondary-color-palette: (
+  100: adjust-color($secondary-action-color, $saturation: -25%, $lightness: 50%),
+  200: adjust-color($secondary-action-color, $saturation: -13%, $lightness: 20%),
+  300: adjust-color($secondary-action-color, $saturation: -3%, $lightness: 10%),
+  400: adjust-color($secondary-action-color, $saturation: -1%, $lightness: 5%),
+  500: $secondary-action-color,
+  600: adjust-color($secondary-action-color, $saturation: 5%, $lightness: -4%),
+  700: adjust-color($secondary-action-color, $saturation: 11%, $lightness: -8%),
+  800: adjust-color($secondary-action-color, $saturation: 18%, $lightness: -10%),
+  900: adjust-color($secondary-action-color, $saturation: 24%, $lightness: -18%),
 ) !default;
 
 /// Breakpoints map

--- a/src/lib/style/base/_icons.scss
+++ b/src/lib/style/base/_icons.scss
@@ -1,4 +1,5 @@
 @use '../abstracts/variables' as SRC;
+@use 'sass:map';
 
 .SRC-arrow-icon,
 .Icon-Plus,
@@ -12,12 +13,12 @@
 .SRC-r-icon,
 .SRC-python-icon {
   path {
-    fill: SRC.$primary-action-color-500;
+    fill: map.get(SRC.$primary-color-palette, 500);
   }
 }
 
 .SRC-terminal-icon > rect.outer {
-  fill: SRC.$primary-action-color-500;
+  fill: map.get(SRC.$primary-color-palette, 500);
 }
 
 .styled-svg-wrapper {
@@ -52,12 +53,12 @@
   &.themed {
     path,
     circle {
-      fill: SRC.$primary-action-color-500;
+      fill: map.get(SRC.$primary-color-palette, 500);
     }
     .icon-kinomics,
     .icon-proteomics {
       path {
-        stroke: SRC.$primary-action-color-500;
+        stroke: map.get(SRC.$primary-color-palette, 500);
         fill: none;
       }
     }
@@ -65,7 +66,7 @@
       .styled-svg-wrapper {
         display: inline-flex;
         padding: 2px;
-        background-color: rgba(SRC.$primary-action-color-500, 0.1);
+        background-color: rgba(map.get(SRC.$primary-color-palette, 500), 0.1);
         border-radius: 50%;
         margin: 0 2px;
       }
@@ -75,7 +76,7 @@
 
 .SRC-Sort-Icon-Active {
   padding: 2px;
-  background-color: SRC.$primary-action-color-500;
+  background-color: map.get(SRC.$primary-color-palette, 500);
   path {
     fill: white;
   }
@@ -85,7 +86,7 @@
   padding: 2px;
 
   path {
-    fill: SRC.$primary-action-color-500;
+    fill: map.get(SRC.$primary-color-palette, 500);
   }
 }
 

--- a/src/lib/style/bootstrap4_backports/_base-import.scss
+++ b/src/lib/style/bootstrap4_backports/_base-import.scss
@@ -1,5 +1,6 @@
 @use '../abstracts/variables' as SRC;
 @use 'sass:color';
+@use 'sass:map';
 
 .bootstrap-4-backport {
   //initial bootstrap config based on Synapse design
@@ -157,5 +158,50 @@
       $hover-background: SRC.$gray-light,
       $active-background: SRC.$gray-light
     );
+  }
+
+  // Primary button based on Synapse Design System
+  // See https://www.figma.com/file/0oPm5lLSUva8kyfVNMS6FA/Synapse-Style-%26-Component-Library?node-id=53%3A1189
+  .btn-sds-primary {
+    @include button-variant(
+      $background: map.get(SRC.$primary-color-palette, 500),
+      $border: map.get(SRC.$primary-color-palette, 500),
+      $hover-background: map.get(SRC.$primary-color-palette, 600),
+      $hover-border: map.get(SRC.$primary-color-palette, 600),
+      $active-background: map.get(SRC.$primary-color-palette, 700),
+      $active-border: map.get(SRC.$primary-color-palette, 700)
+    );
+    border-radius: 0px;
+    font-weight: 900;
+    &:hover {
+      box-shadow: none; // ?
+    }
+
+    &:disabled {
+      color: map.get(SRC.$colors, 'gray-600');
+      background-color: map.get(SRC.$colors, 'gray-400');
+      border-color: map.get(SRC.$colors, 'gray-400');
+    }
+  }
+
+  // Secondary button based on Synapse Design System
+  // See https://www.figma.com/file/0oPm5lLSUva8kyfVNMS6FA/Synapse-Style-%26-Component-Library?node-id=53%3A1216
+  .btn-outline {
+    @include button-outline-variant(
+      $color: map.get(SRC.$primary-color-palette, 500),
+      $color-hover: map.get(SRC.$primary-color-palette, 600),
+      $active-background: rgba(255, 255, 255, 0),
+      $active-border: map.get(SRC.$primary-color-palette, 700)
+    );
+    border-radius: 0px;
+    font-weight: 900;
+    &:hover {
+      box-shadow: none; // ?
+    }
+
+    &:disabled {
+      color: map.get(SRC.$colors, 'gray-600');
+      border-color: map.get(SRC.$colors, 'gray-400');
+    }
   }
 }

--- a/src/lib/style/components/_carousel.scss
+++ b/src/lib/style/components/_carousel.scss
@@ -1,4 +1,5 @@
 @use '../abstracts/variables' as SRC;
+@use 'sass:map';
 
 .SRC-Carousel {
   padding-top: 10px;
@@ -31,14 +32,14 @@
       width: 16px;
       height: 16px;
       background: none;
-      border: 1px solid SRC.$primary-action-color-500;
+      border: 1px solid map.get(SRC.$primary-color-palette, 500);
     }
 
     .BrainhubCarousel__dot--selected::before {
       width: 16px;
       height: 16px;
-      background-color: SRC.$primary-action-color-500;
-      border: 1px solid SRC.$primary-action-color-500;
+      background-color: map.get(SRC.$primary-color-palette, 500);
+      border: 1px solid map.get(SRC.$primary-color-palette, 500);
     }
   }
 }

--- a/src/lib/style/components/_project-view-card.scss
+++ b/src/lib/style/components/_project-view-card.scss
@@ -1,4 +1,5 @@
 @use '../abstracts/variables' as SRC;
+@use 'sass:map';
 
 .ProjectViewCard {
   word-wrap: break-word;
@@ -24,7 +25,7 @@
   &__ImagePlaceholder {
     width: 100%;
     height: 25%;
-    background: SRC.$primary-action-color-300;
+    background: map.get(SRC.$primary-color-palette, 300);
   }
 
   &__ProjectName {

--- a/src/lib/style/components/_query-filter.scss
+++ b/src/lib/style/components/_query-filter.scss
@@ -1,11 +1,12 @@
 @use '../abstracts/variables' as SRC;
+@use 'sass:map';
 
 .QueryFilter {
   &__title {
     font-weight: bold;
   }
   padding: 2rem;
-  background-color: rgba(SRC.$primary-action-color-500, 0.05);
+  background-color: rgba(map.get(SRC.$primary-color-palette, 500), 0.05);
   &__facet {
     margin: 2rem 0;
     &:first-child {

--- a/src/lib/style/components/entity_finder/_entity-finder.scss
+++ b/src/lib/style/components/entity_finder/_entity-finder.scss
@@ -1,5 +1,6 @@
 @use '../../abstracts/variables' as SRC;
 @use 'sass:color';
+@use 'sass:map';
 
 $-border-size: 1px;
 $-header-height: 45px;
@@ -51,7 +52,7 @@ $-splitter-width: 12px;
       top: 1px;
     }
     .ClearSearchIcon {
-      color: SRC.$primary-action-color-500;
+      color: map.get(SRC.$primary-color-palette, 500);
       cursor: pointer;
       position: relative;
       left: -20px;

--- a/src/lib/style/components/entity_finder/_selection-pane.scss
+++ b/src/lib/style/components/entity_finder/_selection-pane.scss
@@ -1,5 +1,6 @@
 @use '../../abstracts/variables' as SRC;
 @use 'sass:color';
+@use 'sass:map';
 
 .EntityFinderSelectionPane {
   width: 100%;
@@ -28,7 +29,7 @@
     }
 
     &__DeselectButton {
-      color: SRC.$primary-action-color-500;
+      color: map.get(SRC.$primary-color-palette, 500);
       cursor: pointer;
     }
   }


### PR DESCRIPTION
Utilizing this in the new component. I think we will likely apply these changes to Synapse before the component comes out of experimental mode.

The only visual change is that the primary palette's '500' item is no longer a super-saturated version of the primary action color. This change will be visible in a few Synapse.org components and portals, but shouldn't break anything.