### PR TITLE
QueryWrapper: Split fetching stats and rows

### DIFF
--- a/src/lib/utils/hooks/SynapseAPI/entity/useGetQueryResultBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/entity/useGetQueryResultBundle.ts
@@ -5,6 +5,7 @@ import {
   UseInfiniteQueryOptions,
   useQuery,
   UseQueryOptions,
+  UseQueryResult,
 } from 'react-query'
 import { SynapseClient } from '../../..'
 import { SynapseClientError } from '../../../SynapseClient'
@@ -179,7 +180,7 @@ export function useGetQueryResultBundleWithAsyncStatus(
     data:
       // Don't return a result until we have both rows and stats
       rowResult.data && statsResult.data
-        ? {
+        ? ({
             ...rowResult.data,
             responseBody: rowResult.data.responseBody
               ? {
@@ -188,9 +189,12 @@ export function useGetQueryResultBundleWithAsyncStatus(
                   queryResult: rowResult.data.responseBody.queryResult,
                 }
               : undefined,
-          }
+          } as AsynchronousJobStatus<QueryBundleRequest, QueryResultBundle>)
         : undefined,
-  }
+  } as UseQueryResult<
+    AsynchronousJobStatus<QueryBundleRequest, QueryResultBundle>,
+    SynapseClient.SynapseClientError
+  >
   return resultObject
 }
 export function useInfiniteQueryResultBundle(

--- a/src/lib/utils/hooks/SynapseAPI/entity/useGetQueryResultBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/entity/useGetQueryResultBundle.ts
@@ -172,15 +172,19 @@ export function useGetQueryResultBundleWithAsyncStatus(
     setCurrentAsyncStatus,
   )
 
+  // construct a result object using the two results
   const resultObject = {
+    // For the query status, use the rowResult data since it may be changing/updated more often
     ...rowResult,
     data:
+      // Don't return a result until we have both rows and stats
       rowResult.data && statsResult.data
         ? {
             ...rowResult.data,
             responseBody: rowResult.data.responseBody
               ? {
                   ...statsResult.data?.responseBody,
+                  // Append the rows to the stats result.
                   queryResult: rowResult.data.responseBody.queryResult,
                 }
               : undefined,


### PR DESCRIPTION
When we split QueryWrapper and InfiniteQueryWrapper, one optimization that we forgot to include in QueryWrapper is re-using the non-row data for a query (such as total count of results) when navigating between pages. Fetching data other than rows can be very expensive on the backend, so we should only request this data once. This should greatly improve performance when navigating between pages.