### PR TITLE
SWC-5961: UserCardSmall improvements

### DIFF
--- a/src/__tests__/lib/containers/UserCardTests.test.tsx
+++ b/src/__tests__/lib/containers/UserCardTests.test.tsx
@@ -257,6 +257,17 @@ describe('it creates the correct UI for the small card', () => {
     await screen.findByText(`@${mockUserProfileData.userName}`)
     expect(container.querySelector('span.UserCardSmall')).not.toBeNull()
   })
+
+  test('showFullName', async () => {
+    renderSmallUserCard({
+      ...props,
+      showFullName: true,
+    })
+    await screen.findByText(
+      `${mockUserProfileData.firstName} ${mockUserProfileData.lastName}`,
+    )
+    await screen.findByText(`(@${mockUserProfileData.userName})`)
+  })
 })
 
 describe('it creates the correct UI for the medium card', () => {

--- a/src/__tests__/lib/containers/UserSearchBoxV2.test.tsx
+++ b/src/__tests__/lib/containers/UserSearchBoxV2.test.tsx
@@ -31,7 +31,7 @@ describe('UserSearchBoxV2 tests', () => {
     userEvent.type(input, MOCK_USER_NAME.substring(0, 3))
 
     // Make a selection
-    await selectEvent.select(input, '@' + MOCK_USER_NAME)
+    await selectEvent.select(input, new RegExp('@' + MOCK_USER_NAME))
 
     await waitFor(() =>
       expect(onChange).toHaveBeenLastCalledWith(

--- a/src/__tests__/lib/containers/dataaccess/AccessHistoryDashboard.test.tsx
+++ b/src/__tests__/lib/containers/dataaccess/AccessHistoryDashboard.test.tsx
@@ -109,7 +109,7 @@ describe('AccessHistoryDashboard tests', () => {
 
     const userInput = await screen.findByRole('textbox')
     userEvent.type(userInput, MOCK_USER_NAME.substring(0, 1))
-    await selectEvent.select(userInput, '@' + MOCK_USER_NAME)
+    await selectEvent.select(userInput, new RegExp('@' + MOCK_USER_NAME))
 
     await screen.findByLabelText('Select a user to view their access history')
     await screen.findByLabelText('Filter by Access Requirement Name')
@@ -140,7 +140,7 @@ describe('AccessHistoryDashboard tests', () => {
 
     const userInput = await screen.findByRole('textbox')
     userEvent.type(userInput, MOCK_USER_NAME.substring(0, 1))
-    await selectEvent.select(userInput, '@' + MOCK_USER_NAME)
+    await selectEvent.select(userInput, new RegExp('@' + MOCK_USER_NAME))
 
     await waitFor(() =>
       expect(
@@ -171,7 +171,7 @@ describe('AccessHistoryDashboard tests', () => {
     const { history } = renderComponent()
     const userInput = await screen.findByRole('textbox')
     userEvent.type(userInput, MOCK_USER_NAME.substring(0, 1))
-    await selectEvent.select(userInput, '@' + MOCK_USER_NAME)
+    await selectEvent.select(userInput, new RegExp('@' + MOCK_USER_NAME))
 
     await screen.findByLabelText('Select a user to view their access history')
     const arNameInput = await screen.findByLabelText(

--- a/src/__tests__/lib/containers/dataaccess/AccessRequirementDashboard.test.tsx
+++ b/src/__tests__/lib/containers/dataaccess/AccessRequirementDashboard.test.tsx
@@ -117,7 +117,7 @@ describe('AccessRequirementDashboard tests', () => {
     const { history } = renderComponent()
     const reviewerInput = (await screen.findAllByRole('textbox'))[2]
     userEvent.type(reviewerInput, MOCK_USER_NAME.substring(0, 1))
-    await selectEvent.select(reviewerInput, '@' + MOCK_USER_NAME)
+    await selectEvent.select(reviewerInput, new RegExp('@' + MOCK_USER_NAME))
 
     await waitFor(() =>
       expect(

--- a/src/__tests__/lib/containers/dataaccess/AccessSubmissionDashboard.test.tsx
+++ b/src/__tests__/lib/containers/dataaccess/AccessSubmissionDashboard.test.tsx
@@ -133,7 +133,7 @@ describe('AccessSubmissionDashboard tests', () => {
     const { history } = renderComponent()
     const requesterInput = (await screen.findAllByRole('textbox'))[1]
     userEvent.type(requesterInput, MOCK_USER_NAME.substring(0, 1))
-    await selectEvent.select(requesterInput, '@' + MOCK_USER_NAME)
+    await selectEvent.select(requesterInput, new RegExp('@' + MOCK_USER_NAME))
 
     await waitFor(() =>
       expect(
@@ -154,7 +154,7 @@ describe('AccessSubmissionDashboard tests', () => {
     const { history } = renderComponent()
     const reviewerInput = (await screen.findAllByRole('textbox'))[2]
     userEvent.type(reviewerInput, MOCK_USER_NAME.substring(0, 1))
-    await selectEvent.select(reviewerInput, '@' + MOCK_USER_NAME)
+    await selectEvent.select(reviewerInput, new RegExp('@' + MOCK_USER_NAME))
 
     await waitFor(() =>
       expect(

--- a/src/lib/containers/UserCardSmall.tsx
+++ b/src/lib/containers/UserCardSmall.tsx
@@ -99,7 +99,8 @@ export const UserCardSmall = (props: UserCardSmallProps) => {
   const fullName =
     showFullName && (userProfile.firstName || userProfile.lastName) ? (
       <span className={'user-fullname'}>
-        {`${userProfile.firstName ?? ''}`}&nbsp;
+        {`${userProfile.firstName ?? ''}`}
+        {userProfile.firstName && userProfile.lastName ? '\u00A0' : ''}
         {`${userProfile.lastName ?? ''}`}
       </span>
     ) : null

--- a/src/lib/containers/UserCardSmall.tsx
+++ b/src/lib/containers/UserCardSmall.tsx
@@ -96,64 +96,44 @@ export const UserCardSmall = (props: UserCardSmallProps) => {
     <></>
   )
 
-  const fullName = showFullName ? (
-    <span className={'user-fullname'}>
-      &nbsp;
-      {`${userProfile.firstName ?? ''}`}&nbsp;{`${userProfile.lastName ?? ''}`}
-    </span>
-  ) : (
-    <></>
-  )
+  const fullName =
+    showFullName && (userProfile.firstName || userProfile.lastName) ? (
+      <span className={'user-fullname'}>
+        {`${userProfile.firstName ?? ''}`}&nbsp;
+        {`${userProfile.lastName ?? ''}`}
+      </span>
+    ) : null
 
-  return showCardOnHover ? (
+  const Tag = showCardOnHover || !disableLink ? 'a' : 'span'
+
+  const style: React.CSSProperties = showCardOnHover
+    ? { whiteSpace: 'nowrap' }
+    : disableLink
+    ? { cursor: 'unset' }
+    : {}
+
+  return (
     <>
-      <OverlayComponent />
-      <a
-        ref={target}
+      {showCardOnHover && <OverlayComponent />}
+      <Tag
+        className={`SRC-userCard UserCardSmall SRC-boldText ${className ?? ''}`}
+        style={style}
         href={disableLink ? undefined : link}
+        target={openLinkInNewTab ? '_blank' : ''}
+        rel={openLinkInNewTab ? 'noreferrer' : ''}
+        ref={target}
         onMouseEnter={() => toggleShow()}
         onMouseLeave={() => toggleHide()}
-        onClick={event => {
-          event.preventDefault()
-          // if someone explicitly set the disable link,
-          // we just return without going to the Synapse's user profile page
-          if (disableLink) {
-            return
-          }
-          window.open(link, '_blank')
-        }}
-        className={`SRC-userCard UserCardSmall ${className ?? ''}`}
-        style={{ whiteSpace: 'nowrap' }}
       >
         {avatar}
-        {`@${userProfile.userName}`}
         {fullName}
+        {fullName ? '\u00A0(' : ''}
+        {`@${userProfile.userName}`}
+        {fullName ? ')' : ''}
         {showAccountLevelIcon && (
           <span className={'account-level-icon'}>{accountLevelIcon}</span>
         )}
-      </a>
+      </Tag>
     </>
-  ) : disableLink ? (
-    <span
-      className="SRC-userCard UserCardSmall SRC-boldText"
-      style={{ cursor: 'unset' }}
-    >
-      {avatar}
-      {`@${userProfile.userName}`}
-      {fullName}
-    </span>
-  ) : (
-    <a>
-      {avatar}
-      {/* eslint-disable-next-line react/jsx-no-target-blank*/}
-      <a
-        className="SRC-userCard UserCardSmall"
-        target={openLinkInNewTab ? '_blank' : ''}
-        rel={openLinkInNewTab ? 'noreferrer' : ''}
-        href={link}
-      >
-        {`@${userProfile.userName}`}
-      </a>
-    </a>
   )
 }

--- a/src/lib/containers/UserCardSmall.tsx
+++ b/src/lib/containers/UserCardSmall.tsx
@@ -26,6 +26,8 @@ export type UserCardSmallProps = {
 const TIMER_DELAY_SHOW = 250 // milliseconds
 const TIMER_DELAY_HIDE = 500
 
+const NONBREAKING_SPACE = '\u00A0'
+
 export const UserCardSmall = (props: UserCardSmallProps) => {
   const {
     userProfile,
@@ -100,18 +102,19 @@ export const UserCardSmall = (props: UserCardSmallProps) => {
     showFullName && (userProfile.firstName || userProfile.lastName) ? (
       <span className={'user-fullname'}>
         {`${userProfile.firstName ?? ''}`}
-        {userProfile.firstName && userProfile.lastName ? '\u00A0' : ''}
+        {userProfile.firstName && userProfile.lastName ? NONBREAKING_SPACE : ''}
         {`${userProfile.lastName ?? ''}`}
       </span>
     ) : null
 
   const Tag = showCardOnHover || !disableLink ? 'a' : 'span'
 
-  const style: React.CSSProperties = showCardOnHover
-    ? { whiteSpace: 'nowrap' }
-    : disableLink
-    ? { cursor: 'unset' }
-    : {}
+  let style: React.CSSProperties = {}
+  if (showCardOnHover) {
+    style = { whiteSpace: 'nowrap' }
+  } else if (disableLink) {
+    style = { cursor: 'unset' }
+  }
 
   return (
     <>
@@ -128,7 +131,7 @@ export const UserCardSmall = (props: UserCardSmallProps) => {
       >
         {avatar}
         {fullName}
-        {fullName ? '\u00A0(' : ''}
+        {fullName ? `${NONBREAKING_SPACE}(` : ''}
         {`@${userProfile.userName}`}
         {fullName ? ')' : ''}
         {showAccountLevelIcon && (

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -596,7 +596,6 @@ div.SRC-logo-cursor * {
   height: fit-content;
   width: fit-content;
   cursor: pointer;
-  color: SRC.$primary-action-color;
 }
 
 .SRC-userImgSmall,


### PR DESCRIPTION
- Refactor UserCardSmall to always render the same block of code
- When showFullName, render as Full Name (@username) instead of @username Full Name
- Remove color styling. It will have the correct color if it's a link.

SWC-5961 will utilize the new name ordering and should not have a color applied, as it will not be a link.

<img width="431" alt="image" src="https://user-images.githubusercontent.com/17580037/184024619-5eecd6c7-2bf3-40d9-b40e-e552b7fa27c8.png">
