### PR TITLE
SWC-5948

### DIFF
--- a/src/__tests__/lib/containers/entity_finder/tree/TreeNode.test.tsx
+++ b/src/__tests__/lib/containers/entity_finder/tree/TreeNode.test.tsx
@@ -5,7 +5,7 @@ import { when } from 'jest-when'
 import React from 'react'
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
 import {
-  NodeAppearance,
+  EntityTreeNodeType,
   TreeNode,
   TreeNodeProps,
 } from '../../../../../lib/containers/entity_finder/tree/TreeNode'
@@ -41,7 +41,7 @@ const defaultProps: TreeNodeProps = {
   },
   selected: Map([['syn456', NO_VERSION_NUMBER]]),
   setSelectedId: mockSetSelectedId,
-  appearance: NodeAppearance.SELECT,
+  treeNodeType: EntityTreeNodeType.SELECT,
   selectableTypes: Object.values(EntityType),
 }
 
@@ -212,9 +212,10 @@ describe('TreeNode tests', () => {
     await waitFor(() => expect(mockFetchNextPageOfChildren).toBeCalled())
   })
 
-  it('Has aria-selected as true when the selectedId matches the entity ID', async () => {
+  it('Has aria-selected as true when the selectedId matches the entity ID (SELECT)', async () => {
     // Set auto-expand to render children and ensure that they don't get the selected attribute
     renderComponent({
+      treeNodeType: EntityTreeNodeType.SELECT,
       selected: Map([[defaultProps.entityHeader!.id, NO_VERSION_NUMBER]]),
       autoExpand: () => true,
     })
@@ -239,6 +240,35 @@ describe('TreeNode tests', () => {
       'false',
     )
   })
+
+  it('Has aria-selected as true when the currentContainer matches the entity ID (BROWSE)', async () => {
+    renderComponent({
+      treeNodeType: EntityTreeNodeType.BROWSE,
+      currentContainer: defaultProps.entityHeader!.id,
+      autoExpand: () => true,
+    })
+    await waitFor(() =>
+      expect(mockUseGetEntityChildren).toBeCalledWith(
+        expect.objectContaining({
+          parentId: expect.stringContaining(defaultProps.entityHeader!.id),
+        }),
+        expect.anything(),
+      ),
+    )
+    expect(screen.getAllByRole('treeitem')[0]).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    expect(screen.getAllByRole('treeitem')[1]).toHaveAttribute(
+      'aria-selected',
+      'false',
+    )
+    expect(screen.getAllByRole('treeitem')[2]).toHaveAttribute(
+      'aria-selected',
+      'false',
+    )
+  })
+
   it('invokes setSelectedId when the item is clicked ', async () => {
     // Set auto-expand to automatically render children
     renderComponent({

--- a/src/__tests__/lib/containers/entity_finder/tree/TreeView.test.tsx
+++ b/src/__tests__/lib/containers/entity_finder/tree/TreeView.test.tsx
@@ -18,7 +18,7 @@ import {
   PaginatedResults,
   ProjectHeader,
 } from '../../../../../lib/utils/synapseTypes'
-import { NodeAppearance } from '../../../../../lib/containers/entity_finder/tree/TreeNode'
+import { EntityTreeNodeType } from '../../../../../lib/containers/entity_finder/tree/TreeNode'
 import userEvent from '@testing-library/user-event'
 import { SynapseContextProvider } from '../../../../../lib/utils/SynapseContext'
 import { MOCK_CONTEXT_VALUE } from '../../../../../mocks/MockSynapseContext'
@@ -78,7 +78,7 @@ const defaultProps: TreeViewProps = {
   setDetailsViewConfiguration: mockSetDetailsViewConfiguration,
   setBreadcrumbItems: mockSetBreadcrumbItems,
   toggleSelection: mockToggleSelection,
-  nodeAppearance: NodeAppearance.SELECT,
+  treeNodeType: EntityTreeNodeType.SELECT,
   showScopeAsRootNode: true,
   selectableTypes: Object.values(EntityType),
 }

--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -30,7 +30,7 @@ import {
   EntityDetailsListDataConfigurationType,
 } from './details/EntityDetailsList'
 import { SelectionPane } from './SelectionPane'
-import { NodeAppearance } from './tree/TreeNode'
+import { EntityTreeNodeType } from './tree/TreeNode'
 import { FinderScope, TreeView } from './tree/TreeView'
 
 library.add(faTimes, faSearch)
@@ -355,7 +355,7 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                     projectId={projectId}
                     initialContainer={initialContainer}
                     showScopeAsRootNode={false}
-                    nodeAppearance={NodeAppearance.SELECT}
+                    treeNodeType={EntityTreeNodeType.SELECT}
                     selectableTypes={selectableTypes}
                   />
                 </div>
@@ -380,7 +380,7 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                             initialScope={initialScope}
                             projectId={projectId}
                             initialContainer={initialContainer}
-                            nodeAppearance={NodeAppearance.BROWSE}
+                            treeNodeType={EntityTreeNodeType.BROWSE}
                             setBreadcrumbItems={setBreadcrumbs}
                             selectableTypes={visibleTypesInTree}
                           />

--- a/src/lib/containers/entity_finder/tree/TreeNode.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeNode.tsx
@@ -17,7 +17,7 @@ export type RootNodeConfiguration = {
   children: (Pick<EntityHeader, 'name' | 'id' | 'type'> | ProjectHeader)[]
 }
 
-export enum NodeAppearance {
+export enum EntityTreeNodeType {
   SELECT,
   BROWSE,
 }
@@ -29,7 +29,7 @@ export type TreeNodeProps = {
   level?: number
   autoExpand?: (entityId: string) => boolean
   visibleTypes?: EntityType[]
-  appearance: NodeAppearance
+  treeNodeType: EntityTreeNodeType
   /* If rootNodeConfiguration is defined, then entityHeader will be ignored */
   rootNodeConfiguration?: RootNodeConfiguration
   selectableTypes: EntityType[]
@@ -45,7 +45,7 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
   autoExpand = () => false,
   visibleTypes = [EntityType.PROJECT, EntityType.FOLDER],
   rootNodeConfiguration,
-  appearance,
+  treeNodeType,
   selectableTypes,
   currentContainer,
 }: TreeNodeProps) => {
@@ -53,7 +53,7 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
   const nodeId = isRootNode ? 'root' : entityHeader!.id
 
   const isSelected =
-    appearance === NodeAppearance.SELECT
+    treeNodeType === EntityTreeNodeType.SELECT
       ? selected.has(nodeId)
       : currentContainer === nodeId
 
@@ -118,7 +118,7 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
   return (
     <div
       className={`Node ${
-        appearance === NodeAppearance.SELECT ? 'SelectNode' : 'BrowseNode'
+        treeNodeType === EntityTreeNodeType.SELECT ? 'SelectNode' : 'BrowseNode'
       }`}
       role="treeitem"
       aria-selected={isSelected}
@@ -159,7 +159,7 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
         ) : (
           <span></span>
         )}
-        {appearance === NodeAppearance.SELECT && ( // SWC-5592
+        {treeNodeType === EntityTreeNodeType.SELECT && ( // SWC-5592
           <div className="EntityIcon">
             {!isRootNode && entityHeader && (
               <EntityTypeIcon type={getEntityTypeFromHeader(entityHeader)} />
@@ -169,7 +169,7 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
         <div className="EntityName" data-for={TOOLTIP_ID} data-tip={nodeName}>
           <span>{nodeName}</span>
         </div>
-        {appearance === NodeAppearance.SELECT && (
+        {treeNodeType === EntityTreeNodeType.SELECT && (
           <EntityBadgeIcons
             entityId={nodeId}
             showHasDiscussionThread={false}
@@ -193,7 +193,7 @@ export const TreeNode: React.FunctionComponent<TreeNodeProps> = ({
                 level={level + 1}
                 autoExpand={autoExpand}
                 visibleTypes={visibleTypes}
-                appearance={appearance}
+                treeNodeType={treeNodeType}
                 selectableTypes={selectableTypes}
                 currentContainer={currentContainer}
               />

--- a/src/lib/containers/entity_finder/tree/TreeView.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeView.tsx
@@ -148,12 +148,10 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
     },
   )
 
-  const {
-    data: currentContainerBundle,
-    isSuccess: isSuccessBundle,
-  } = useGetEntityBundle(currentContainer!, undefined, undefined, {
-    enabled: !!currentContainer && currentContainer !== 'root',
-  })
+  const { data: currentContainerBundle, isSuccess: isSuccessBundle } =
+    useGetEntityBundle(currentContainer!, undefined, undefined, {
+      enabled: !!currentContainer && currentContainer !== 'root',
+    })
 
   const { ref, inView } = useInView({ rootMargin: '500px' })
 
@@ -407,6 +405,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
               rootNodeConfiguration={rootNodeConfiguration}
               appearance={nodeAppearance}
               selectableTypes={selectableTypes}
+              currentContainer={currentContainer}
             />
           ) : (
             topLevelEntities.map(entity => (
@@ -420,6 +419,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
                 entityHeader={entity}
                 appearance={nodeAppearance}
                 selectableTypes={selectableTypes}
+                currentContainer={currentContainer}
               />
             ))
           )}

--- a/src/lib/containers/entity_finder/tree/TreeView.tsx
+++ b/src/lib/containers/entity_finder/tree/TreeView.tsx
@@ -21,7 +21,7 @@ import {
   EntityDetailsListDataConfiguration,
   EntityDetailsListDataConfigurationType,
 } from '../details/EntityDetailsList'
-import { NodeAppearance, TreeNode } from './TreeNode'
+import { EntityTreeNodeType, TreeNode } from './TreeNode'
 import { Map } from 'immutable'
 
 const isEntityIdInPath = (entityId: string, path: EntityPath): boolean => {
@@ -66,7 +66,7 @@ export type TreeViewProps = {
   setBreadcrumbItems?: (items: BreadcrumbItem[]) => void
   /** Determines whether to show the root node corresponding to the selected scope */
   showScopeAsRootNode?: boolean
-  nodeAppearance: NodeAppearance
+  treeNodeType: EntityTreeNodeType
   /** The entity types that may be selected. */
   selectableTypes: EntityType[]
 }
@@ -86,7 +86,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
   setDetailsViewConfiguration,
   setBreadcrumbItems,
   showScopeAsRootNode = true,
-  nodeAppearance,
+  treeNodeType,
   selectableTypes,
 }: TreeViewProps) => {
   const DEFAULT_CONFIGURATION: EntityDetailsListDataConfiguration = {
@@ -105,7 +105,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
   const [currentContainer, setCurrentContainer] = useState<
     string | 'root' | null
   >(
-    nodeAppearance === NodeAppearance.BROWSE
+    treeNodeType === EntityTreeNodeType.BROWSE
       ? initialContainer
       : initialContainer,
   )
@@ -351,7 +351,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
   return (
     <div
       className={`TreeView ${
-        nodeAppearance === NodeAppearance.SELECT ? 'SelectTree' : 'BrowseTree'
+        treeNodeType === EntityTreeNodeType.SELECT ? 'SelectTree' : 'BrowseTree'
       }`}
     >
       <div className="Header">
@@ -403,7 +403,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
               visibleTypes={visibleTypes}
               autoExpand={shouldAutoExpand}
               rootNodeConfiguration={rootNodeConfiguration}
-              appearance={nodeAppearance}
+              treeNodeType={treeNodeType}
               selectableTypes={selectableTypes}
               currentContainer={currentContainer}
             />
@@ -417,7 +417,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
                 visibleTypes={visibleTypes}
                 autoExpand={shouldAutoExpand}
                 entityHeader={entity}
-                appearance={nodeAppearance}
+                treeNodeType={treeNodeType}
                 selectableTypes={selectableTypes}
                 currentContainer={currentContainer}
               />

--- a/src/lib/style/components/entity_finder/_breadcrumbs.scss
+++ b/src/lib/style/components/entity_finder/_breadcrumbs.scss
@@ -1,4 +1,5 @@
 @use '../../abstracts/variables' as SRC;
+@use '../../abstracts/mixins' as mixins;
 @use './entity-finder' as EntityFinder;
 
 .Breadcrumbs {
@@ -10,17 +11,16 @@
   white-space: nowrap;
   overflow-x: auto;
   .BreadcrumbItem {
-    color: SRC.$primary-action-color;
-  }
-  .BreadcrumbItem:hover {
-    text-decoration: underline;
+    @include mixins.normalLink();
+    font-weight: normal;
   }
   .BreadcrumbItem.Current {
     color: unset;
     font-weight: bold;
     cursor: unset;
-  }
-  .BreadcrumbItem.Current:hover {
-    text-decoration: unset;
+
+    &:hover {
+      text-decoration: unset;
+    }
   }
 }

--- a/src/lib/style/components/entity_finder/_tree-node-browse.scss
+++ b/src/lib/style/components/entity_finder/_tree-node-browse.scss
@@ -1,4 +1,5 @@
 @use '../../abstracts/variables' as SRC;
+@use '../../abstracts/mixins' as SrcMixins;
 @use './entity-finder' as EntityFinder;
 @use 'sass:color';
 
@@ -6,19 +7,28 @@
   .Node.BrowseNode {
     .NodeContent {
       grid-template-columns: [toggle] 20px [name] auto;
-      font-size: small;
       padding: 5px 10px 5px 20px;
       .ExpandButton {
         font-size: 15px;
       }
     }
   }
-  .Node[aria-disabled='false'] {
+  .Node[aria-disabled='false'][aria-selected='false']
+    > .NodeContent
+    > .EntityName {
+    @include SrcMixins.normalLink();
+    font-weight: normal;
+
+    &:hover {
+      // The default offset provided by normalLink() is too much for this component and the underline may not appear
+      text-underline-offset: 2px;
+    }
   }
 
-  .Node.BrowseNode[aria-disabled='false'][aria-selected='true'] {
-    > .NodeContent {
-      font-weight: bold;
-    }
+  .Node.BrowseNode[aria-disabled='false'][aria-selected='true']
+    > .NodeContent
+    > .EntityName
+    > span {
+    font-weight: bold;
   }
 }


### PR DESCRIPTION
When in Entity Finder's dual-pane mode, add styling to the tree items to make it seem more responsive to input and intuitive to click.

The styles used in the Tree view and the breadcrumbs are now more in-line with the link styles across Synapse.

https://user-images.githubusercontent.com/17580037/152576600-756858a8-8916-45c7-8e3b-8803e5ff4523.mov

