### PR TITLE
SWC-5805 - use `current-password` for login

### DIFF
--- a/src/__tests__/lib/containers/Login.test.tsx
+++ b/src/__tests__/lib/containers/Login.test.tsx
@@ -10,7 +10,7 @@ SynapseClient.login = jest.fn().mockResolvedValue({
   authenticationReceipt: 'xyz-456',
 })
 
-describe('Functionality of Login Component ', () => {
+describe('Functionality of Login Component', () => {
   const callback = jest.fn()
 
   it('renders', () => {

--- a/src/lib/containers/Login.tsx
+++ b/src/lib/containers/Login.tsx
@@ -165,25 +165,25 @@ class Login extends React.Component<Props, State> {
           or
         </div>
         <Form onSubmit={this.handleLogin}>
-          <label htmlFor={'exampleEmail'}>Username or Email Address</label>
+          <label htmlFor={'username'}>Username or Email Address</label>
           <Form.Control
             required
             autoComplete="username"
             placeholder="Username or Email Address"
             className="LoginComponent__Input"
-            id="exampleEmail"
+            id="username"
             name="username"
             type="text"
             value={this.state.username}
             onChange={this.handleChange}
           />
-          <label htmlFor={'examplePassword'}>Password</label>
+          <label htmlFor={'current-password'}>Password</label>
           <Form.Control
             required
-            autoComplete="password"
+            autoComplete="current-password"
             placeholder="Password"
             className="LoginComponent__Input"
-            id="examplePassword"
+            id="current-password"
             name="password"
             type="password"
             value={this.state.password}


### PR DESCRIPTION
We'll want to make sure this update hits SWC, Portals, and the OAuth app