### PR TITLE
Improve test suite stability

### DIFF
--- a/src/__tests__/lib/containers/personal_access_token/AccessTokenPage.test.tsx
+++ b/src/__tests__/lib/containers/personal_access_token/AccessTokenPage.test.tsx
@@ -153,16 +153,22 @@ describe('basic functionality', () => {
     renderComponent(props)
 
     // Click the button to render the modal
-    userEvent.click(
-      await screen.findByRole('button', { name: 'Create New Token' }),
-    )
+    const openModalButton = await screen.findByRole('button', {
+      name: 'Create New Token',
+    })
+    userEvent.click(openModalButton)
 
     // Simulate creation
-    userEvent.click(
-      await screen.findByRole('button', { name: 'Invoke onCreate' }),
-    )
+    const createTokenButton = await screen.findByRole('button', {
+      name: 'Invoke onCreate',
+    })
+    userEvent.click(createTokenButton)
 
-    expect(SynapseClient.getPersonalAccessTokenRecords).toHaveBeenCalledTimes(2)
+    await waitFor(() =>
+      expect(SynapseClient.getPersonalAccessTokenRecords).toHaveBeenCalledTimes(
+        2,
+      ),
+    )
   })
 
   it('rerenders the list when onDelete is called', async () => {
@@ -175,9 +181,14 @@ describe('basic functionality', () => {
     renderComponent(props)
 
     // Trigger onDelete on a card.
-    userEvent.click(await screen.findByText('Invoke onDelete'))
+    const deleteButton = await screen.findByText('Invoke onDelete')
+    userEvent.click(deleteButton)
 
-    expect(SynapseClient.getPersonalAccessTokenRecords).toHaveBeenCalledTimes(2)
+    await waitFor(() =>
+      expect(SynapseClient.getPersonalAccessTokenRecords).toHaveBeenCalledTimes(
+        2,
+      ),
+    )
   })
 
   it('loads a second page and shows the load more button only when there is a next page token', async () => {


### PR DESCRIPTION
We have had inconsistent test runs in our CI and npm publish builds. [The last release took 3 runs to get a clean build](https://github.com/Sage-Bionetworks/Synapse-React-Client/actions/runs/2163664689), with 0 code changes. Unfortunately, the logs do not make it clear why the build has failed.

So I diff'd the fail logs with the success log and the major difference was this warning, which was present in the failed runs but absent from the successful run:

```

  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Warning: An update to AccessTokenPage inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in AccessTokenPage (at AccessTokenPage.test.tsx:98)
        in QueryClientProvider (at SynapseContext.tsx:46)
        in SynapseContextProvider (at TestingLibraryUtils.tsx:33)
        in RtlWrapper".

      60 |         })
      61 |         .catch(err => {
    > 62 |           setIsLoading(false)
         |           ^
      63 |           setErrorMessage(err)
      64 |           setShowErrorMessage(true)
      65 |         })

      at console.error (node_modules/@jest/console/build/BufferedConsole.js:163:10)
      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:88:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:60:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-dom/cjs/react-dom.development.js:23284:7)
      at setIsLoading (node_modules/react-dom/cjs/react-dom.development.js:15656:9)
      at src/lib/containers/personal_access_token/AccessTokenPage.tsx:62:11


  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
        in AccessTokenPage (at AccessTokenPage.test.tsx:98)
        in QueryClientProvider (at SynapseContext.tsx:46)
        in SynapseContextProvider (at TestingLibraryUtils.tsx:33)
        in RtlWrapper".

      60 |         })
      61 |         .catch(err => {
    > 62 |           setIsLoading(false)
         |           ^
      63 |           setErrorMessage(err)
      64 |           setShowErrorMessage(true)
      65 |         })

      at console.error (node_modules/@jest/console/build/BufferedConsole.js:163:10)
      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:88:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:60:5)
      at warnAboutUpdateOnUnmountedFiberInDEV (node_modules/react-dom/cjs/react-dom.development.js:23161:5)
      at scheduleUpdateOnFiber (node_modules/react-dom/cjs/react-dom.development.js:21169:5)
      at setIsLoading (node_modules/react-dom/cjs/react-dom.development.js:15660:5)
      at src/lib/containers/personal_access_token/AccessTokenPage.tsx:62:11


  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Warning: An update to AccessTokenPage inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in AccessTokenPage (at AccessTokenPage.test.tsx:98)
        in QueryClientProvider (at SynapseContext.tsx:46)
        in SynapseContextProvider (at TestingLibraryUtils.tsx:33)
        in RtlWrapper".

      61 |         .catch(err => {
      62 |           setIsLoading(false)
    > 63 |           setErrorMessage(err)
         |           ^
      64 |           setShowErrorMessage(true)
      65 |         })
      66 |     }

      at console.error (node_modules/@jest/console/build/BufferedConsole.js:163:10)
      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:88:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:60:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-dom/cjs/react-dom.development.js:23284:7)
      at setErrorMessage (node_modules/react-dom/cjs/react-dom.development.js:15656:9)
      at src/lib/containers/personal_access_token/AccessTokenPage.tsx:63:11


  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Warning: An update to AccessTokenPage inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://fb.me/react-wrap-tests-with-act
        in AccessTokenPage (at AccessTokenPage.test.tsx:98)
        in QueryClientProvider (at SynapseContext.tsx:46)
        in SynapseContextProvider (at TestingLibraryUtils.tsx:33)
        in RtlWrapper".

      62 |           setIsLoading(false)
      63 |           setErrorMessage(err)
    > 64 |           setShowErrorMessage(true)
         |           ^
      65 |         })
      66 |     }
      67 |   }, [loadNextPage, accessToken, nextPageToken])

      at console.error (node_modules/@jest/console/build/BufferedConsole.js:163:10)
      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:88:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:60:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-dom/cjs/react-dom.development.js:23284:7)
      at setShowErrorMessage (node_modules/react-dom/cjs/react-dom.development.js:15656:9)
      at src/lib/containers/personal_access_token/AccessTokenPage.tsx:64:11
```

In both runs, the failure was in AccessTokenPage.test.tsx. The warning was easy to replicate locally (at least for me) when running the test suite in interactive mode (`yarn test`) but not if I ran with `CI="true"`. These changes should hopefully make this problem go away.

It would also be a good idea for us to see if there's a tool that would output something (e.g. an HTML page) that clarifies why a test run failed, including non-test failure cases like this.