### PR TITLE
Replace access icons with new MUI icons

### DIFF
--- a/src/__tests__/lib/containers/HasAccess.test.tsx
+++ b/src/__tests__/lib/containers/HasAccess.test.tsx
@@ -1,9 +1,4 @@
-import {
-  faDatabase,
-  faLink,
-  faUnlockAlt,
-  faLock,
-} from '@fortawesome/free-solid-svg-icons'
+import { faDatabase, faLink } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { mount } from 'enzyme'
 import {
@@ -33,6 +28,7 @@ import {
   SynapseTestContext,
 } from '../../../mocks/MockSynapseContext'
 import { resolveAllPending } from '../../../lib/testutils/EnzymeHelpers'
+import IconSvg from '../../../lib/containers/IconSvg'
 
 const SynapseClient = require('../../../lib/utils/SynapseClient')
 const entityId = 'syn9988882982'
@@ -112,9 +108,9 @@ describe('basic tests', () => {
 
     await resolveAllPending(wrapper)
 
-    const icons = wrapper.find(FontAwesomeIcon)
-    expect(icons).toHaveLength(2)
-    expect(icons.get(1).props.icon).toEqual(faUnlockAlt)
+    const icons = wrapper.find(IconSvg)
+    expect(icons).toHaveLength(1)
+    expect(icons.get(0).props.options.icon).toEqual('accessOpen')
     // no access restrictions
     expect(wrapper.find('button')).toHaveLength(0)
   })
@@ -129,9 +125,9 @@ describe('basic tests', () => {
     const { wrapper } = renderComponent(props)
     await resolveAllPending(wrapper)
 
-    const icons = wrapper.find(FontAwesomeIcon)
-    expect(icons).toHaveLength(2)
-    expect(icons.get(1).props.icon).toEqual(faUnlockAlt)
+    const icons = wrapper.find(IconSvg)
+    expect(icons).toHaveLength(1)
+    expect(icons.get(0).props.options.icon).toEqual('accessOpen')
     // no access restrictions
     expect(wrapper.find('button')).toHaveLength(0)
   })
@@ -142,9 +138,9 @@ describe('basic tests', () => {
       isInDownloadList: false,
       fileHandle: externalFileHandle,
     })
-    const icons = wrapper.find(FontAwesomeIcon)
-    expect(icons).toHaveLength(2)
-    expect(icons.get(1).props.icon).toEqual(faUnlockAlt)
+    const icons = wrapper.find(IconSvg)
+    expect(icons).toHaveLength(1)
+    expect(icons.get(0).props.options.icon).toEqual('accessOpen')
     // no access restrictions
     expect(wrapper.find('button')).toHaveLength(0)
   })
@@ -227,9 +223,9 @@ describe('basic tests', () => {
       isInDownloadList: false,
       fileHandle: tooLargeFileHandle,
     })
-    const icons = wrapper.find(FontAwesomeIcon)
-    expect(icons).toHaveLength(2)
-    expect(icons.get(1).props.icon).toEqual(faUnlockAlt)
+    const icons = wrapper.find(IconSvg)
+    expect(icons).toHaveLength(1)
+    expect(icons.get(0).props.options.icon).toEqual('accessOpen')
     // no access restrictions
     expect(wrapper.find('button')).toHaveLength(0)
   })
@@ -251,9 +247,9 @@ describe('basic tests', () => {
       ...props,
       fileHandle: IsOpenNoUnmetAccessRestrictions,
     })
