### PR TITLE
Replace Travis with GitHub Actions for automated test runs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Build/Test CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'yarn'
+    - run: yarn test:coverage
+    - run: yarn build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,5 +26,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
+    - run: yarn install --frozen-lockfile
     - run: yarn test:coverage
     - run: yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - 15
-script:
-  - yarn test:coverage
-  - yarn build


### PR DESCRIPTION
Pretty much the same build, but test on both Node 14 and Node 16 (12 is active but no longer supported in ~1 month).

In my opinion, knowing that our package supports all active LTS versions of Node is worth the risk of 2x likelier to fail due to test instability. I'd rather identify and fix those tests anyways.