### PR TITLE
Rewrite Enzyme tests

### DIFF
--- a/src/__tests__/lib/containers/AccountLevelBadge.test.tsx
+++ b/src/__tests__/lib/containers/AccountLevelBadge.test.tsx
@@ -1,10 +1,9 @@
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
 import * as React from 'react'
-import { resolveAllPending } from '../../../lib/testutils/EnzymeHelpers'
 import {
   AccountLevelBadge,
-  accountLevelRegisteredLabel,
   accountLevelCertifiedLabel,
+  accountLevelRegisteredLabel,
   accountLevelVerifiedLabel,
 } from '../../../lib/containers/AccountLevelBadge'
 import { UserBundle } from '../../../lib/utils/synapseTypes'
@@ -41,36 +40,30 @@ describe('basic functionality', () => {
       .fn()
       .mockResolvedValueOnce(mockRegistered)
 
-    const wrapper = mount(<AccountLevelBadge {...props} />)
-    await resolveAllPending(wrapper)
+    render(<AccountLevelBadge {...props} />)
 
     // find account level label
-    const label = wrapper.find('.AccountLevelBadge__body__userAccountLevel')
-    expect(label.text()).toEqual(accountLevelRegisteredLabel)
+    await screen.findByText(accountLevelRegisteredLabel)
     expect(SynapseClient.getUserBundle).toHaveBeenCalledTimes(1)
   })
 
   it('certified user', async () => {
     SynapseClient.getUserBundle = jest.fn().mockResolvedValueOnce(mockCertified)
 
-    const wrapper = mount(<AccountLevelBadge {...props} />)
-    await resolveAllPending(wrapper)
+    render(<AccountLevelBadge {...props} />)
 
     // find account level label
-    const label = wrapper.find('.AccountLevelBadge__body__userAccountLevel')
-    expect(label.text()).toEqual(accountLevelCertifiedLabel)
+    await screen.findByText(accountLevelCertifiedLabel)
     expect(SynapseClient.getUserBundle).toHaveBeenCalledTimes(1)
   })
 
   it('verified user', async () => {
     SynapseClient.getUserBundle = jest.fn().mockResolvedValueOnce(mockVerified)
 
-    const wrapper = mount(<AccountLevelBadge {...props} />)
-    await resolveAllPending(wrapper)
+    render(<AccountLevelBadge {...props} />)
 
     // find account level label
-    const label = wrapper.find('.AccountLevelBadge__body__userAccountLevel')
-    expect(label.text()).toEqual(accountLevelVerifiedLabel)
+    await screen.findByText(accountLevelVerifiedLabel)
     expect(SynapseClient.getUserBundle).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/__tests__/lib/containers/CopyToClipboardInput.test.tsx
+++ b/src/__tests__/lib/containers/CopyToClipboardInput.test.tsx
@@ -1,8 +1,7 @@
-import CopyToClipboardInput from '../../../lib/containers/CopyToClipboardInput'
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as React from 'react'
-import { act } from '@testing-library/react'
-import { Button, FormControl } from 'react-bootstrap'
+import CopyToClipboardInput from '../../../lib/containers/CopyToClipboardInput'
 
 describe('basic functionality', () => {
   const props = {
@@ -10,31 +9,29 @@ describe('basic functionality', () => {
     inputWidth: '500px',
   }
 
-  it('copies to clipboard when icon is clicked', async () => {
+  it('copies to clipboard when icon is clicked', () => {
     Object.assign(navigator, {
       clipboard: {
         writeText: jest.fn().mockImplementation(() => Promise.resolve()),
       },
     })
-    const wrapper = mount(<CopyToClipboardInput {...props} />)
-    await act(async () => {
-      await wrapper.find(Button).simulate('click')
-    })
+    render(<CopyToClipboardInput {...props} />)
+    const button = screen.getByRole('button')
+    userEvent.click(button)
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       'some value to be copied',
     )
   })
 
-  it('copies to clipboard when input field is clicked', async () => {
+  it('copies to clipboard when input field is clicked', () => {
     Object.assign(navigator, {
       clipboard: {
         writeText: jest.fn().mockImplementation(() => Promise.resolve()),
       },
     })
-    const wrapper = mount(<CopyToClipboardInput {...props} />)
-    await act(async () => {
-      await wrapper.find(FormControl).simulate('click')
-    })
+    render(<CopyToClipboardInput {...props} />)
+    const inputField = screen.getByRole('textbox')
+    userEvent.click(inputField)
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       'some value to be copied',
     )

--- a/src/__tests__/lib/containers/DirectDownload.test.tsx
+++ b/src/__tests__/lib/containers/DirectDownload.test.tsx
@@ -1,33 +1,108 @@
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
 import * as React from 'react'
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
 import DirectDownload, {
   DirectFileDownloadProps,
 } from '../../../lib/containers/DirectDownload'
-import { act } from '@testing-library/react'
-import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
-import { SynapseTestContext } from '../../../mocks/MockSynapseContext'
+import { createWrapper } from '../../../lib/testutils/TestingLibraryUtils'
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '../../../lib/utils/functions/getEndpoint'
+import {
+  BatchFileResult,
+  FileHandleAssociateType,
+} from '../../../lib/utils/synapseTypes'
+import { CloudProviderFileHandleConcreteTypeEnum } from '../../../lib/utils/synapseTypes/CloudProviderFileHandle'
+import {
+  mockFileEntity,
+  MOCK_FILE_ENTITY_ID,
+} from '../../../mocks/entity/mockEntity'
+import { rest, server } from '../../../mocks/msw/server'
+import { MOCK_USER_ID } from '../../../mocks/user/mock_user_profile'
 
 describe('DirectDownload: basic functionality', () => {
   const props: DirectFileDownloadProps = {
-    associatedObjectId: 'abc',
-    entityVersionNumber: '345',
+    associatedObjectId: MOCK_FILE_ENTITY_ID,
+    associatedObjectType: FileHandleAssociateType.FileEntity,
+    entityVersionNumber: mockFileEntity.versionNumber?.toString(),
   }
 
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  const batchFileResponse: BatchFileResult = {
+    requestedFiles: [
+      {
+        fileHandleId: '69241673',
+        fileHandle: {
+          id: '69241673',
+          etag: '13aa7228-c75f-4e73-aeb2-b5304b8f1e6c',
+          createdBy: MOCK_USER_ID.toString(),
+          createdOn: '2020-11-30T15:57:57.000Z',
+          modifiedOn: '2020-11-30T15:57:57.000Z',
+          concreteType: CloudProviderFileHandleConcreteTypeEnum.S3FileHandle,
+          contentType: 'image/png',
+          contentMd5: 'fa4b066053ce2d5d23ae3f3774925dfd',
+          fileName: 'test-file-handle.png',
+          storageLocationId: 1,
+          contentSize: 464978,
+          status: 'AVAILABLE',
+          bucketName: 'proddata.sagebase.org',
+          key: '3329874/daff448b-d801-4b7c-8fa4-9ca33f0ba9ff/test-file-handle.png',
+          isPreview: false,
+        },
+        preSignedURL: 'https://s3.amazonaws.com/some-presigned-url',
+      },
+    ],
+  }
   it('render direct download component without crashing', async () => {
-    const wrapper = mount(<DirectDownload {...props} />, {
-      wrappingComponent: SynapseTestContext,
+    server.use(
+      rest.post(
+        `${getEndpoint(
+          BackendDestinationEnum.REPO_ENDPOINT,
+        )}/file/v1/fileHandle/batch`,
+
+        async (req, res, ctx) => {
+          return res(ctx.status(200), ctx.json(batchFileResponse))
+        },
+      ),
+    )
+
+    render(<DirectDownload {...props} />, {
+      wrapper: createWrapper(),
     })
     mockAllIsIntersecting(true)
-    expect(wrapper).toBeDefined()
+    await screen.findByRole('img')
   })
 
-  it('file handle fetch failure should display nothing', async () => {
-    await act(async () => {
-      const wrapper = await mount(<DirectDownload {...props} />, {
-        wrappingComponent: SynapseTestContext,
-      })
-      mockAllIsIntersecting(true)
-      expect(wrapper.children()).toEqual({})
+  it('file handle fetch failure should display nothing', () => {
+    server.use(
+      rest.post(
+        `${getEndpoint(
+          BackendDestinationEnum.REPO_ENDPOINT,
+        )}/file/v1/fileHandle/batch`,
+
+        async (req, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.json({
+              requestedFiles: [
+                {
+                  fileHandleId: '29241673',
+                  failureCode: 'UNAUTHORIZED',
+                },
+              ],
+            }),
+          )
+        },
+      ),
+    )
+
+    render(<DirectDownload {...props} />, {
+      wrapper: createWrapper(),
     })
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
 })

--- a/src/__tests__/lib/containers/EntityForm.test.tsx
+++ b/src/__tests__/lib/containers/EntityForm.test.tsx
@@ -1,20 +1,11 @@
+import { render, screen } from '@testing-library/react'
 import * as React from 'react'
-import { mount } from 'enzyme'
 import EntityForm, { EntityFormProps } from '../../../lib/containers/EntityForm'
-import { mockUserProfileData } from '../../../mocks/user/mock_user_profile'
+import { createWrapper } from '../../../lib/testutils/TestingLibraryUtils'
 import { mockFileEntity } from '../../../mocks/entity/mockEntity'
-import reactJsonschemaForm from '@rjsf/core'
-import { SynapseTestContext } from '../../../mocks/MockSynapseContext'
+import { mockUserProfileData } from '../../../mocks/user/mock_user_profile'
 
-const createShallowComponent = (props: EntityFormProps) => {
-  const wrapper = mount(<EntityForm {...props} />, {
-    wrappingComponent: SynapseTestContext,
-  })
-  const instance = wrapper.instance() as EntityForm
-  return { wrapper, instance }
-}
-
-describe('it basic tests', () => {
+describe('EntityForm', () => {
   // Test setup
   const SynapseClient = require('../../../lib/utils/SynapseClient')
   SynapseClient.getUserProfile = jest.fn(() =>
@@ -24,6 +15,12 @@ describe('it basic tests', () => {
   SynapseClient.lookupChildEntity = jest.fn(() =>
     Promise.resolve({ id: targetFolderId }),
   )
+  SynapseClient.getFileResult = jest.fn(() =>
+    Promise.resolve({ presignedUrl: 'presigned-url' }),
+  )
+
+  SynapseClient.getFileHandleContent = jest.fn(() => Promise.resolve('{}'))
+
   SynapseClient.getEntity = jest.fn(() => Promise.resolve(mockFileEntity))
   const parentContainerId: string = 'syn20355732'
   const formSchemaEntityId: string = 'syn20184776'
@@ -37,13 +34,12 @@ describe('it basic tests', () => {
     initFormData,
     synIdCallback,
   }
-  it('renders without crashing', () => {
-    const { wrapper } = createShallowComponent(props)
-    expect(wrapper).toBeDefined()
-  })
 
   it('renders Form', () => {
-    const { wrapper } = createShallowComponent(props)
-    expect(wrapper.find(reactJsonschemaForm)).toBeDefined()
+    const { container } = render(<EntityForm {...props} />, {
+      wrapper: createWrapper(),
+    })
+    const form = container.querySelector('form')
+    expect(form).toBeDefined()
   })
 })

--- a/src/__tests__/lib/containers/ErrorPage.test.tsx
+++ b/src/__tests__/lib/containers/ErrorPage.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
 import ErrorPage, { ErrorPageProps } from '../../../lib/containers/ErrorPage'
 
 describe('DirectDownload: basic functionality', () => {
@@ -9,15 +9,11 @@ describe('DirectDownload: basic functionality', () => {
     message: '5678',
   }
 
-  it('render error page component without crashing', async () => {
-    const wrapper = mount(<ErrorPage {...propsNoAccess} />)
-    expect(wrapper).toBeDefined()
-  })
-
-  it('should render the correct content', async () => {
-    const wrapper = mount(<ErrorPage {...propsNoAccess} />)
-    expect(wrapper.find('no-access.svg')).not.toBeNull()
-    expect(wrapper.find('h2').text()).toEqual('bcd')
-    expect(wrapper.find('p').text()).toEqual('5678')
+  it('should render the correct content', () => {
+    render(<ErrorPage {...propsNoAccess} />)
+    // Should actually be an image, but our test platform doesn't currently load SVGs imported as React Components
+    screen.getByText('no-access.svg')
+    screen.getByRole('heading', { name: propsNoAccess.title })
+    screen.getByText(propsNoAccess.message)
   })
 })

--- a/src/__tests__/lib/containers/IconSvg.test.tsx
+++ b/src/__tests__/lib/containers/IconSvg.test.tsx
@@ -1,6 +1,6 @@
-import { mount } from 'enzyme'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as React from 'react'
-import ReactTooltip from 'react-tooltip'
 import IconSvg, { IconSvgOptions } from '../../../lib/containers/IconSvg'
 
 describe('IconSvg: basic functionality', () => {
@@ -9,14 +9,9 @@ describe('IconSvg: basic functionality', () => {
     color: '#000000',
   }
 
-  it('render component without crashing', async () => {
-    const wrapper = mount(<IconSvg options={iconOptions} />)
-    expect(wrapper).toBeDefined()
-  })
-
-  it('should render the correct icon', async () => {
-    const wrapper = mount(<IconSvg options={iconOptions} />)
-    expect(wrapper.find('.styled-svg-wrapper').prop('data-svg')).toEqual('data')
+  it('should render an image', () => {
+    render(<IconSvg options={iconOptions} />)
+    screen.getByRole('img')
   })
 
   it('should render tooltip when label is set', async () => {
@@ -25,7 +20,9 @@ describe('IconSvg: basic functionality', () => {
       color: '#000000',
       label: 'abc',
     }
-    const wrapper = mount(<IconSvg options={iconOptionsWithLabel} />)
-    expect(wrapper.containsMatchingElement(<ReactTooltip />)).toEqual(true)
+    render(<IconSvg options={iconOptionsWithLabel} />)
+    const iconContainer = screen.getByRole('img')
+    userEvent.hover(iconContainer)
+    await screen.findByText(iconOptionsWithLabel.label!)
   })
 })

--- a/src/__tests__/lib/containers/Login.test.tsx
+++ b/src/__tests__/lib/containers/Login.test.tsx
@@ -1,7 +1,7 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as React from 'react'
-import { shallow } from 'enzyme'
 import Login from '../../../lib/containers/Login'
-import { resolveAllPending } from '../../../lib/testutils/EnzymeHelpers'
 
 const SynapseClient = require('../../../lib/utils/SynapseClient')
 SynapseClient.login = jest.fn().mockResolvedValue({
@@ -14,22 +14,17 @@ describe('Functionality of Login Component', () => {
   const callback = jest.fn()
 
   it('renders', () => {
-    const tree = shallow(<Login sessionCallback={callback} />)
-    expect(tree).toBeDefined()
+    render(<Login sessionCallback={callback} />)
+    screen.getByLabelText('Username or Email Address')
+    screen.getByLabelText('Password')
   })
 
   it('Makes a login request and invokes the callback when clicking Sign In', async () => {
-    const tree = shallow(<Login sessionCallback={callback} />)
+    render(<Login sessionCallback={callback} />)
 
-    const loginButton = tree.findWhere(
-      n =>
-        n.name() === 'Button' &&
-        n.prop('className').includes('SRC-login-button'),
-    )
-    loginButton.prop('onSubmit')({ preventDefault: () => {} })
+    userEvent.click(screen.getByRole('button', { name: 'Log in' }))
 
-    await resolveAllPending(tree)
-    expect(SynapseClient.login).toHaveBeenCalled()
-    expect(callback).toHaveBeenCalled()
+    await waitFor(() => expect(SynapseClient.login).toHaveBeenCalled())
+    await waitFor(() => expect(callback).toHaveBeenCalled())
   })
 })

--- a/src/__tests__/lib/containers/widgets/Checkbox.test.tsx
+++ b/src/__tests__/lib/containers/widgets/Checkbox.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { mount, HTMLAttributes, ReactWrapper } from 'enzyme'
 import {
   Checkbox,
   CheckboxProps,
@@ -9,57 +8,42 @@ import userEvent from '@testing-library/user-event'
 
 const mockCallback = jest.fn()
 
-function createTestProps(overrides?: CheckboxProps): CheckboxProps {
-  return {
-    label: 'checkboxLabel',
-    checked: true,
-    className: 'checkboxClass',
-    onChange: mockCallback,
-    ...overrides,
-  }
+const props: CheckboxProps = {
+  label: 'checkboxLabel',
+  checked: true,
+  className: 'checkboxClass',
+  onChange: mockCallback,
 }
-let wrapper: ReactWrapper<any, Readonly<{}>, React.Component<{}, {}, any>>
-let props: CheckboxProps
-let checkboxProps: HTMLAttributes
-
-function init(overrides?: CheckboxProps) {
-  props = createTestProps(overrides)
-  wrapper = mount(<Checkbox {...props} />)
-  checkboxProps = wrapper.find('input').props()
-}
-
-beforeEach(() => init())
 
 describe('basic function', () => {
   it('should render with correct properties', () => {
-    expect(wrapper).toBeDefined()
-    expect(wrapper.find('label').text()).toBe(props.label)
-    expect(checkboxProps.checked).toBe(true)
-    expect(checkboxProps.id!.startsWith('src-checkbox-')).toBe(true)
-    expect(wrapper.find('div').at(0).hasClass('checkboxClass')).toBe(true)
+    render(<Checkbox {...props} />)
+
+    expect(screen.queryByRole('checkbox')).toBeInTheDocument()
+    expect(screen.queryByLabelText(props.label)).toBeInTheDocument()
+    expect(screen.getByRole<HTMLInputElement>('checkbox').checked).toBe(true)
+    expect(
+      screen
+        .getByRole<HTMLInputElement>('checkbox')
+        .id.startsWith('src-checkbox-'),
+    ).toBe(true)
   })
 
   it('should render with correct checked state', () => {
-    init({ ...props, checked: false })
-    expect(checkboxProps.checked).toBe(false)
+    render(<Checkbox {...props} checked={false} />)
+    expect(screen.getByRole<HTMLInputElement>('checkbox').checked).toBe(false)
   })
 
   it('should call callbackFn on change with correct params and change the value', () => {
-    init({ ...props, checked: false })
+    render(<Checkbox {...props} checked={false} />)
 
-    let event = {
-      target: {
-        checked: true,
-      },
-    } as React.ChangeEvent<HTMLInputElement>
-
-    expect(wrapper.find('input').props().checked).toBe(false)
-    wrapper.find('input').simulate('change', event)
+    userEvent.click(screen.getByRole('checkbox'))
     expect(mockCallback).toHaveBeenCalledWith(true)
-    expect(wrapper.find('input').props().checked).toBe(true)
+
+    expect(screen.getByRole<HTMLInputElement>('checkbox').checked).toBe(true)
   })
 
-  it('should be accessible via RTL', async () => {
+  it('should be accessible via RTL', () => {
     render(<Checkbox {...props} />)
     expect(() => screen.getByRole('checkbox')).not.toThrowError()
 

--- a/src/lib/containers/IconSvg.tsx
+++ b/src/lib/containers/IconSvg.tsx
@@ -273,6 +273,7 @@ const IconSvg: React.FunctionComponent<IconSvgProps> = props => {
         id={`icon-${icon}`}
         data-for={`icon-${icon}`}
         data-tip={label}
+        role={'img'}
       >
         {getIcon(options)}
       </span>

--- a/src/lib/containers/MarkdownSynapse.tsx
+++ b/src/lib/containers/MarkdownSynapse.tsx
@@ -667,7 +667,11 @@ export default class MarkdownSynapse extends React.Component<
       text += p4
       elements.push(
         <div key={p4}>
-          <a className={`link ${TOC_CLASS[Number(p2)]}`} data-anchor={p3}>
+          <a
+            role="link"
+            className={`link ${TOC_CLASS[Number(p2)]}`}
+            data-anchor={p3}
+          >
             {p4}
           </a>
         </div>,

--- a/src/lib/containers/widgets/RadioGroup.tsx
+++ b/src/lib/containers/widgets/RadioGroup.tsx
@@ -17,7 +17,7 @@ export const RadioGroup: React.FunctionComponent<RadioGroupProps> = (
     : `radiogroup`
 
   return (
-    <div className={className}>
+    <div className={className} role="radiogroup">
       {props.options.map(option => (
         <RadioOption
           groupId={props.id}
@@ -49,6 +49,9 @@ const RadioOption: React.FunctionComponent<RadioOptionProps> = (
       <input
         id={uniqueId}
         type="radio"
+        onChange={() => {
+          // no-op -- change is handled by the div
+        }}
         checked={props.currentValue === props.value}
         value={props.value}
       />

--- a/src/lib/template_style/_form.scss
+++ b/src/lib/template_style/_form.scss
@@ -103,8 +103,8 @@
   }
   input[type='checkbox']:focus + label::before,
   input[type='checkbox']:focus + span::before,
-  input[type='radio']:focus:checked + label::before,
-  input[type='radio']:focus:checked + span::before,
+  input[type='radio']:focus + label::before,
+  input[type='radio']:focus + span::before,
   input[type='checkbox']:hover:checked:not(:disabled) + label::before,
   input[type='checkbox']:hover:checked:not(:disabled) + span::before,
   input[type='radio']:hover:checked:not(:disabled) + label::before,


### PR DESCRIPTION
Replacing Enzyme tests with RTL tests will
* Give us better confidence in testing behavior rather than implementation
* Unblock us from upgrading to >= React 17

This PR avoids touching actual components whenever possible. Any component changes typically facilitate good testing/accessibility practices, like adding appropriate ARIA roles to elements.