### PR TITLE
Tighten spacing between accessors

### DIFF
--- a/src/lib/containers/dataaccess/SubmissionPage.tsx
+++ b/src/lib/containers/dataaccess/SubmissionPage.tsx
@@ -273,7 +273,7 @@ export default function SubmissionPage(props: SubmissionPageProps) {
           {submission ? (
             submission.accessorChanges.map(accessorChange => (
               <React.Fragment key={accessorChange.userId}>
-                <Typography className="Key" variant="smallText1">
+                <Typography className="Key DataAccessor" variant="smallText1">
                   <span style={{ whiteSpace: 'nowrap' }}>
                     <UserCard
                       key={accessorChange.userId}
@@ -282,7 +282,7 @@ export default function SubmissionPage(props: SubmissionPageProps) {
                     />
                   </span>
                 </Typography>
-                <Typography className="Value" variant="smallText1">
+                <Typography className="Value DataAccessor" variant="smallText1">
                   {upperFirst(
                     toLower(
                       accessorChange.type.substring(

--- a/src/lib/style/components/_submission-page.scss
+++ b/src/lib/style/components/_submission-page.scss
@@ -38,8 +38,14 @@
       > * {
         white-space: nowrap;
       }
+
+      .DataAccessor {
+        margin-top: 5px;
+        margin-bottom: 3px;
+      }
     }
   }
+
   ul {
     padding-left: 25px;
     li {


### PR DESCRIPTION
Previously requesters were spaced out, making each row look like an independent unit of information, when they are actually related.

![image](https://user-images.githubusercontent.com/17580037/172399737-11834509-449c-422e-a5e0-b0d4d50e2f42.png)
