### PR TITLE
SWC-6017 - Dropdown icon from caret to chevron

### DIFF
--- a/src/lib/style/bootstrap4_backports/_base-import.scss
+++ b/src/lib/style/bootstrap4_backports/_base-import.scss
@@ -16,6 +16,8 @@
   $input-border-width: 1px;
   $input-border-radius: 2px;
   $modal-footer-margin-between: 0rem;
+  // Hide the caret, we will replace it with a chevron (see .dropdown-toggle in overrides.scss)
+  $enable-caret: false;
   @import 'bootstrap/scss/bootstrap';
 
   .alert-danger {

--- a/src/lib/style/bootstrap4_backports/_overrides.scss
+++ b/src/lib/style/bootstrap4_backports/_overrides.scss
@@ -40,8 +40,13 @@
     box-shadow: SRC.$box-shadow-soft;
   }
 
-  button.dropdown-toggle.btn::after {
-    font-size: 18px;
+  .dropdown-toggle {
+    &::after {
+      margin-left: 0.8em;
+      content: '›';
+      transform: rotate(90deg) scaleX(1.33);
+      font-weight: 500;
+    }
   }
 
   .dropdown-toggle.secondary-caret::after {

--- a/src/lib/style/components/entity_finder/_tree-view.scss
+++ b/src/lib/style/components/entity_finder/_tree-view.scss
@@ -65,9 +65,6 @@
     button.btn {
       padding: 5px 10px;
     }
-    button.btn::after {
-      margin-left: 7px;
-    }
   }
 
   .Placeholder {


### PR DESCRIPTION
# Entity Finder  
Before:
![Screen Shot 2022-08-10 at 12 27 57 PM](https://user-images.githubusercontent.com/17580037/183963428-b57a0df7-8fed-4919-a01c-abe17d77f07a.png)

After:
![Screen Shot 2022-08-10 at 12 22 30 PM](https://user-images.githubusercontent.com/17580037/183963207-4d6200b4-f17c-4cd9-a159-346a375e2880.png)

# Facet selection dropdown (uses secondary color)
Before:
![Screen Shot 2022-08-10 at 12 27 26 PM](https://user-images.githubusercontent.com/17580037/183963423-546ac887-8e57-47e1-a0b1-61e107732687.png)

After:
![Screen Shot 2022-08-10 at 12 24 12 PM](https://user-images.githubusercontent.com/17580037/183963213-0381d94f-c7f3-4836-aa3e-aba8075537ee.png)
