### PR TITLE
SWC-5637: Set modal-footer-margin-between to 0 because it breaks alignment

### DIFF
--- a/src/lib/style/bootstrap4_backports/_base-import.scss
+++ b/src/lib/style/bootstrap4_backports/_base-import.scss
@@ -15,6 +15,7 @@
   $input-border-color: SRC.$border-color-gray;
   $input-border-width: 1px;
   $input-border-radius: 2px;
+  $modal-footer-margin-between: 0rem;
   @import 'bootstrap/scss/bootstrap';
 
   .alert-danger {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17580037/181765966-c8618160-1ea6-4b22-a86e-88426717acfe.png)

Spacing is still OK when there are multiple buttons:
<img width="325" alt="image" src="https://user-images.githubusercontent.com/17580037/181766579-040a694f-1a67-424f-9c32-ce17305bb616.png">
