### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  # Maintain dependencies for yarn
-  - package-ecosystem: "yarn"
+  # Maintain dependencies from npm
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

Should automatically create a PR to upgrade the code scan action from v1 (will be deprecated this Dec.) to v2: https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/