### PR TITLE
Handle case where Synapse serves non-JSON

### DIFF
--- a/src/__tests__/lib/containers/UserCardTests.test.tsx
+++ b/src/__tests__/lib/containers/UserCardTests.test.tsx
@@ -149,7 +149,11 @@ describe('it creates the correct UI for the avatar', () => {
           BackendDestinationEnum.REPO_ENDPOINT,
         )}${PROFILE_IMAGE_PREVIEW(':userId')}`,
         async (req, res, ctx) => {
-          return res(ctx.status(200), ctx.text(IMAGE_URL))
+          return res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'text/plain'),
+            ctx.text(IMAGE_URL),
+          )
         },
       ),
       // Handler for the "presigned" URL itself:

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -306,11 +306,14 @@ const fetchWithExponentialTimeout = async <TResponse>(
     response = await fetch(url, options)
   }
 
+  const contentType = response.headers.get('Content-Type')
   const responseBody = await response.text()
   let responseObject: TResponse | SynapseError | string = responseBody
   try {
     // try to parse it as json
-    responseObject = JSON.parse(responseBody) as TResponse | SynapseError
+    if (contentType && contentType.includes('application/json')) {
+      responseObject = JSON.parse(responseBody) as TResponse | SynapseError
+    }
   } catch (error) {
     console.warn('Failed to parse response as JSON', responseBody)
   }


### PR DESCRIPTION
Test suite fails with the following error:
```
  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?

    Attempted to log "Failed to parse response as JSON http://some-image-url.notarealurl/image.jpg".

      313 |     responseObject = JSON.parse(responseBody) as TResponse | SynapseError

      314 |   } catch (error) {

    > 315 |     console.warn('Failed to parse response as JSON', responseBody)

          |             ^

      316 |   }

      317 |

      318 |   if (response.ok) {

      at console.warn (node_modules/@jest/console/build/BufferedConsole.js:232:10)

      at warn (src/lib/utils/SynapseClient.ts:315:13)

      at step (node_modules/tslib/tslib.js:144:27)

      at Object.next (node_modules/tslib/tslib.js:125:57)

      at fulfilled (node_modules/tslib/tslib.js:115:62)
```

We could update this mock function to return JSON, but the Synapse backend doesn't also doesn't return JSON for this endpoint. The correct fix is to check the server response content type before attempting to parse JSON.