-    const icons = wrapper.find(FontAwesomeIcon)
-    expect(icons).toHaveLength(2)
-    expect(icons.get(1).props.icon).toEqual(faUnlockAlt)
+    const icons = wrapper.find(IconSvg)
+    expect(icons).toHaveLength(1)
+    expect(icons.get(0).props.options.icon).toEqual('accessOpen')
   })
 
   it('works with unmet controlled access data AND an UNAUTHORIZED ACL', async () => {
@@ -277,9 +273,9 @@ describe('basic tests', () => {
       mockUnmetControlledDataRestrictionInformationACT,
     )
 
-    const icons = wrapper.find(FontAwesomeIcon)
-    expect(icons).toHaveLength(2)
-    expect(icons.get(1).props.icon).toEqual(faLock)
+    const icons = wrapper.find(IconSvg)
+    expect(icons).toHaveLength(1)
+    expect(icons.get(0).props.options.icon).toEqual('accessClosed')
     const tooltipSpan = wrapper.find(
       `[data-tip="${
         HasAccess.tooltipText[
@@ -310,9 +306,9 @@ describe('basic tests', () => {
       mockOpenRestrictionInformation,
     )
 
-    const icons = wrapper.find(FontAwesomeIcon)
-    expect(icons).toHaveLength(2)
-    expect(icons.get(1).props.icon).toEqual(faLock)
+    const icons = wrapper.find(IconSvg)
+    expect(icons).toHaveLength(1)
+    expect(icons.get(0).props.options.icon).toEqual('accessClosed')
     const tooltipSpan = wrapper.find(
       `[data-tip="${
         HasAccess.tooltipText[FileHandleDownloadTypeEnum.AccessBlockedByACL]

--- a/src/__tests__/lib/utils/hooks/useTheme.test.tsx
+++ b/src/__tests__/lib/utils/hooks/useTheme.test.tsx
@@ -1,0 +1,25 @@
+import {
+  defaultSynapseTheme,
+  mergeTheme,
+} from '../../../../lib/utils/hooks/useTheme'
+
+describe('Synapse Theme tests', () => {
+  it('properly merges a custom theme with the default theme', () => {
+    const customColor = '#000000'
+    const customTheme = {
+      colors: {
+        success: customColor,
+      },
+    }
+    const mergedTheme = mergeTheme(customTheme)
+
+    expect(mergedTheme.colors.success).toEqual(customColor)
+    expect(mergedTheme.colors.warning).toEqual(
+      defaultSynapseTheme.colors.warning,
+    )
+    expect(mergedTheme.colors.info).toEqual(defaultSynapseTheme.colors.info)
+    expect(mergedTheme.colors.error).toEqual(defaultSynapseTheme.colors.error)
+  })
+
+  // TODO: Test merging color palettes and validate that an entire palette is generated when providing one color
+})

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -16,13 +16,7 @@
  */
 
 import { IconProp, library } from '@fortawesome/fontawesome-svg-core'
-import {
-  faCircle,
-  faDatabase,
-  faLink,
-  faUnlockAlt,
-  faLock,
-} from '@fortawesome/free-solid-svg-icons'
+import { faCircle, faDatabase, faLink } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import * as React from 'react'
 import ReactTooltip from 'react-tooltip'
@@ -50,8 +44,9 @@ import AccessRequirementList, {
 } from './access_requirement_list/AccessRequirementList'
 import { SRC_SIGN_IN_CLASS } from '../utils/SynapseConstants'
 import { SynapseContext } from '../utils/SynapseContext'
+import IconSvg from './IconSvg'
+import { ThemeContext } from '../utils/hooks/useTheme'
 
-library.add(faUnlockAlt)
 library.add(faDatabase)
 library.add(faCircle)
 
@@ -321,13 +316,47 @@ export default class HasAccess extends React.Component<
     )
   }
 
+  renderOpenAccessIcon() {
+    return (
+      <ThemeContext.Consumer>
+        {theme => {
+          return (
+            <IconSvg
+              options={{
+                icon: 'accessOpen',
+                color: theme.colors.success,
+              }}
+            />
+          )
+        }}
+      </ThemeContext.Consumer>
+    )
+  }
+
+  renderLockedIcon() {
+    return (
+      <ThemeContext.Consumer>
+        {theme => {
+          return (
+            <IconSvg
+              options={{
+                icon: 'accessClosed',
+                color: theme.colors.warning,
+              }}
+            />
+          )
+        }}
+      </ThemeContext.Consumer>
+    )
+  }
+
   renderIcon = (
     downloadType: FileHandleDownloadTypeEnum | string,
     restrictionInformation?: RestrictionInformationResponse,
   ) => {
     // if there are any access restrictions
     if (restrictionInformation?.hasUnmetAccessRequirement) {
-      return this.renderIconHelper(faLock, 'SRC-warning-color')
+      return this.renderLockedIcon()
     }
     switch (downloadType) {
       // fileHandle available
@@ -339,12 +368,12 @@ export default class HasAccess extends React.Component<
       // was FileEntity, but no fileHandle was available
       case FileHandleDownloadTypeEnum.AccessBlockedByACL:
       case FileHandleDownloadTypeEnum.AccessBlockedToAnonymous:
-        return this.renderIconHelper(faLock, 'SRC-warning-color')
+        return this.renderLockedIcon()
       // was a FileEntity, and fileHandle was available
       case FileHandleDownloadTypeEnum.Accessible:
       // or was not a FileEntity, but no unmet access restrictions
       case FileHandleDownloadTypeEnum.NoFileHandle:
-        return this.renderIconHelper(faUnlockAlt, 'SRC-success-color')
+        return this.renderOpenAccessIcon()
       default:
         // nothing is rendered until access requirement is loaded
         return <></>
@@ -411,7 +440,8 @@ export default class HasAccess extends React.Component<
           style={{
             fontSize: '14px',
             cursor: 'pointer',
-            marginLeft: '10px',
+            marginLeft: '5px',
+            verticalAlign: 'middle',
           }}
           className={this.props.className}
           onClick={this.handleGetAccess}

--- a/src/lib/containers/HasAccess.tsx
+++ b/src/lib/containers/HasAccess.tsx
@@ -296,7 +296,18 @@ export default class HasAccess extends React.Component<
       })
   }
 
-  renderIconHelper = (iconProp: IconProp, classColor: string) => {
+  renderIconSvg(icon: string, color: string) {
+    return (
+      <IconSvg
+        options={{
+          icon: icon,
+          color: color,
+        }}
+      />
+    )
+  }
+
+  renderFontAwesomeIcon = (iconProp: IconProp, classColor: string) => {
     return (
       <span className="fa-layers fa-fw">
         <FontAwesomeIcon
@@ -316,64 +327,42 @@ export default class HasAccess extends React.Component<
     )
   }
 
-  renderOpenAccessIcon() {
-    return (
-      <ThemeContext.Consumer>
-        {theme => {
-          return (
-            <IconSvg
-              options={{
-                icon: 'accessOpen',
-                color: theme.colors.success,
-              }}
-            />
-          )
-        }}
-      </ThemeContext.Consumer>
-    )
-  }
-
-  renderLockedIcon() {
-    return (
-      <ThemeContext.Consumer>
-        {theme => {
-          return (
-            <IconSvg
-              options={{
-                icon: 'accessClosed',
-                color: theme.colors.warning,
-              }}
-            />
-          )
-        }}
-      </ThemeContext.Consumer>
-    )
-  }
-
   renderIcon = (
     downloadType: FileHandleDownloadTypeEnum | string,
     restrictionInformation?: RestrictionInformationResponse,
   ) => {
     // if there are any access restrictions
     if (restrictionInformation?.hasUnmetAccessRequirement) {
-      return this.renderLockedIcon()
+      return (
+        <ThemeContext.Consumer>
+          {theme => this.renderIconSvg('accessClosed', theme.colors.warning)}
+        </ThemeContext.Consumer>
+      )
     }
     switch (downloadType) {
       // fileHandle available
       case FileHandleDownloadTypeEnum.ExternalFileLink:
       case FileHandleDownloadTypeEnum.ExternalCloudFile:
-        return this.renderIconHelper(faLink, 'SRC-warning-color')
+        return this.renderFontAwesomeIcon(faLink, 'SRC-warning-color')
       case FileHandleDownloadTypeEnum.TooLarge:
-        return this.renderIconHelper(faDatabase, 'SRC-danger-color')
+        return this.renderFontAwesomeIcon(faDatabase, 'SRC-danger-color')
       // was FileEntity, but no fileHandle was available
       case FileHandleDownloadTypeEnum.AccessBlockedByACL:
       case FileHandleDownloadTypeEnum.AccessBlockedToAnonymous:
-        return this.renderLockedIcon()
+        return (
+          <ThemeContext.Consumer>
+            {theme => this.renderIconSvg('accessClosed', theme.colors.warning)}
+          </ThemeContext.Consumer>
+        )
       // was a FileEntity, and fileHandle was available
       case FileHandleDownloadTypeEnum.Accessible:
       // or was not a FileEntity, but no unmet access restrictions
       case FileHandleDownloadTypeEnum.NoFileHandle:
-        return this.renderOpenAccessIcon()
+        return (
+          <ThemeContext.Consumer>
+            {theme => this.renderIconSvg('accessOpen', theme.colors.success)}
+          </ThemeContext.Consumer>
+        )
       default:
         // nothing is rendered until access requirement is loaded
         return <></>

--- a/src/lib/containers/IconSvg.tsx
+++ b/src/lib/containers/IconSvg.tsx
@@ -34,6 +34,8 @@ import {
   Code,
   GridOnTwoTone,
   RemoveCircleTwoTone,
+  LockOpenTwoTone,
+  VpnKeyTwoTone,
 } from '@material-ui/icons'
 
 import AccountCertified from '../assets/mui_components/AccountCertified'
@@ -90,6 +92,10 @@ const getIcon = (options: IconSvgOptions) => {
   }
 
   switch (icon) {
+    case 'accessOpen':
+      return <LockOpenTwoTone style={customSvgStyle} />
+    case 'accessClosed':
+      return <VpnKeyTwoTone style={customSvgStyle} />
     case 'arrowBack':
       return <ArrowBackIos style={muiSvgStyle} />
     case 'arrowForward':

--- a/src/lib/utils/SynapseContext.tsx
+++ b/src/lib/utils/SynapseContext.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { SynapseErrorBoundary } from '../containers/ErrorBanner'
+import { SynapseTheme, ThemeProvider } from './hooks/useTheme'
 
 const defaultQueryClient = new QueryClient({
   defaultOptions: {
@@ -32,6 +33,7 @@ export const SynapseContext = React.createContext<
 export type SynapseContextProviderProps = {
   synapseContext?: SynapseContextType
   queryClient?: QueryClient
+  theme?: SynapseTheme
 }
 
 /**
@@ -40,15 +42,17 @@ export type SynapseContextProviderProps = {
  * @returns
  */
 export const SynapseContextProvider: React.FunctionComponent<SynapseContextProviderProps> =
-  ({ children, synapseContext, queryClient }) => {
+  ({ children, synapseContext, queryClient, theme }) => {
     return (
       <SynapseContext.Provider value={synapseContext}>
         <QueryClientProvider client={queryClient ?? defaultQueryClient}>
-          {synapseContext?.withErrorBoundary ? (
-            <SynapseErrorBoundary>{children}</SynapseErrorBoundary>
-          ) : (
-            children
-          )}
+          <ThemeProvider theme={theme}>
+            {synapseContext?.withErrorBoundary ? (
+              <SynapseErrorBoundary>{children}</SynapseErrorBoundary>
+            ) : (
+              children
+            )}
+          </ThemeProvider>
         </QueryClientProvider>
       </SynapseContext.Provider>
     )

--- a/src/lib/utils/hooks/useTheme.tsx
+++ b/src/lib/utils/hooks/useTheme.tsx
@@ -1,10 +1,12 @@
-import React, { useContext } from 'react'
+import { merge } from 'lodash'
+import React, { useContext, useMemo } from 'react'
+import DeepPartial from '../types/DeepPartial'
 
 /**
- * TODO: Ensure the default colors here match the default colors in _variables.scss
+ * TODO: Ensure the default colors here match the default colors in _variables.scss, ideally having a single point of control
  */
 
-const defaultTheme: ThemeContextType = {
+export const defaultSynapseTheme: SynapseTheme = {
   colors: {
     success: '#32a330',
     info: '#017fa5',
@@ -13,7 +15,7 @@ const defaultTheme: ThemeContextType = {
   },
 }
 
-export type ThemeContextType = {
+export type SynapseTheme = {
   colors: {
     success: string
     info: string
@@ -25,23 +27,34 @@ export type ThemeContextType = {
 /**
  * This must be exported to use the context in class components.
  */
-export const ThemeContext = React.createContext<ThemeContextType>(defaultTheme)
+export const ThemeContext =
+  React.createContext<SynapseTheme>(defaultSynapseTheme)
 
 export type ThemeProviderProps = {
-  theme?: ThemeContextType
+  theme?: DeepPartial<SynapseTheme>
+}
+
+export function mergeTheme(theme: DeepPartial<SynapseTheme>): SynapseTheme {
+  // TODO: Handle merging color palettes where an entire palette can be generated from a single base color.
+  return merge({}, defaultSynapseTheme, theme)
 }
 
 export const ThemeProvider: React.FunctionComponent<ThemeProviderProps> = ({
-  theme = defaultTheme,
+  theme = defaultSynapseTheme,
   children,
 }) => {
-  return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+  const mergedTheme = useMemo(() => mergeTheme(theme), [theme])
+  return (
+    <ThemeContext.Provider value={mergedTheme}>
+      {children}
+    </ThemeContext.Provider>
+  )
 }
 
-export function useTheme(): ThemeContextType {
+export function useTheme(): SynapseTheme {
   const context = useContext(ThemeContext)
   if (context === undefined) {
-    return defaultTheme
+    return defaultSynapseTheme
   }
   return context
 }

--- a/src/lib/utils/hooks/useTheme.tsx
+++ b/src/lib/utils/hooks/useTheme.tsx
@@ -1,0 +1,47 @@
+import React, { useContext } from 'react'
+
+/**
+ * TODO: Ensure the default colors here match the default colors in _variables.scss
+ */
+
+const defaultTheme: ThemeContextType = {
+  colors: {
+    success: '#32a330',
+    info: '#017fa5',
+    warning: '#cc9f00',
+    error: '#c13415',
+  },
+}
+
+export type ThemeContextType = {
+  colors: {
+    success: string
+    info: string
+    warning: string
+    error: string
+  }
+}
+
+/**
+ * This must be exported to use the context in class components.
+ */
+export const ThemeContext = React.createContext<ThemeContextType>(defaultTheme)
+
+export type ThemeProviderProps = {
+  theme?: ThemeContextType
+}
+
+export const ThemeProvider: React.FunctionComponent<ThemeProviderProps> = ({
+  theme = defaultTheme,
+  children,
+}) => {
+  return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme(): ThemeContextType {
+  const context = useContext(ThemeContext)
+  if (context === undefined) {
+    return defaultTheme
+  }
+  return context
+}

--- a/src/lib/utils/types/DeepPartial.ts
+++ b/src/lib/utils/types/DeepPartial.ts
@@ -1,0 +1,12 @@
+/**
+ * Type that recursively makes all properties in an object optional. Use sparingly, as this is computationally expensive.
+ * Implementation: https://stackoverflow.com/questions/61132262/typescript-deep-partial
+ * Performance issues: https://github.com/microsoft/TypeScript/issues/35729
+ */
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>
+    }
+  : T
+
+export default DeepPartial


### PR DESCRIPTION
Tried to re-align the icons with circles and couldn't get it consistent in both SWC and portals. So let's just use the new icons.

<img width="606" alt="image" src="https://user-images.githubusercontent.com/17580037/164115757-47099419-2be9-4251-b94e-40b31e72ee23.png">


<img width="606" alt="image" src="https://user-images.githubusercontent.com/17580037/164115870-9662f8c2-f9f9-4279-97a7-4ffbfae1b859.png">
