### PR TITLE
SWC-6205

### DIFF
--- a/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
+++ b/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
@@ -16,6 +16,7 @@ import { SearchDetails } from './configurations/SearchDetails'
 import { getIsAllSelectedFromInfiniteList } from '../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 import { DetailsView } from './view/DetailsView'
 import { EntityTreeContainer } from '../tree/EntityTree'
+import { SynapseErrorBoundary } from '../../ErrorBanner'
 
 export enum EntityDetailsListDataConfigurationType {
   HEADER_LIST, // simply displays one or more entity headers. incompatible with pagination
@@ -141,5 +142,5 @@ export const EntityDetailsList: React.FunctionComponent<
     setComponent(getComponentFromConfiguration(configuration))
   }, [configuration, sharedProps])
 
-  return component
+  return <SynapseErrorBoundary>{component}</SynapseErrorBoundary>
 }

--- a/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react'
-import { useErrorHandler } from 'react-error-boundary'
+import React, { useState } from 'react'
 import { useGetEntityChildrenInfinite } from '../../../../utils/hooks/SynapseAPI/entity/useGetEntityChildren'
 import { Direction, SortBy } from '../../../../utils/synapseTypes'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
@@ -15,7 +14,6 @@ export const EntityChildrenDetails: React.FunctionComponent<
 > = ({ parentContainerId, ...sharedProps }) => {
   const [sortBy, setSortBy] = useState<SortBy>(SortBy.NAME)
   const [sortDirection, setSortDirection] = useState<Direction>(Direction.ASC)
-  const handleError = useErrorHandler()
 
   const getChildrenInfiniteRequestObject = {
     parentId: parentContainerId,
@@ -24,15 +22,10 @@ export const EntityChildrenDetails: React.FunctionComponent<
     sortBy: sortBy,
     sortDirection: sortDirection,
   }
-  const {
-    data,
-    isLoading,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-    isError,
-    error,
-  } = useGetEntityChildrenInfinite(getChildrenInfiniteRequestObject)
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    useGetEntityChildrenInfinite(getChildrenInfiniteRequestObject, {
+      useErrorBoundary: true,
+    })
   const entities = data?.pages.flatMap(page => page.page) ?? []
   const totalEntities = data?.pages[0].totalChildCount
 
@@ -44,12 +37,6 @@ export const EntityChildrenDetails: React.FunctionComponent<
     fetchNextPage,
     isFetchingNextPage,
   )
-
-  useEffect(() => {
-    if (isError && error) {
-      handleError(error)
-    }
-  }, [isError, error, handleError])
 
   return (
     <DetailsView

--- a/src/lib/containers/entity_finder/details/configurations/FavoritesDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/FavoritesDetails.tsx
@@ -1,25 +1,16 @@
-import React, { useEffect } from 'react'
-import { useErrorHandler } from 'react-error-boundary'
+import React from 'react'
 import { useGetFavoritesInfinite } from '../../../../utils/hooks/SynapseAPI/user/useFavorites'
+import useGetIsAllSelectedFromInfiniteList from '../../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import { DetailsView } from '../view/DetailsView'
-import useGetIsAllSelectedFromInfiniteList from '../../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 
 type FavoritesDetailsProps = EntityDetailsListSharedProps
 
 export const FavoritesDetails: React.FunctionComponent<
   FavoritesDetailsProps
 > = ({ ...sharedProps }) => {
-  const {
-    data,
-    isLoading,
-    hasNextPage,
-    fetchNextPage,
-    isFetchingNextPage,
-    isError,
-    error,
-  } = useGetFavoritesInfinite()
-  const handleError = useErrorHandler()
+  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useGetFavoritesInfinite({ useErrorBoundary: true })
 
   const entities = data?.pages.flatMap(page => page.results) ?? []
 
@@ -31,12 +22,6 @@ export const FavoritesDetails: React.FunctionComponent<
     fetchNextPage,
     isFetchingNextPage,
   )
-
-  useEffect(() => {
-    if (isError && error) {
-      handleError(error)
-    }
-  }, [isError, error, handleError])
 
   return (
     <DetailsView

--- a/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect } from 'react'
-import { useErrorHandler } from 'react-error-boundary'
+import React from 'react'
 import { useGetProjectsInfinite } from '../../../../utils/hooks/SynapseAPI/user/useProjects'
+import useGetIsAllSelectedFromInfiniteList from '../../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 import { GetProjectsParameters } from '../../../../utils/synapseTypes/GetProjectsParams'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import { DetailsView } from '../view/DetailsView'
-import useGetIsAllSelectedFromInfiniteList from '../../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 
 type ProjectListDetailsProps = EntityDetailsListSharedProps & {
   projectsParams: GetProjectsParameters
@@ -13,16 +12,8 @@ type ProjectListDetailsProps = EntityDetailsListSharedProps & {
 export const ProjectListDetails: React.FunctionComponent<
   ProjectListDetailsProps
 > = ({ projectsParams, ...sharedProps }) => {
-  const {
-    data,
-    isLoading,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-    isError,
-    error,
-  } = useGetProjectsInfinite(projectsParams)
-  const handleError = useErrorHandler()
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    useGetProjectsInfinite(projectsParams, { useErrorBoundary: true })
 
   const projects = data?.pages.flatMap(page => page.results) ?? []
 
@@ -34,12 +25,6 @@ export const ProjectListDetails: React.FunctionComponent<
     fetchNextPage,
     isFetchingNextPage,
   )
-
-  useEffect(() => {
-    if (isError && error) {
-      handleError(error)
-    }
-  }, [isError, error, handleError])
 
   return (
     <DetailsView

--- a/src/lib/containers/entity_finder/details/configurations/SearchDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/SearchDetails.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react'
-import { useErrorHandler } from 'react-error-boundary'
+import React from 'react'
 import { useSearchInfinite } from '../../../../utils/hooks/SynapseAPI/search/useSearch'
 import { SearchQuery } from '../../../../utils/synapseTypes/Search'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
@@ -13,24 +12,11 @@ export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
   searchQuery,
   ...sharedProps
 }) => {
-  const {
-    data,
-    isLoading,
-    hasNextPage,
-    fetchNextPage,
-    isFetchingNextPage,
-    error,
-    isError,
-  } = useSearchInfinite(searchQuery, {
-    enabled: !!searchQuery.queryTerm,
-  })
-  const handleError = useErrorHandler()
-
-  useEffect(() => {
-    if (isError && error) {
-      handleError(error)
-    }
-  }, [isError, error, handleError])
+  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useSearchInfinite(searchQuery, {
+      enabled: !!searchQuery.queryTerm,
+      useErrorBoundary: true,
+    })
 
   if (searchQuery.queryTerm) {
     return (


### PR DESCRIPTION


https://user-images.githubusercontent.com/17580037/178755079-e7736b85-a018-4b87-b6bf-fa7a55860fa5.mov


* When in Entity Finder dual-pane view, toggle the selected tree to be open when navigating from the right pane.
* Add an error boundary to EntityDetailsList, which contains all of the API calls that result in populating in the table portion of the dual-pane view.