### PR TITLE
SWC-5799

### DIFF
--- a/src/lib/containers/FluidModal.tsx
+++ b/src/lib/containers/FluidModal.tsx
@@ -23,7 +23,6 @@ export type FluidModalProps = {
   onClose: () => void
   primaryAction?: ModalAction
   secondaryActions?: ModalAction[]
-  tertiaryActions?: ModalAction[]
 }
 
 function ModalActionButton(props: ModalAction) {
@@ -71,22 +70,6 @@ export const FluidModal = (props: FluidModalProps) => {
       </Modal.Header>
       <Modal.Body>{props.children}</Modal.Body>
       <Modal.Footer>
-        {props.tertiaryActions && (
-          <>
-            {props.tertiaryActions.map((action, index) => {
-              return (
-                <ModalActionButton
-                  key={index}
-                  {...{
-                    variant: 'outline',
-                    ...action,
-                  }}
-                />
-              )
-            })}
-            <div style={{ margin: 'auto' }}></div>
-          </>
-        )}
         {props.secondaryActions &&
           props.secondaryActions.reverse().map((action, index) => {
             return (

--- a/src/lib/containers/entity/metadata/EntityModal.tsx
+++ b/src/lib/containers/entity/metadata/EntityModal.tsx
@@ -70,11 +70,11 @@ export const EntityModal: React.FC<EntityModalProps> = ({
   })
 
   let primaryAction
-  let tertiaryActions
+  let secondaryActions
 
   if (!entityBundle) {
     primaryAction = { skeleton: true }
-    tertiaryActions = undefined
+    secondaryActions = undefined
   } else {
     // TODO: Determine if we're on the entity page to conditonally show this button
     primaryAction = {
@@ -99,7 +99,7 @@ export const EntityModal: React.FC<EntityModalProps> = ({
           annotationEditorFormRef.current?.submit()
         },
       }
-      tertiaryActions = [
+      secondaryActions = [
         {
           copy: 'Cancel',
           onClick: () => {
@@ -108,7 +108,7 @@ export const EntityModal: React.FC<EntityModalProps> = ({
         },
       ]
     } else if (canEdit) {
-      tertiaryActions = [
+      secondaryActions = [
         {
           copy: 'Edit',
           disabled: isVersionable && !isLatestVersion,
@@ -139,7 +139,7 @@ export const EntityModal: React.FC<EntityModalProps> = ({
         show={show}
         onClose={onClose}
         primaryAction={primaryAction}
-        tertiaryActions={tertiaryActions}
+        secondaryActions={secondaryActions}
       >
         <>
           <ReactTooltip


### PR DESCRIPTION
* Move the "Edit" action to the right side of the modal by making it a secondary action, rather than tertiary action, in the FluidModal component
* Remove tertiaryActions since we aren't using it (and shouldn't use it per Synapse style guidelines)