### PR TITLE
SWC-6086

### DIFF
--- a/src/__tests__/lib/containers/DownloadConfirmation.test.tsx
+++ b/src/__tests__/lib/containers/DownloadConfirmation.test.tsx
@@ -74,29 +74,18 @@ const addFilesToDownloadListResponse: AddToDownloadListResponse = {
   numberOfFilesAdded: 1,
 }
 
-const queryContext: Partial<QueryContextType> = {
-  getLastQueryRequest: () => queryBundleRequest,
-  data: queryBundleResponse,
-}
-
-const queryVisualizationContext: Partial<QueryVisualizationContextType> = {
-  topLevelControlsState: {
-    showDownloadConfirmation: true,
-  },
-}
-
 function renderComponent(
   componentProps?: DownloadConfirmationProps,
   wrapperProps?: SynapseContextType,
 ) {
   return render(
-    <QueryContextProvider queryContext={queryContext}>
-      <QueryVisualizationContextProvider
-        queryVisualizationContext={queryVisualizationContext}
-      >
-        <DownloadConfirmation {...componentProps} />
-      </QueryVisualizationContextProvider>
-    </QueryContextProvider>,
+    // <QueryContextProvider queryContext={queryContext}>
+    //   <QueryVisualizationContextProvider
+    //     queryVisualizationContext={queryVisualizationContext}
+    //   >
+    <DownloadConfirmation {...componentProps} />,
+    //   </QueryVisualizationContextProvider>
+    // </QueryContextProvider>,
     {
       wrapper: createWrapper(wrapperProps),
     },
@@ -113,8 +102,17 @@ describe('DownloadConfirmation', () => {
   getDownloadListStatisticsResultsFn = SynapseClient.getDownloadListStatistics =
     jest.fn().mockResolvedValue(filesStatisticsResponse)
 
+  SynapseClient.getQueryTableResults = jest
+    .fn()
+    .mockResolvedValue(queryBundleResponse)
+
   const props: DownloadConfirmationProps = {
     fnClose: mockClose,
+    topLevelControlsState: {
+      showDownloadConfirmation: true,
+    },
+    setTopLevelControlsState: jest.fn(),
+    getLastQueryRequest: () => queryBundleRequest,
   }
 
   beforeEach(() => {

--- a/src/lib/containers/download_list/DownloadConfirmation.tsx
+++ b/src/lib/containers/download_list/DownloadConfirmation.tsx
@@ -4,16 +4,16 @@ import useDeepCompareEffect from 'use-deep-compare-effect'
 import { SynapseClient } from '../../utils'
 import { useGetDownloadListStatistics } from '../../utils/hooks/SynapseAPI/useGetDownloadListStatistics'
 import { useGetEntityChildren } from '../../utils/hooks/SynapseAPI/useGetEntityChildren'
+import useGetQueryResultBundle from '../../utils/hooks/SynapseAPI/useGetQueryResultBundle'
 import { useSynapseContext } from '../../utils/SynapseContext'
 import { EntityType, QueryBundleRequest } from '../../utils/synapseTypes/'
 import { AddToDownloadListRequest } from '../../utils/synapseTypes/DownloadListV2/AddToDownloadListRequest'
 import { FilesStatisticsResponse } from '../../utils/synapseTypes/DownloadListV2/QueryResponseDetails'
-import { useQueryVisualizationContext } from '../QueryVisualizationWrapper'
+import { TopLevelControlsState } from '../QueryVisualizationWrapper'
 import {
   QUERY_FILTERS_COLLAPSED_CSS,
   QUERY_FILTERS_EXPANDED_CSS,
 } from '../QueryWrapper'
-import { useQueryContext } from '../QueryWrapper'
 import SignInButton from '../SignInButton'
 import { displayToast } from '../ToastMessage'
 import DownloadDetails from './DownloadDetails'
@@ -27,6 +27,13 @@ enum StatusEnum {
 }
 
 export type DownloadConfirmationProps = {
+  // TODO: Use useQueryContext/useQueryVisualizationContext instead of passing in props
+  // This component is used outside of a QueryWrapper in SWC so that needs to be fixed first.
+  getLastQueryRequest: () => QueryBundleRequest
+  topLevelControlsState?: TopLevelControlsState
+  setTopLevelControlsState?: React.Dispatch<
+    React.SetStateAction<TopLevelControlsState>
+  >
   fnClose?: () => void
   folderId?: string
   downloadCartPageUrl?: string
@@ -159,10 +166,17 @@ const DownloadConfirmationContent = (props: {
 //============= DownloadConfirmation component =============
 
 export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationProps> =
-  ({ folderId, fnClose, downloadCartPageUrl = '/DownloadCart' }) => {
-    const { data: queryResultBundle, getLastQueryRequest } = useQueryContext()
-    const { topLevelControlsState, setTopLevelControlsState } =
-      useQueryVisualizationContext()
+  ({
+    getLastQueryRequest,
+    topLevelControlsState,
+    setTopLevelControlsState,
+    folderId,
+    fnClose,
+    downloadCartPageUrl = '/DownloadCart',
+  }) => {
+    const { data: queryResultBundle } = useGetQueryResultBundle(
+      getLastQueryRequest(),
+    )
     const { accessToken } = useSynapseContext()
     const [status, setStatus] = useState<StatusEnum>(
       accessToken ? StatusEnum.LOADING_INFO : StatusEnum.SIGNED_OUT,
@@ -243,10 +257,12 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
     const onCancel = fnClose
       ? () => fnClose()
       : () => {
-          setTopLevelControlsState(state => ({
-            ...state,
-            showDownloadConfirmation: false,
-          }))
+          if (setTopLevelControlsState) {
+            setTopLevelControlsState(state => ({
+              ...state,
+              showDownloadConfirmation: false,
+            }))
+          }
         }
 
     const triggerAddToDownload = async () => {
@@ -286,7 +302,7 @@ export const DownloadConfirmation: React.FunctionComponent<DownloadConfirmationP
           transition={false}
           className={`download-confirmation ${
             StatusConstruct[status].className
-          } ${topLevelControlsState.showDownloadConfirmation ? '' : 'hidden'}
+          } ${topLevelControlsState?.showDownloadConfirmation ? '' : 'hidden'}
           ${
             showFacetFilter
               ? QUERY_FILTERS_EXPANDED_CSS

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -193,6 +193,15 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> =
                           )}
                           <SqlEditor />
                           <DownloadConfirmation
+                            getLastQueryRequest={
+                              queryContext.getLastQueryRequest
+                            }
+                            topLevelControlsState={
+                              queryVisualizationContext.topLevelControlsState
+                            }
+                            setTopLevelControlsState={
+                              queryVisualizationContext.setTopLevelControlsState
+                            }
                             downloadCartPageUrl={downloadCartPageUrl}
                           />
                           <TopLevelControls

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -132,6 +132,7 @@ import { DownloadListManifestRequest } from './synapseTypes/DownloadListV2/Downl
 import { DownloadListPackageRequest } from './synapseTypes/DownloadListV2/DownloadListPackageRequest'
 import { DownloadListPackageResponse } from './synapseTypes/DownloadListV2/DownloadListPackageResponse'
 import { DownloadListQueryRequest } from './synapseTypes/DownloadListV2/DownloadListQueryRequest'
+import { DownloadListQueryResponse } from './synapseTypes/DownloadListV2/DownloadListQueryResponse'
 import {
   ActionRequiredRequest,
   AvailableFilesRequest,
@@ -2853,11 +2854,12 @@ const getDownloadListJobResponse = async (
     undefined,
     BackendDestinationEnum.REPO_ENDPOINT,
   )
-  return getAsyncResultBodyFromJobId(
+  const response = await getAsyncResultBodyFromJobId<DownloadListQueryResponse>(
     asyncJobId.token,
     `/repo/v1/download/list/query/async/get/${asyncJobId.token}`,
     accessToken,
   )
+  return response.responseDetails
 }
 
 /**


### PR DESCRIPTION
* DownloadConfirmation should use query props instead of context, because SWC uses it outside of the QueryWrapper
* Download list query API response body has a field `responseDetails` that should be used