### PR TITLE
SWC-5875 Follow up

### DIFF
--- a/src/lib/containers/FluidModal.tsx
+++ b/src/lib/containers/FluidModal.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from '@material-ui/lab'
 import React from 'react'
 import { Button, Modal } from 'react-bootstrap'
 import { ButtonVariant } from 'react-bootstrap/esm/types'
@@ -5,15 +6,19 @@ import Typography from '../utils/typography/Typography'
 import { HelpPopover, HelpPopoverProps } from './HelpPopover'
 
 type ModalAction = {
+  skeleton?: boolean
   variant?: ButtonVariant
-  copy: React.ReactNode
-  onClick: () => void
+  copy?: React.ReactNode
+  onClick?: () => void
+  disabled?: boolean
+  [key: string]: any
 }
 
 export type FluidModalProps = {
+  className?: string
   show: boolean
   children: JSX.Element
-  title: string
+  title: string | JSX.Element
   titlePopoverProps?: HelpPopoverProps
   onClose: () => void
   primaryAction?: ModalAction
@@ -21,12 +26,14 @@ export type FluidModalProps = {
   tertiaryActions?: ModalAction[]
 }
 
-function ModalActionButton(props: Required<ModalAction>) {
-  return (
-    <Button variant={props.variant} onClick={props.onClick}>
-      {props.copy}
-    </Button>
-  )
+function ModalActionButton(props: ModalAction) {
+  const { copy, skeleton, ...rest } = props
+
+  if (props.skeleton) {
+    return <Skeleton variant="rect" width={150} />
+  }
+
+  return <Button {...rest}>{copy}</Button>
 }
 
 /**
@@ -35,10 +42,12 @@ function ModalActionButton(props: Required<ModalAction>) {
  * @returns
  */
 export const FluidModal = (props: FluidModalProps) => {
+  const hasActions =
+    props.primaryAction || props.secondaryActions || props.tertiaryActions
   // TODO: Info button
   return (
     <Modal
-      className="FluidModal bootstrap-4-backport"
+      className={`FluidModal bootstrap-4-backport ${props.className ?? ''}`}
       backdrop="static"
       animation={false}
       show={props.show}
@@ -63,10 +72,26 @@ export const FluidModal = (props: FluidModalProps) => {
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>{props.children}</Modal.Body>
-      <Modal.Footer>
-        {props.tertiaryActions && (
-          <>
-            {props.tertiaryActions.map((action, index) => {
+      {hasActions && (
+        <Modal.Footer>
+          {props.tertiaryActions && (
+            <>
+              {props.tertiaryActions.map((action, index) => {
+                return (
+                  <ModalActionButton
+                    key={index}
+                    {...{
+                      variant: 'outline',
+                      ...action,
+                    }}
+                  />
+                )
+              })}
+              <div style={{ margin: 'auto' }}></div>
+            </>
+          )}
+          {props.secondaryActions &&
+            props.secondaryActions.reverse().map((action, index) => {
               return (
                 <ModalActionButton
                   key={index}
@@ -77,30 +102,16 @@ export const FluidModal = (props: FluidModalProps) => {
                 />
               )
             })}
-            <div style={{ margin: 'auto' }}></div>
-          </>
-        )}
-        {props.secondaryActions &&
-          props.secondaryActions.reverse().map((action, index) => {
-            return (
-              <ModalActionButton
-                key={index}
-                {...{
-                  variant: 'outline',
-                  ...action,
-                }}
-              />
-            )
-          })}
-        {props.primaryAction && (
-          <ModalActionButton
-            {...{
-              variant: 'sds-primary',
-              ...props.primaryAction,
-            }}
-          />
-        )}
-      </Modal.Footer>
+          {props.primaryAction && (
+            <ModalActionButton
+              {...{
+                variant: 'sds-primary',
+                ...props.primaryAction,
+              }}
+            />
+          )}
+        </Modal.Footer>
+      )}
     </Modal>
   )
 }

--- a/src/lib/containers/FluidModal.tsx
+++ b/src/lib/containers/FluidModal.tsx
@@ -42,8 +42,6 @@ function ModalActionButton(props: ModalAction) {
  * @returns
  */
 export const FluidModal = (props: FluidModalProps) => {
-  const hasActions =
-    props.primaryAction || props.secondaryActions || props.tertiaryActions
   // TODO: Info button
   return (
     <Modal
@@ -72,26 +70,10 @@ export const FluidModal = (props: FluidModalProps) => {
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>{props.children}</Modal.Body>
-      {hasActions && (
-        <Modal.Footer>
-          {props.tertiaryActions && (
-            <>
-              {props.tertiaryActions.map((action, index) => {
-                return (
-                  <ModalActionButton
-                    key={index}
-                    {...{
-                      variant: 'outline',
-                      ...action,
-                    }}
-                  />
-                )
-              })}
-              <div style={{ margin: 'auto' }}></div>
-            </>
-          )}
-          {props.secondaryActions &&
-            props.secondaryActions.reverse().map((action, index) => {
+      <Modal.Footer>
+        {props.tertiaryActions && (
+          <>
+            {props.tertiaryActions.map((action, index) => {
               return (
                 <ModalActionButton
                   key={index}
@@ -102,16 +84,30 @@ export const FluidModal = (props: FluidModalProps) => {
                 />
               )
             })}
-          {props.primaryAction && (
-            <ModalActionButton
-              {...{
-                variant: 'sds-primary',
-                ...props.primaryAction,
-              }}
-            />
-          )}
-        </Modal.Footer>
-      )}
+            <div style={{ margin: 'auto' }}></div>
+          </>
+        )}
+        {props.secondaryActions &&
+          props.secondaryActions.reverse().map((action, index) => {
+            return (
+              <ModalActionButton
+                key={index}
+                {...{
+                  variant: 'outline',
+                  ...action,
+                }}
+              />
+            )
+          })}
+        {props.primaryAction && (
+          <ModalActionButton
+            {...{
+              variant: 'sds-primary',
+              ...props.primaryAction,
+            }}
+          />
+        )}
+      </Modal.Footer>
     </Modal>
   )
 }

--- a/src/lib/containers/entity/annotations/CustomAdditionalPropertiesFieldTemplate.tsx
+++ b/src/lib/containers/entity/annotations/CustomAdditionalPropertiesFieldTemplate.tsx
@@ -35,7 +35,7 @@ export const CustomAdditionalPropertiesFieldTemplate = (
     return <div className="hidden">{children}</div>
   }
   return (
-    <div className={classNames}>
+    <div className={`${classNames ?? ''} container-fluid`}>
       <div className="row form-additional">
         <div className="col-xs-3">
           <FormGroup>

--- a/src/lib/containers/entity/annotations/CustomObjectFieldTemplate.tsx
+++ b/src/lib/containers/entity/annotations/CustomObjectFieldTemplate.tsx
@@ -19,10 +19,8 @@ export function CustomObjectFieldTemplate(
   const { TitleField, DescriptionField } = props
   const CUSTOM_OBJECT_FIELD_TEMPLATE_TOOLTIP_ID = `CustomObjectFieldTooltip-${props.idSchema.$id}`
 
-  const [
-    previousSchemaDefinedProperties,
-    setPreviousSchemaDefinedProperties,
-  ] = useState<Set<string>>(new Set())
+  const [previousSchemaDefinedProperties, setPreviousSchemaDefinedProperties] =
+    useState<Set<string>>(new Set())
 
   /**
    * We track how the schema changes as the user enters data, causing conditional subschemas to be evaluated.
@@ -95,17 +93,19 @@ export function CustomObjectFieldTemplate(
         return <div key={prop.name}>{prop.content}</div>
       })}
       {utils.canExpand(props.schema, props.uiSchema, props.formData) && (
-        <Button
-          variant="gray"
-          className="object-property-expand"
-          onClick={props.onAddClick(props.schema)}
-          disabled={props.disabled || props.readonly}
-          data-for={CUSTOM_OBJECT_FIELD_TEMPLATE_TOOLTIP_ID}
-          data-tip={`Add a new custom field`}
-          aria-label={'Add Custom Field'}
-        >
-          <AddToList />
-        </Button>
+        <div className="container-fluid">
+          <Button
+            variant="gray"
+            className="object-property-expand"
+            onClick={props.onAddClick(props.schema)}
+            disabled={props.disabled || props.readonly}
+            data-for={CUSTOM_OBJECT_FIELD_TEMPLATE_TOOLTIP_ID}
+            data-tip={`Add a new custom field`}
+            aria-label={'Add Custom Field'}
+          >
+            <AddToList />
+          </Button>
+        </div>
       )}
     </fieldset>
   )

--- a/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
+++ b/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
@@ -39,16 +39,14 @@ export type SchemaDrivenAnnotationEditorProps = {
   entityId?: string
   /** If no entity ID is supplied, the schema to use for the form */
   schemaId?: string
+  /** Optionally supply a ref to the form to handle submission externally with `formRef.current.submit()` */
+  formRef?: React.RefObject<Form<Record<string, unknown>>>
+  /** Provide live input validation. This can cause major performance degradation. */
   liveValidate?: boolean
+  /** Invoked after a successful form submission */
   onSuccess?: () => void
-  /** If defined, shows a 'Cancel' button and runs this effect on click */
+  /** If defined and formRef is not supplied, shows a 'Cancel' button and runs this effect on click */
   onCancel?: () => void
-}
-
-export type SchemaDrivenAnnotationEditorModalProps = {
-  entityId: string
-  show: boolean
-  onHide: () => void
 }
 
 // patternProperties lets us define how to treat additionalProperties in a JSON schema by property name
@@ -73,6 +71,7 @@ export const SchemaDrivenAnnotationEditor = (
       /* no-op */
     },
     onCancel,
+    formRef: formRefFromParent,
   } = props
   const handleError = useErrorHandler()
   const formRef = useRef<Form<Record<string, unknown>>>(null)
@@ -216,7 +215,7 @@ export const SchemaDrivenAnnotationEditor = (
             ArrayFieldTemplate={CustomArrayFieldTemplate}
             ObjectFieldTemplate={CustomObjectFieldTemplate}
             FieldTemplate={CustomDefaultTemplate}
-            ref={formRef}
+            ref={formRefFromParent ?? formRef}
             disabled={mutation.isLoading}
             /* Errors are displayed by an Alert component below, so we don't show the builtin ErrorList */
             ErrorList={() => null}
@@ -298,25 +297,29 @@ export const SchemaDrivenAnnotationEditor = (
                 Annotations could not be updated: {submissionError.reason}
               </Alert>
             )}
-            <hr />
-            <div className="SaveButtonContainer">
-              <Button
-                variant="primary-500"
-                onClick={() => {
-                  formRef.current!.submit()
-                }}
-              >
-                {entityId ? 'Save' : 'Validate'}
-              </Button>
-              {onCancel && (
-                <>
-                  <div className="Spacer" />
-                  <Button variant="primary-500" onClick={onCancel}>
-                    Cancel
+            {!formRefFromParent && (
+              <>
+                <hr />
+                <div className="SaveButtonContainer">
+                  <Button
+                    variant="primary-500"
+                    onClick={() => {
+                      formRef.current!.submit()
+                    }}
+                  >
+                    {entityId ? 'Save' : 'Validate'}
                   </Button>
-                </>
-              )}
-            </div>
+                  {onCancel && (
+                    <>
+                      <div className="Spacer" />
+                      <Button variant="primary-500" onClick={onCancel}>
+                        Cancel
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </>
+            )}
           </Form>
           {showConfirmation && (
             <ConfirmationModal

--- a/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
+++ b/src/lib/containers/entity/annotations/SchemaDrivenAnnotationEditor.tsx
@@ -39,7 +39,7 @@ export type SchemaDrivenAnnotationEditorProps = {
   entityId?: string
   /** If no entity ID is supplied, the schema to use for the form */
   schemaId?: string
-  /** Optionally supply a ref to the form to handle submission externally with `formRef.current.submit()` */
+  /** Optionally supply a ref to the form to handle submission externally with `formRef.current.submit()`. If provided, the editor will not render its own submit UI. */
   formRef?: React.RefObject<Form<Record<string, unknown>>>
   /** Provide live input validation. This can cause major performance degradation. */
   liveValidate?: boolean

--- a/src/lib/containers/entity/metadata/EntityModal.md
+++ b/src/lib/containers/entity/metadata/EntityModal.md
@@ -2,71 +2,151 @@ Simple schema:
 syn25741218 (valid)
 syn25741219 (invalid)
 
-
 Complex schema
 syn23555348 (valid)
 syn23555349 (invalid)
 
 ```jsx
-const [isOpen, setIsOpen] = React.useState(false);
+const [isOpen, setIsOpen] = React.useState(false)
 
-<div className="bootstrap-4-backport">
-    <button className="btn btn-default" onClick={() => setIsOpen(true)} >Open project</button>
-    {isOpen && <EntityModal show={isOpen} onClose={() => setIsOpen(false)} initialTab={"ANNOTATIONS"} accessToken={accessToken} entityId={"syn23567475"}/>}
+return (
+  <div className="bootstrap-4-backport">
+    <button className="btn btn-default" onClick={() => setIsOpen(true)}>
+      Open project
+    </button>
+    {isOpen && (
+      <EntityModal
+        show={isOpen}
+        onClose={() => setIsOpen(false)}
+        initialTab={'ANNOTATIONS'}
+        accessToken={accessToken}
+        entityId={'syn23567475'}
+      />
+    )}
+  </div>
+)
+```
+
+```jsx
+const [isOpen, setIsOpen] = React.useState(false)
+
+return (
+  <div className="bootstrap-4-backport">
+    <button className="btn btn-default" onClick={() => setIsOpen(true)}>
+      Open folder
+    </button>
+    {isOpen && (
+      <EntityModal
+        show={isOpen}
+        onClose={() => setIsOpen(false)}
+        initialTab={'ANNOTATIONS'}
+        accessToken={accessToken}
+        entityId={'syn24183903'}
+      />
+    )}
+  </div>
+)
+```
+
+```jsx
+const [isOpen, setIsOpen] = React.useState(false)
+
+return (
+  <div className="bootstrap-4-backport">
+    <button className="btn btn-default" onClick={() => setIsOpen(true)}>
+      Open file entity with no annotations or schema
+    </button>
+    {isOpen && (
+      <EntityModal
+        show={isOpen}
+        onClose={() => setIsOpen(false)}
+        initialTab={'ANNOTATIONS'}
+        accessToken={accessToken}
+        entityId={'syn25830585'}
+      />
+    )}
+  </div>
+)
+```
+
+```jsx
+const [isOpen, setIsOpen] = React.useState(false)
+
+return (
+  <div className="bootstrap-4-backport">
+    <button className="btn btn-default" onClick={() => setIsOpen(true)}>
+      Open entity with simple schema (valid)
+    </button>
+    {isOpen && (
+      <EntityModal
+        show={isOpen}
+        onClose={() => setIsOpen(false)}
+        initialTab={'ANNOTATIONS'}
+        accessToken={accessToken}
+        entityId={'syn25741218'}
+      />
+    )}
+  </div>
+)
+```
+
+```jsx
+const [isOpen, setIsOpen] = React.useState(false)
+
+return (
+  <div className="bootstrap-4-backport">
+    <button className="btn btn-default" onClick={() => setIsOpen(true)}>
+      Open entity with simple schema (invalid)
+    </button>
+    {isOpen && (
+      <EntityModal
+        show={isOpen}
+        onClose={() => setIsOpen(false)}
+        initialTab={'ANNOTATIONS'}
+        accessToken={accessToken}
+        entityId={'syn25741219'}
+      />
+    )}
+  </div>
+)
+```
+
+```jsx
+const [isOpen, setIsOpen] = React.useState(false)
+
+;<div className="bootstrap-4-backport">
+  <button className="btn btn-default" onClick={() => setIsOpen(true)}>
+    Open entity with complex schema (valid)
+  </button>
+  {isOpen && (
+    <EntityModal
+      show={isOpen}
+      onClose={() => setIsOpen(false)}
+      initialTab={'ANNOTATIONS'}
+      accessToken={accessToken}
+      entityId={'syn23555348'}
+    />
+  )}
 </div>
 ```
 
 ```jsx
-const [isOpen, setIsOpen] = React.useState(false);
+const [isOpen, setIsOpen] = React.useState(false)
 
-<div className="bootstrap-4-backport">
-    <button className="btn btn-default" onClick={() => setIsOpen(true)} >Open folder</button>
-    {isOpen && <EntityModal show={isOpen} onClose={() => setIsOpen(false)} initialTab={"ANNOTATIONS"} accessToken={accessToken} entityId={"syn24183903"}/>}
-</div>
-```
-
-```jsx
-const [isOpen, setIsOpen] = React.useState(false);
-
-<div className="bootstrap-4-backport">
-    <button className="btn btn-default" onClick={() => setIsOpen(true)} >Open file entity with no annotations or schema</button>
-    {isOpen && <EntityModal show={isOpen} onClose={() => setIsOpen(false)} initialTab={"ANNOTATIONS"} accessToken={accessToken} entityId={"syn25830585"}/>}
-</div>
-```
-
-
-```jsx
-const [isOpen, setIsOpen] = React.useState(false);
-
-<div className="bootstrap-4-backport">
-    <button className="btn btn-default" onClick={() => setIsOpen(true)} >Open entity with simple schema (valid)</button>
-    {isOpen && <EntityModal show={isOpen} onClose={() => setIsOpen(false)} initialTab={"ANNOTATIONS"} accessToken={accessToken} entityId={"syn25741218"}/>}
-</div>
-```
-
-```jsx
-const [isOpen, setIsOpen] = React.useState(false);
-
-<div className="bootstrap-4-backport">
-    <button className="btn btn-default" onClick={() => setIsOpen(true)} >Open entity with simple schema (invalid)</button>
-    {isOpen && <EntityModal show={isOpen} onClose={() => setIsOpen(false)} initialTab={"ANNOTATIONS"} accessToken={accessToken} entityId={"syn25741219"}/>}
-</div>
-```
-
-```jsx
-const [isOpen, setIsOpen] = React.useState(false);
-
-<div className="bootstrap-4-backport">
-    <button className="btn btn-default" onClick={() => setIsOpen(true)} >Open entity with complex schema (valid)</button>
-    {isOpen && <EntityModal show={isOpen} onClose={() => setIsOpen(false)} initialTab={"ANNOTATIONS"} accessToken={accessToken} entityId={"syn23555348"}/>}
-</div>
-```
-
-```jsx
-const [isOpen, setIsOpen] = React.useState(false);
-
-<div className="bootstrap-4-backport">
-    <button className="btn btn-default" onClick={() => setIsOpen(true)} >Open entity with complex schema (invalid)</button>
-    {isOpen && <EntityModal show={isOpen} onClose={() => setIsOpen(false)} initialTab={"ANNOTATIONS"} accessToken={accessToken} entityId={"syn23555349"}/>}
-</div>
+return (
+  <div className="bootstrap-4-backport">
+    <button className="btn btn-default" onClick={() => setIsOpen(true)}>
+      Open entity with complex schema (invalid)
+    </button>
+    {isOpen && (
+      <EntityModal
+        show={isOpen}
+        onClose={() => setIsOpen(false)}
+        initialTab={'ANNOTATIONS'}
+        accessToken={accessToken}
+        entityId={'syn23555349'}
+      />
+    )}
+  </div>
+)
 ```

--- a/src/lib/style/components/_annotations.scss
+++ b/src/lib/style/components/_annotations.scss
@@ -68,6 +68,10 @@
         margin: 12px 5px 1rem;
         justify-self: center;
         align-self: start;
+
+        svg {
+          vertical-align: unset;
+        }
       }
 
       .array-item {

--- a/src/lib/style/components/_entity-metadata.scss
+++ b/src/lib/style/components/_entity-metadata.scss
@@ -21,6 +21,7 @@
   }
 }
 
+.MetadataTable,
 .AnnotationsTable {
   width: 100%;
   margin: 0px;
@@ -42,17 +43,6 @@
   }
 }
 
-.MetadataTable {
-  width: 100%;
-  margin: 0px;
-  &__Row {
-    &__Key {
-      font-weight: bold;
-      padding: 6px 0px;
-    }
-
-    &__Value {
-      padding: 6px 0px;
-    }
-  }
+.FluidModal.EntityMetadata:not(.isInEditMode) .modal-dialog {
+  max-width: 600px;
 }


### PR DESCRIPTION
Lots of weirdness in this Entity Modal/annotations editor UI that I decided to clean up. 

Most changes impact responsiveness of the modal in which we show the annotation editor. [SWC-5801](https://sagebionetworks.jira.com/browse/SWC-5801) was originally filed to address the new annotations editor. We created a `FluidModal` component that adheres to that spec for the Datasets -> Entity Finder use case. We're using it here now for the Entity metadata/annotations modal.

There are also a handful of changes that fix style issues.

Before:

https://user-images.githubusercontent.com/17580037/166263074-4df01996-b753-40b6-984f-1345487d77c6.mov

After:

https://user-images.githubusercontent.com/17580037/166262693-932cf86d-504b-47ed-b9d3-b9805014d20a.mov