### PR TITLE
Generalize useGetIsAllSelectedInfiniteList

### DIFF
--- a/src/__tests__/lib/utils/hooks/useGetIsAllSelectedInfiniteList.test.ts
+++ b/src/__tests__/lib/utils/hooks/useGetIsAllSelectedInfiniteList.test.ts
@@ -1,9 +1,23 @@
 import { getIsAllSelectedFromInfiniteList } from '../../../../lib/utils/hooks/useGetIsAllSelectedInfiniteList'
 import { Map } from 'immutable'
 import { EntityHeader, EntityType } from '../../../../lib/utils/synapseTypes'
+import { getEntityTypeFromHeader } from '../../../../lib/utils/functions/EntityTypeUtils'
 
 const ALL_TYPES = Object.values(EntityType)
 const mockFetchNextPage = jest.fn()
+
+function isSelectedInMap(map: Map<string, number>) {
+  return (e: EntityHeader) => {
+    return map.has(e.id)
+  }
+}
+
+function isSelectableByEntityType(types: EntityType[]) {
+  return (e: EntityHeader) => {
+    const type = getEntityTypeFromHeader(e)
+    return types.includes(type)
+  }
+}
 
 describe('getIsAllSelectedInifiniteList tests', () => {
   beforeEach(() => {
@@ -26,8 +40,9 @@ describe('getIsAllSelectedInifiniteList tests', () => {
     expect(
       getIsAllSelectedFromInfiniteList(
         fetchedEntities,
-        selectedEntities,
-        ALL_TYPES,
+        selectedEntities.size,
+        isSelectedInMap(selectedEntities),
+        isSelectableByEntityType(ALL_TYPES),
         false,
         mockFetchNextPage,
         false,
@@ -40,8 +55,9 @@ describe('getIsAllSelectedInifiniteList tests', () => {
     expect(
       getIsAllSelectedFromInfiniteList(
         fetchedEntities,
-        selectedEntities,
-        ALL_TYPES,
+        selectedEntities.size,
+        isSelectedInMap(selectedEntities),
+        isSelectableByEntityType(ALL_TYPES),
         false,
         mockFetchNextPage,
         false,
@@ -65,8 +81,9 @@ describe('getIsAllSelectedInifiniteList tests', () => {
     expect(
       getIsAllSelectedFromInfiniteList(
         fetchedEntities,
-        selectedEntities,
-        ALL_TYPES,
+        selectedEntities.size,
+        isSelectedInMap(selectedEntities),
+        isSelectableByEntityType(ALL_TYPES),
         false,
         mockFetchNextPage,
         false,
@@ -100,8 +117,9 @@ describe('getIsAllSelectedInifiniteList tests', () => {
     expect(
       getIsAllSelectedFromInfiniteList(
         fetchedEntities,
-        selectedEntities,
-        ALL_TYPES,
+        selectedEntities.size,
+        isSelectedInMap(selectedEntities),
+        isSelectableByEntityType(ALL_TYPES),
         false,
         mockFetchNextPage,
         false,
@@ -135,8 +153,9 @@ describe('getIsAllSelectedInifiniteList tests', () => {
     expect(
       getIsAllSelectedFromInfiniteList(
         fetchedEntities,
-        selectedEntities,
-        [EntityType.PROJECT], // can only select projects
+        selectedEntities.size,
+        isSelectedInMap(selectedEntities),
+        isSelectableByEntityType([EntityType.PROJECT]), // can only select projects
         false,
         mockFetchNextPage,
         false,
@@ -170,8 +189,9 @@ describe('getIsAllSelectedInifiniteList tests', () => {
     expect(
       getIsAllSelectedFromInfiniteList(
         fetchedEntities,
-        selectedEntities,
-        ALL_TYPES,
+        selectedEntities.size,
+        isSelectedInMap(selectedEntities),
+        isSelectableByEntityType(ALL_TYPES),
         true, // There is a next page
         mockFetchNextPage,
         false,
@@ -208,8 +228,9 @@ describe('getIsAllSelectedInifiniteList tests', () => {
     expect(
       getIsAllSelectedFromInfiniteList(
         fetchedEntities,
-        selectedEntities,
-        [EntityType.DATASET], // Can only select Datasets
+        selectedEntities.size,
+        isSelectedInMap(selectedEntities),
+        isSelectableByEntityType([EntityType.DATASET]), // Can only select Datasets
         true, // There is a next page
         mockFetchNextPage,
         false,
@@ -246,8 +267,9 @@ describe('getIsAllSelectedInifiniteList tests', () => {
     expect(
       getIsAllSelectedFromInfiniteList(
         fetchedEntities,
-        selectedEntities,
-        ALL_TYPES,
+        selectedEntities.size,
+        isSelectedInMap(selectedEntities),
+        isSelectableByEntityType(ALL_TYPES),
         true, // There is a next page
         mockFetchNextPage,
         true, // isFetching
@@ -284,8 +306,9 @@ describe('getIsAllSelectedInifiniteList tests', () => {
     expect(
       getIsAllSelectedFromInfiniteList(
         fetchedEntities,
-        selectedEntities,
-        [EntityType.FILE], // Can only select Files
+        selectedEntities.size,
+        isSelectedInMap(selectedEntities),
+        isSelectableByEntityType([EntityType.FILE]), // Can only select Files
         true, // There is a next page
         mockFetchNextPage,
         false,

--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -15,12 +15,19 @@ import 'react-reflex/styles.css'
 import { SizeMe } from 'react-sizeme'
 import Arrow from '../../assets/icons/Arrow'
 import { SynapseClient } from '../../utils'
-import { entityTypeToFriendlyName } from '../../utils/functions/EntityTypeUtils'
+import {
+  entityTypeToFriendlyName,
+  getEntityTypeFromHeader,
+} from '../../utils/functions/EntityTypeUtils'
 import { SYNAPSE_ENTITY_ID_REGEX } from '../../utils/functions/RegularExpressions'
 import { useSynapseContext } from '../../utils/SynapseContext'
-import { EntityHeader, Reference } from '../../utils/synapseTypes'
+import {
+  EntityHeader,
+  ProjectHeader,
+  Reference,
+} from '../../utils/synapseTypes'
 import { EntityType } from '../../utils/synapseTypes/EntityType'
-import { KeyValue } from '../../utils/synapseTypes/Search'
+import { Hit, KeyValue } from '../../utils/synapseTypes/Search'
 import { SynapseErrorBoundary } from '../ErrorBanner'
 import IconSvg from '../IconSvg'
 import { BreadcrumbItem, Breadcrumbs, BreadcrumbsProps } from './Breadcrumbs'
@@ -32,6 +39,7 @@ import {
 import { SelectionPane } from './SelectionPane'
 import { EntityTree, EntityTreeContainer, FinderScope } from './tree/EntityTree'
 import { EntityTreeNodeType } from './tree/VirtualizedTree'
+import { useEntitySelection } from './useEntitySelection'
 
 const DEFAULT_SELECTABLE_TYPES = Object.values(EntityType)
 const TABLE_DEFAULT_VISIBLE_TYPES = Object.values(EntityType)
@@ -142,64 +150,21 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
     [setBreadcrumbsProps],
   )
 
-  /**
-   *
-   * @param entity The entity to check selected status
-   * @param selected the list of selected entities
-   * @returns a boolean array of length equal to entities.length denoting selection status
-   */
-  function isSelected(
-    entity: Reference,
-    selected: Map<string, number>,
-  ): boolean {
-    const match = selected.get(entity.targetId)
-    if (match == null) {
-      return false
-    }
-    if (match === NO_VERSION_NUMBER) {
-      return entity.targetVersionNumber === undefined
-    }
-    return match === entity.targetVersionNumber
-  }
+  const [selectedEntities, toggleSelection] = useEntitySelection(selectMultiple)
 
-  /**
-   * Given the existing selections and a list of toggled references, return the new list of selections
-   * @param selected
-   * @param toggledReference
-   * @returns
-   */
-  function entitySelectionReducer(
-    selected: Map<string, number>,
-    toggledReferences: Reference | Reference[],
-  ): Map<string, number> {
-    const newSelected = selected.withMutations(map => {
-      // Note: we currently don't allow selecting two versions of the same entity, so we replace previous selected version with new selected version
-      if (!Array.isArray(toggledReferences)) {
-        toggledReferences = [toggledReferences]
-      }
-      toggledReferences.forEach(toggledReference => {
-        if (isSelected(toggledReference, selected)) {
-          // remove from selection
-          map.delete(toggledReference.targetId)
-        } else {
-          // add to selection
-          if (!selectMultiple) {
-            map.clear()
-          }
-          map.set(
-            toggledReference.targetId,
-            toggledReference.targetVersionNumber ?? NO_VERSION_NUMBER,
-          )
-        }
-      })
-    })
+  const isIdSelected = useCallback(
+    (entity: EntityHeader | ProjectHeader | Hit) => {
+      return selectedEntities.has(entity.id)
+    },
+    [selectedEntities],
+  )
 
-    return newSelected
-  }
-
-  const [selectedEntities, toggleSelection] = useReducer(
-    entitySelectionReducer,
-    Map<string, number>(),
+  const isSelectable = useCallback(
+    (entity: EntityHeader | ProjectHeader | Hit) => {
+      const type = getEntityTypeFromHeader(entity)
+      return selectableTypes.includes(type)
+    },
+    [selectableTypes],
   )
 
   useEffect(() => {
@@ -355,6 +320,8 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
               mustSelectVersionNumber={mustSelectVersionNumber}
               selectColumnType={selectMultiple ? 'checkbox' : 'none'}
               selected={selectedEntities}
+              isIdSelected={isIdSelected}
+              isSelectable={isSelectable}
               visibleTypes={selectableTypes}
               selectableTypes={selectableTypes}
               toggleSelection={toggleSelection}
@@ -418,6 +385,8 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                             mustSelectVersionNumber={mustSelectVersionNumber}
                             showVersionSelection={showVersionSelection}
                             selected={selectedEntities}
+                            isIdSelected={isIdSelected}
+                            isSelectable={isSelectable}
                             visibleTypes={selectableAndVisibleTypesInList}
                             selectableTypes={selectableTypes}
                             selectColumnType={

--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -1,13 +1,5 @@
-import { Map } from 'immutable'
 import pluralize from 'pluralize'
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useReducer,
-  useRef,
-  useState,
-} from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, FormControl } from 'react-bootstrap'
 import { useErrorHandler } from 'react-error-boundary'
 import { ReflexContainer, ReflexElement, ReflexSplitter } from 'react-reflex'

--- a/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
+++ b/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
@@ -1,5 +1,5 @@
 import { Map } from 'immutable'
-import React, { Dispatch, SetStateAction, useState } from 'react'
+import React, { Dispatch, SetStateAction, useCallback, useState } from 'react'
 import useDeepCompareEffect from 'use-deep-compare-effect'
 import {
   EntityHeader,
@@ -17,6 +17,7 @@ import { getIsAllSelectedFromInfiniteList } from '../../../utils/hooks/useGetIsA
 import { DetailsView } from './view/DetailsView'
 import { EntityTreeContainer } from '../tree/EntityTree'
 import { SynapseErrorBoundary } from '../../ErrorBanner'
+import { getEntityTypeFromHeader } from '../../../utils/functions/EntityTypeUtils'
 
 export enum EntityDetailsListDataConfigurationType {
   HEADER_LIST, // simply displays one or more entity headers. incompatible with pagination
@@ -51,6 +52,8 @@ export type EntityDetailsListSharedProps = {
   visibleTypes: EntityType[]
   selected: Map<string, number>
   selectableTypes: EntityType[]
+  isIdSelected: (header: EntityHeader | ProjectHeader) => boolean
+  isSelectable: (header: EntityHeader | ProjectHeader) => boolean
   toggleSelection: (entity: Reference | Reference[]) => void
   latestVersionText?: string
   setCurrentContainer?: Dispatch<SetStateAction<EntityTreeContainer>>
@@ -98,8 +101,9 @@ export const EntityDetailsList: React.FunctionComponent<
               enableSelectAll={sharedProps.enableSelectAll}
               selectAllIsChecked={getIsAllSelectedFromInfiniteList(
                 (config.headerList as (EntityHeader | ProjectHeader)[]) ?? [],
-                sharedProps.selected,
-                sharedProps.selectableTypes,
+                sharedProps.selected.size,
+                sharedProps.isIdSelected,
+                sharedProps.isSelectable,
               )}
             />
           )

--- a/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
+++ b/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
@@ -1,6 +1,7 @@
 import { Map } from 'immutable'
-import React, { Dispatch, SetStateAction, useCallback, useState } from 'react'
+import React, { Dispatch, SetStateAction, useState } from 'react'
 import useDeepCompareEffect from 'use-deep-compare-effect'
+import { getIsAllSelectedFromInfiniteList } from '../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 import {
   EntityHeader,
   EntityType,
@@ -9,15 +10,13 @@ import {
 } from '../../../utils/synapseTypes'
 import { GetProjectsParameters } from '../../../utils/synapseTypes/GetProjectsParams'
 import { SearchQuery } from '../../../utils/synapseTypes/Search'
+import { SynapseErrorBoundary } from '../../ErrorBanner'
+import { EntityTreeContainer } from '../tree/EntityTree'
 import { EntityChildrenDetails } from './configurations/EntityChildrenDetails'
 import { FavoritesDetails } from './configurations/FavoritesDetails'
 import { ProjectListDetails } from './configurations/ProjectListDetails'
 import { SearchDetails } from './configurations/SearchDetails'
-import { getIsAllSelectedFromInfiniteList } from '../../../utils/hooks/useGetIsAllSelectedInfiniteList'
 import { DetailsView } from './view/DetailsView'
-import { EntityTreeContainer } from '../tree/EntityTree'
-import { SynapseErrorBoundary } from '../../ErrorBanner'
-import { getEntityTypeFromHeader } from '../../../utils/functions/EntityTypeUtils'
 
 export enum EntityDetailsListDataConfigurationType {
   HEADER_LIST, // simply displays one or more entity headers. incompatible with pagination

--- a/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/EntityChildrenDetails.tsx
@@ -31,8 +31,9 @@ export const EntityChildrenDetails: React.FunctionComponent<
 
   const selectAllCheckboxState = useGetIsAllSelectedFromInfiniteList(
     entities,
-    sharedProps.selected,
-    sharedProps.selectableTypes,
+    sharedProps.selected.size,
+    sharedProps.isIdSelected,
+    sharedProps.isSelectable,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,

--- a/src/lib/containers/entity_finder/details/configurations/FavoritesDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/FavoritesDetails.tsx
@@ -16,8 +16,9 @@ export const FavoritesDetails: React.FunctionComponent<
 
   const selectAllCheckboxState = useGetIsAllSelectedFromInfiniteList(
     entities,
-    sharedProps.selected,
-    sharedProps.selectableTypes,
+    sharedProps.selected.size,
+    sharedProps.isIdSelected,
+    sharedProps.isSelectable,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,

--- a/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
@@ -19,8 +19,9 @@ export const ProjectListDetails: React.FunctionComponent<
 
   const selectAllCheckboxState = useGetIsAllSelectedFromInfiniteList(
     projects,
-    sharedProps.selected,
-    sharedProps.selectableTypes,
+    sharedProps.selected.size,
+    sharedProps.isIdSelected,
+    sharedProps.isSelectable,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,

--- a/src/lib/containers/entity_finder/useEntitySelection.ts
+++ b/src/lib/containers/entity_finder/useEntitySelection.ts
@@ -1,0 +1,66 @@
+import { useCallback, useReducer } from 'react'
+import { Map } from 'immutable'
+import { Reference } from '../../utils/synapseTypes'
+import { NO_VERSION_NUMBER } from './EntityFinder'
+
+export function useEntitySelection(selectMultiple: boolean) {
+  /**
+   *
+   * @param entity The entity to check selected status
+   * @param selected the list of selected entities
+   * @returns a boolean array of length equal to entities.length denoting selection status
+   */
+  const isSelected = useCallback(
+    (entity: Reference, selected: Map<string, number>): boolean => {
+      const match = selected.get(entity.targetId)
+      if (match == null) {
+        return false
+      }
+      if (match === NO_VERSION_NUMBER) {
+        return entity.targetVersionNumber === undefined
+      }
+      return match === entity.targetVersionNumber
+    },
+    [],
+  )
+
+  /**
+   * Given the existing selections and a list of toggled references, return the new list of selections
+   * @param selected
+   * @param toggledReference
+   * @returns
+   */
+  const entitySelectionReducer = useCallback(
+    (
+      selected: Map<string, number>,
+      toggledReferences: Reference | Reference[],
+    ): Map<string, number> => {
+      const newSelected = selected.withMutations(map => {
+        // Note: we currently don't allow selecting two versions of the same entity, so we replace previous selected version with new selected version
+        if (!Array.isArray(toggledReferences)) {
+          toggledReferences = [toggledReferences]
+        }
+        toggledReferences.forEach(toggledReference => {
+          if (isSelected(toggledReference, selected)) {
+            // remove from selection
+            map.delete(toggledReference.targetId)
+          } else {
+            // add to selection
+            if (!selectMultiple) {
+              map.clear()
+            }
+            map.set(
+              toggledReference.targetId,
+              toggledReference.targetVersionNumber ?? NO_VERSION_NUMBER,
+            )
+          }
+        })
+      })
+
+      return newSelected
+    },
+    [isSelected, selectMultiple],
+  )
+
+  return useReducer(entitySelectionReducer, Map<string, number>())
+}

--- a/src/lib/utils/hooks/useGetIsAllSelectedInfiniteList.ts
+++ b/src/lib/utils/hooks/useGetIsAllSelectedInfiniteList.ts
@@ -11,6 +11,7 @@ import { SynapseClientError } from '../SynapseClientError'
  *
  * We don't currently support an indeterminate checkbox state because that would require always fetching all pages of a given query, which does not scale.
  * @param items An arbitrary list of items that have already been fetched
+ * @param numSelected The number of items that have been selected.
  * @param isSelected A function that takes an item and returns a boolean indicating if that item is selected
  * @param isSelectable A function that takes an item and returns a boolean indicating if that item can be selected
  * @param hasNextPage Whether or not there are additional pages of items (typically supplied by useInfiniteQuery)
@@ -68,6 +69,7 @@ export function getIsAllSelectedFromInfiniteList<TItem, TFetchResult>(
  *
  * There is also a non-hook version of this function that can be called in contexts where hooks cannot be used.
  * @param items An arbitrary list of items that have already been fetched
+ * @param numSelected The number of items that have been selected.
  * @param isSelected A function that takes an item and returns a boolean indicating if that item is selected
  * @param isSelectable A function that takes an item and returns a boolean indicating if that item can be selected
  * @param hasNextPage Whether or not there are additional pages of items (typically supplied by useInfiniteQuery)

--- a/src/lib/utils/hooks/useGetIsAllSelectedInfiniteList.ts
+++ b/src/lib/utils/hooks/useGetIsAllSelectedInfiniteList.ts
@@ -1,44 +1,39 @@
-import { Map } from 'immutable'
 import { useEffect, useState } from 'react'
 import { FetchNextPageOptions, InfiniteQueryObserverResult } from 'react-query'
-import { getEntityTypeFromHeader } from '../functions/EntityTypeUtils'
 import { SynapseClientError } from '../SynapseClientError'
-import { EntityHeader, EntityType, ProjectHeader } from '../synapseTypes'
-import { Hit } from '../synapseTypes/Search'
 
 /**
- * Given a list of entities and a map of which are selected, return a boolean indicating if all of the entities that can be selected
+ * Given a list of items and predicates to determine what items are are selected, and which are selectable, return a boolean indicating if all of the entities that can be selected
  * are selected.
  *
  * This function is compatible with react-query's useInfiniteQuery pagination, in which case it's recommended to use the hook version
  * of this function to get updates as pages are fetched and updated.
  *
  * We don't currently support an indeterminate checkbox state because that would require always fetching all pages of a given query, which does not scale.
- * @param entities An arbitrary list of entities that are displayed
- * @param selected A map where keys are selected entity IDs
- * @param selectableTypes A list of entity types which can be selected. Will be used to filter the list of entities
- * @param hasNextPage Whether or not there are additional pages of entities (typically supplied by useInfiniteQuery)
- * @param fetchNextPage A function to be invoked to fetch an additional page of entities (typically supplied by useInfiniteQuery)
- * @param isFetchingNextPage Indicates if the next page of entities is being fetched (typically supplied by useInfiniteQuery)
- * @returns  true iff all selectable entities have been selected, and there are no additional pages to fetch (because an unfetched page may include an unselected entity)
+ * @param items An arbitrary list of items that have already been fetched
+ * @param isSelected A function that takes an item and returns a boolean indicating if that item is selected
+ * @param isSelectable A function that takes an item and returns a boolean indicating if that item can be selected
+ * @param hasNextPage Whether or not there are additional pages of items (typically supplied by useInfiniteQuery)
+ * @param fetchNextPage A function to be invoked to fetch an additional page of items (typically supplied by useInfiniteQuery)
+ * @param isFetchingNextPage Indicates if the next page of items is being fetched (typically supplied by useInfiniteQuery)
+ * @returns true iff all selectable items have been selected, and there are no additional pages to fetch (because an unfetched page may include an unselected item)
  */
-export function getIsAllSelectedFromInfiniteList<T>(
-  entities: (EntityHeader | ProjectHeader | Hit)[],
-  selected: Map<string, number>,
-  selectableTypes: EntityType[],
+export function getIsAllSelectedFromInfiniteList<TItem, TFetchResult>(
+  items: TItem[],
+  numSelected: number,
+  isSelected: (item: TItem) => boolean,
+  isSelectable: (item: TItem) => boolean,
   hasNextPage?: boolean | undefined,
   fetchNextPage?: (
     options?: FetchNextPageOptions | undefined,
-  ) => Promise<InfiniteQueryObserverResult<T, SynapseClientError>>,
+  ) => Promise<InfiniteQueryObserverResult<TFetchResult, SynapseClientError>>,
   isFetchingNextPage?: boolean,
 ): boolean {
-  if (entities.length === 0 || selected.size === 0) {
+  if (items.length === 0 || numSelected === 0) {
     return false
   } else {
-    const allSelectableFetchedChildrenAreSelected = entities.every(
-      e =>
-        selected.has(e.id) ||
-        !selectableTypes.includes(getEntityTypeFromHeader(e)),
+    const allSelectableFetchedChildrenAreSelected = items.every(
+      e => isSelected(e) || !isSelectable(e),
     )
     if (
       allSelectableFetchedChildrenAreSelected &&
@@ -57,9 +52,7 @@ export function getIsAllSelectedFromInfiniteList<T>(
 
       // At this point, we've fetched all of the pages or encountered an unselected entity
       // The checkbox should be true if there are no unselected entities, and there's at least one selectable entity
-      const selectableEntitiesArePresent = entities.some(e =>
-        selectableTypes.includes(getEntityTypeFromHeader(e)),
-      )
+      const selectableEntitiesArePresent = items.some(e => isSelectable(e))
       return (
         allSelectableFetchedChildrenAreSelected && selectableEntitiesArePresent
       )
@@ -68,49 +61,54 @@ export function getIsAllSelectedFromInfiniteList<T>(
 }
 
 /**
-/**
- * Given a list of entities and a map of which are selected, return a boolean indicating if all of the entities that can be selected
+ * Given a list of items and predicates to determine what items are are selected, and which are selectable, return a boolean indicating if all of the entities that can be selected
  * are selected.
- * 
+ *
  * This function is compatible with react-query's useInfiniteQuery pagination.
- * 
+ *
  * There is also a non-hook version of this function that can be called in contexts where hooks cannot be used.
- * @param entities An arbitrary list of entities that are displayed
- * @param selected A map where keys are selected entity IDs
- * @param selectableTypes A list of entity types which can be selected. Will be used to filter the list of entities
- * @param hasNextPage Whether or not there are additional pages of entities (typically supplied by useInfiniteQuery)
- * @param fetchNextPage A function to be invoked to fetch an additional page of entities (typically supplied by useInfiniteQuery)
- * @param isFetchingNextPage Indicates if the next page of entities is being fetched (typically supplied by useInfiniteQuery)
- * @returns  true iff all selectable entities have been selected, and there are no additional pages to fetch (because an unfetched page may include an unselected entity)
+ * @param items An arbitrary list of items that have already been fetched
+ * @param isSelected A function that takes an item and returns a boolean indicating if that item is selected
+ * @param isSelectable A function that takes an item and returns a boolean indicating if that item can be selected
+ * @param hasNextPage Whether or not there are additional pages of items (typically supplied by useInfiniteQuery)
+ * @param fetchNextPage A function to be invoked to fetch an additional page of items (typically supplied by useInfiniteQuery)
+ * @param isFetchingNextPage Indicates if the next page of items is being fetched (typically supplied by useInfiniteQuery)
+ * @returns true iff all selectable items have been selected, and there are no additional pages to fetch (because an unfetched page may include an unselected item)
  */
-export default function useGetIsAllSelectedFromInfiniteList<T>(
-  entities: (EntityHeader | ProjectHeader | Hit)[],
-  selected: Map<string, number>,
-  selectableTypes: EntityType[],
+export default function useGetIsAllSelectedFromInfiniteList<
+  TItem,
+  TFetchResult,
+>(
+  items: TItem[],
+  numSelected: number,
+  isSelected: (item: TItem) => boolean,
+  isSelectable: (item: TItem) => boolean,
   hasNextPage?: boolean | undefined,
   fetchNextPage?: (
     options?: FetchNextPageOptions | undefined,
-  ) => Promise<InfiniteQueryObserverResult<T, SynapseClientError>>,
+  ) => Promise<InfiniteQueryObserverResult<TFetchResult, SynapseClientError>>,
   isFetchingNextPage?: boolean,
 ) {
   const [isSelectAll, setIsSelectAll] = useState(false)
   useEffect(() => {
     setIsSelectAll(
       getIsAllSelectedFromInfiniteList(
-        entities,
-        selected,
-        selectableTypes,
+        items,
+        numSelected,
+        isSelected,
+        isSelectable,
         hasNextPage,
         fetchNextPage,
         isFetchingNextPage,
       ),
     )
   }, [
-    entities,
+    items,
+    numSelected,
     fetchNextPage,
     hasNextPage,
-    selected,
-    selectableTypes,
+    isSelected,
+    isSelectable,
     isFetchingNextPage,
   ])
 


### PR DESCRIPTION
I was considering re-using `useGetIsAllSelectedFromInfiniteList` for the Trash Can page. I ultimately decided against it, but first rewrote the hook as it only worked with the Entity Finder.

In the hook and underlying function, replace Entity Finder-specific data structures with predicate arguments, so that the utility can be used with items of any type.