### PR TITLE
Add aria-label for checkboxes without a visible label

### DIFF
--- a/src/lib/containers/entity_finder/details/view/DetailsView.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsView.tsx
@@ -296,7 +296,8 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
           }}
         >
           <Checkbox
-            label=""
+            label="Select All"
+            hideLabel={true}
             className="SRC-pointer-events-none"
             checked={selectAllIsChecked}
             disabled={!isEnabled}

--- a/src/lib/containers/entity_finder/details/view/DetailsViewTableRenderers.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsViewTableRenderers.tsx
@@ -232,7 +232,8 @@ export function DetailsViewCheckboxRenderer({
   return (
     !isDisabled && (
       <Checkbox
-        label=""
+        label={`Select ${rowData.entityId}`}
+        hideLabel={true}
         className="SRC-pointer-events-none"
         checked={isSelected}
         onChange={() => {
@@ -438,7 +439,8 @@ export function DatasetEditorCheckboxRenderer(
       <Checkbox
         data-testid={`dataset-editor-checkbox-${entityId}`}
         disabled={isDisabled}
-        label=""
+        label={`Select ${entityId}`}
+        hideLabel={true}
         checked={isSelected}
         onChange={value => {
           setSelected(value)

--- a/src/lib/containers/table/datasets/DatasetItemsEditor.tsx
+++ b/src/lib/containers/table/datasets/DatasetItemsEditor.tsx
@@ -388,7 +388,8 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
         }}
       >
         <Checkbox
-          label=""
+          label="Select All"
+          hideLabel={true}
           className="SRC-pointer-events-none"
           checked={isChecked}
           disabled={datasetToUpdate.items.length === 0}

--- a/src/lib/containers/widgets/Checkbox.tsx
+++ b/src/lib/containers/widgets/Checkbox.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 
 export type CheckboxProps = {
   label: string
+  hideLabel?: boolean
   checked?: boolean
   className?: string
   onChange: (newValue: boolean) => void
@@ -18,6 +19,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
 ) => {
   const {
     checked: propsChecked = false,
+    hideLabel = false,
     isSelectAll = false,
     disabled = false,
   } = props
@@ -49,6 +51,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
   return (
     <div className={className} onClick={props.onClick}>
       <input
+        aria-label={props.label}
         type="checkbox"
         checked={checked}
         id={uniqueId}
@@ -56,7 +59,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
         disabled={disabled}
         data-testid={props['data-testid']}
       />
-      <label htmlFor={uniqueId}>{props.label}</label>
+      {!hideLabel && <label htmlFor={uniqueId}>{props.label}</label>}
       {props.children ?? <></>}
     </div>
   )

--- a/src/lib/containers/widgets/Checkbox.tsx
+++ b/src/lib/containers/widgets/Checkbox.tsx
@@ -59,7 +59,7 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (
         disabled={disabled}
         data-testid={props['data-testid']}
       />
-      {!hideLabel && <label htmlFor={uniqueId}>{props.label}</label>}
+      {<label htmlFor={uniqueId}>{hideLabel ? <></> : props.label}</label>}
       {props.children ?? <></>}
     </div>
   )


### PR DESCRIPTION
Instead of providing an empty string as for a label, which is inaccessible, apply the label to the checkbox using `aria-label` and add the ability to hide the label with a new `hideLabel` prop.