### PR TITLE
SWC-5961b: Simplify types managed by EntityFinder

### DIFF
--- a/src/__tests__/lib/containers/entity_finder/details/DetailsView.test.tsx
+++ b/src/__tests__/lib/containers/entity_finder/details/DetailsView.test.tsx
@@ -4,11 +4,13 @@ import userEvent from '@testing-library/user-event'
 import { Map } from 'immutable'
 import React from 'react'
 import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
+import { toEntityHeader } from '../../../../../lib/containers/entity_finder/details/configurations/ProjectListDetails'
 import {
   DetailsView,
   DetailsViewProps,
 } from '../../../../../lib/containers/entity_finder/details/view/DetailsView'
 import { NO_VERSION_NUMBER } from '../../../../../lib/containers/entity_finder/EntityFinder'
+import { EntityFinderHeader } from '../../../../../lib/containers/entity_finder/EntityFinderHeader'
 import { createWrapper } from '../../../../../lib/testutils/TestingLibraryUtils'
 import { ENTITY_ID_VERSIONS } from '../../../../../lib/utils/APIConstants'
 import {
@@ -21,13 +23,13 @@ import {
   EntityHeader,
   EntityType,
   PaginatedResults,
-  ProjectHeader,
   SortBy,
 } from '../../../../../lib/utils/synapseTypes'
 import { VersionInfo } from '../../../../../lib/utils/synapseTypes/VersionInfo'
 import { mockProjectHeader } from '../../../../../mocks/entity/mockEntity'
 import mockFileEntityData from '../../../../../mocks/entity/mockFileEntity'
 import { rest, server } from '../../../../../mocks/msw/server'
+import { MOCK_USER_ID } from '../../../../../mocks/user/mock_user_profile'
 
 const mockFileEntityHeader = mockFileEntityData.entityHeader
 
@@ -47,20 +49,21 @@ function generateFileHeader(id: number): EntityHeader {
   return {
     id: `syn${id}`,
     name: 'My File',
-    modifiedOn: 'today',
-    modifiedBy: '100000',
+    modifiedOn: '2022-07-12T20:56:38.851Z',
+    modifiedBy: MOCK_USER_ID.toString(),
     type: 'org.sagebionetworks.repo.model.FileEntity',
     versionNumber: 1,
     versionLabel: 'label',
     benefactorId: 456,
     createdOn: '',
     createdBy: '',
+    isLatestVersion: true,
   }
 }
 
-const entityHeaders: (EntityHeader | ProjectHeader)[] = [
-  mockFileEntityHeader,
-  mockProjectHeader,
+const entityHeaders: EntityFinderHeader[] = [
+  mockFileEntityHeader!,
+  toEntityHeader(mockProjectHeader),
 ]
 
 const versionResult: PaginatedResults<VersionInfo> = {
@@ -75,7 +78,7 @@ const versionResult: PaginatedResults<VersionInfo> = {
       contentSize: '100001',
       contentMd5: 'deadbeef',
       modifiedByPrincipalId: '1',
-      modifiedOn: 'today',
+      modifiedOn: '2022-07-12T20:56:38.851Z',
       isLatestVersion: true,
     },
 
@@ -88,7 +91,7 @@ const versionResult: PaginatedResults<VersionInfo> = {
       contentSize: '100000',
       contentMd5: 'abcde0123456789',
       modifiedByPrincipalId: '1',
-      modifiedOn: 'yesterday',
+      modifiedOn: '2022-07-11T20:56:38.851Z',
       isLatestVersion: false,
     },
   ],
@@ -232,7 +235,7 @@ describe('DetailsView tests', () => {
       isLoading: false,
       hasNextPage: true,
       isFetchingNextPage: false,
-      entities: Array(50).fill(manyEntities),
+      entities: manyEntities,
     })
 
     expect(mockFetchNextPage).not.toHaveBeenCalled()
@@ -246,7 +249,7 @@ describe('DetailsView tests', () => {
       isLoading: false,
       hasNextPage: true,
       isFetchingNextPage: false,
-      entities: Array(2).fill(fewEntities),
+      entities: fewEntities,
     })
 
     await waitFor(() => expect(mockFetchNextPage).toHaveBeenCalled())

--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -13,13 +13,9 @@ import {
 } from '../../utils/functions/EntityTypeUtils'
 import { SYNAPSE_ENTITY_ID_REGEX } from '../../utils/functions/RegularExpressions'
 import { useSynapseContext } from '../../utils/SynapseContext'
-import {
-  EntityHeader,
-  ProjectHeader,
-  Reference,
-} from '../../utils/synapseTypes'
+import { Reference } from '../../utils/synapseTypes'
 import { EntityType } from '../../utils/synapseTypes/EntityType'
-import { Hit, KeyValue } from '../../utils/synapseTypes/Search'
+import { KeyValue } from '../../utils/synapseTypes/Search'
 import { SynapseErrorBoundary } from '../ErrorBanner'
 import IconSvg from '../IconSvg'
 import { BreadcrumbItem, Breadcrumbs, BreadcrumbsProps } from './Breadcrumbs'
@@ -28,6 +24,7 @@ import {
   EntityDetailsListDataConfiguration,
   EntityDetailsListDataConfigurationType,
 } from './details/EntityDetailsList'
+import { EntityFinderHeader } from './EntityFinderHeader'
 import { SelectionPane } from './SelectionPane'
 import { EntityTree, EntityTreeContainer, FinderScope } from './tree/EntityTree'
 import { EntityTreeNodeType } from './tree/VirtualizedTree'
@@ -109,7 +106,9 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
   const [breadcrumbsProps, setBreadcrumbsProps] = useState<BreadcrumbsProps>({
     items: [],
   })
-  const [searchByIdResults, setSearchByIdResults] = useState<EntityHeader[]>([])
+  const [searchByIdResults, setSearchByIdResults] = useState<
+    EntityFinderHeader[]
+  >([])
   const [configFromTreeView, setConfigFromTreeView] =
     useState<EntityDetailsListDataConfiguration>({
       type: EntityDetailsListDataConfigurationType.PROMPT,
@@ -145,14 +144,14 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
   const [selectedEntities, toggleSelection] = useEntitySelection(selectMultiple)
 
   const isIdSelected = useCallback(
-    (entity: EntityHeader | ProjectHeader | Hit) => {
+    (entity: EntityFinderHeader) => {
       return selectedEntities.has(entity.id)
     },
     [selectedEntities],
   )
 
   const isSelectable = useCallback(
-    (entity: EntityHeader | ProjectHeader | Hit) => {
+    (entity: EntityFinderHeader) => {
       const type = getEntityTypeFromHeader(entity)
       return selectableTypes.includes(type)
     },

--- a/src/lib/containers/entity_finder/EntityFinderHeader.ts
+++ b/src/lib/containers/entity_finder/EntityFinderHeader.ts
@@ -1,0 +1,35 @@
+import {
+  EntityHeader,
+  ProjectHeader,
+  PROJECT_CONCRETE_TYPE,
+} from '../../utils/synapseTypes'
+
+/**
+ * The entity header fields that also exist in a search Hit. We convert Hits to this object so fields can be accessed consistently within the Entity Finder.
+ */
+export type EntityHeaderFromHit = Omit<
+  EntityHeader,
+  'benefactorId' | 'isLatestVersion'
+>
+
+/**
+ * The EntityHeader fields that also exist in a project header. ProjectHeaders will be converted to match this type.
+ */
+export type EntityHeaderFromProjectHeader = Omit<
+  ProjectHeader,
+  'lastActivity'
+> & { type: PROJECT_CONCRETE_TYPE }
+
+/**
+ * Collection of all entity objects used in the Entity Finder component. The Entity Finder is compatible with multiple APIs that return slightly different objects, so this type is used to represent all of them.
+ *
+ * The entity finder uses
+ *  - EntityHeader
+ *  - ProjectHeader
+ *  - Hit (which we transform to an EntityHeader)
+ *
+ */
+export type EntityFinderHeader =
+  | EntityHeader
+  | EntityHeaderFromProjectHeader
+  | EntityHeaderFromHit

--- a/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
+++ b/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
@@ -2,15 +2,11 @@ import { Map } from 'immutable'
 import React, { Dispatch, SetStateAction, useState } from 'react'
 import useDeepCompareEffect from 'use-deep-compare-effect'
 import { getIsAllSelectedFromInfiniteList } from '../../../utils/hooks/useGetIsAllSelectedInfiniteList'
-import {
-  EntityHeader,
-  EntityType,
-  ProjectHeader,
-  Reference,
-} from '../../../utils/synapseTypes'
+import { EntityType, Reference } from '../../../utils/synapseTypes'
 import { GetProjectsParameters } from '../../../utils/synapseTypes/GetProjectsParams'
 import { SearchQuery } from '../../../utils/synapseTypes/Search'
 import { SynapseErrorBoundary } from '../../ErrorBanner'
+import { EntityFinderHeader } from '../EntityFinderHeader'
 import { EntityTreeContainer } from '../tree/EntityTree'
 import { EntityChildrenDetails } from './configurations/EntityChildrenDetails'
 import { FavoritesDetails } from './configurations/FavoritesDetails'
@@ -30,7 +26,7 @@ export enum EntityDetailsListDataConfigurationType {
 export type EntityDetailsListDataConfiguration = {
   type: EntityDetailsListDataConfigurationType
   /** Defined if type is HEADER_LIST */
-  headerList?: (Pick<EntityHeader, 'name' | 'id' | 'type'> | ProjectHeader)[]
+  headerList?: Pick<EntityFinderHeader, 'id' | 'name' | 'type'>[]
   /** Defined if type is PARENT_CONTAINER */
   parentContainerId?: string
   /** Defined if type is USER_PROJECTS */
@@ -51,8 +47,8 @@ export type EntityDetailsListSharedProps = {
   visibleTypes: EntityType[]
   selected: Map<string, number>
   selectableTypes: EntityType[]
-  isIdSelected: (header: EntityHeader | ProjectHeader) => boolean
-  isSelectable: (header: EntityHeader | ProjectHeader) => boolean
+  isIdSelected: (header: EntityFinderHeader) => boolean
+  isSelectable: (header: EntityFinderHeader) => boolean
   toggleSelection: (entity: Reference | Reference[]) => void
   latestVersionText?: string
   setCurrentContainer?: Dispatch<SetStateAction<EntityTreeContainer>>
@@ -93,13 +89,13 @@ export const EntityDetailsList: React.FunctionComponent<
         case EntityDetailsListDataConfigurationType.HEADER_LIST:
           return (
             <DetailsView
-              entities={config.headerList as (EntityHeader | ProjectHeader)[]}
+              entities={config.headerList as EntityFinderHeader[]}
               isLoading={false}
               hasNextPage={false}
               {...sharedProps}
               enableSelectAll={sharedProps.enableSelectAll}
               selectAllIsChecked={getIsAllSelectedFromInfiniteList(
-                (config.headerList as (EntityHeader | ProjectHeader)[]) ?? [],
+                (config.headerList as EntityFinderHeader[]) ?? [],
                 sharedProps.selected.size,
                 sharedProps.isIdSelected,
                 sharedProps.isSelectable,

--- a/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/ProjectListDetails.tsx
@@ -1,12 +1,23 @@
 import React from 'react'
 import { useGetProjectsInfinite } from '../../../../utils/hooks/SynapseAPI/user/useProjects'
 import useGetIsAllSelectedFromInfiniteList from '../../../../utils/hooks/useGetIsAllSelectedInfiniteList'
+import { ProjectHeader } from '../../../../utils/synapseTypes'
 import { GetProjectsParameters } from '../../../../utils/synapseTypes/GetProjectsParams'
+import { EntityHeaderFromProjectHeader } from '../../EntityFinderHeader'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import { DetailsView } from '../view/DetailsView'
 
 type ProjectListDetailsProps = EntityDetailsListSharedProps & {
   projectsParams: GetProjectsParameters
+}
+
+export function toEntityHeader(
+  projectHeader: ProjectHeader,
+): EntityHeaderFromProjectHeader {
+  return {
+    ...projectHeader,
+    type: 'org.sagebionetworks.repo.model.Project',
+  }
 }
 
 export const ProjectListDetails: React.FunctionComponent<
@@ -15,7 +26,8 @@ export const ProjectListDetails: React.FunctionComponent<
   const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
     useGetProjectsInfinite(projectsParams, { useErrorBoundary: true })
 
-  const projects = data?.pages.flatMap(page => page.results) ?? []
+  const projects =
+    data?.pages.flatMap(page => page.results).map(toEntityHeader) ?? []
 
   const selectAllCheckboxState = useGetIsAllSelectedFromInfiniteList(
     projects,

--- a/src/lib/containers/entity_finder/details/configurations/SearchDetails.tsx
+++ b/src/lib/containers/entity_finder/details/configurations/SearchDetails.tsx
@@ -1,11 +1,25 @@
 import React from 'react'
+import { convertToConcreteEntityType } from '../../../../utils/functions/EntityTypeUtils'
 import { useSearchInfinite } from '../../../../utils/hooks/SynapseAPI/search/useSearch'
-import { SearchQuery } from '../../../../utils/synapseTypes/Search'
+import { Hit, SearchQuery } from '../../../../utils/synapseTypes/Search'
+import { EntityHeaderFromHit } from '../../EntityFinderHeader'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import { DetailsView } from '../view/DetailsView'
 
 type SearchDetailsProps = EntityDetailsListSharedProps & {
   searchQuery: SearchQuery
+}
+
+function toEntityHeader(hit: Hit): EntityHeaderFromHit {
+  return {
+    name: hit.name,
+    id: hit.id,
+    type: convertToConcreteEntityType(hit.node_type),
+    createdOn: hit.created_on.toString(),
+    modifiedOn: hit.modified_on.toString(),
+    createdBy: hit.created_by,
+    modifiedBy: hit.modified_by,
+  }
 }
 
 export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
@@ -21,7 +35,9 @@ export const SearchDetails: React.FunctionComponent<SearchDetailsProps> = ({
   if (searchQuery.queryTerm) {
     return (
       <DetailsView
-        entities={data?.pages.flatMap(page => page.hits) ?? []}
+        entities={
+          data?.pages.flatMap(page => page.hits).map(toEntityHeader) ?? []
+        }
         isLoading={isLoading}
         hasNextPage={hasNextPage}
         fetchNextPage={fetchNextPage}

--- a/src/lib/containers/entity_finder/details/view/DetailsView.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsView.tsx
@@ -16,14 +16,13 @@ import {
   EntityChildrenRequest,
   EntityHeader,
   EntityType,
-  ProjectHeader,
   SortBy,
 } from '../../../../utils/synapseTypes'
-import { Hit } from '../../../../utils/synapseTypes/Search'
 import { HelpPopover } from '../../../HelpPopover'
 import { BlockingLoader } from '../../../LoadingScreen'
 import { Checkbox } from '../../../widgets/Checkbox'
 import { NO_VERSION_NUMBER } from '../../EntityFinder'
+import { EntityFinderHeader } from '../../EntityFinderHeader'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import {
   BadgeIconsRenderer,
@@ -43,7 +42,7 @@ const MIN_TABLE_WIDTH = 1200
 const ROW_HEIGHT = 46
 
 export type DetailsViewProps = EntityDetailsListSharedProps & {
-  entities: (EntityHeader | ProjectHeader | Hit)[]
+  entities: EntityFinderHeader[]
   isLoading: boolean
   hasNextPage?: boolean
   fetchNextPage?: () => Promise<any>
@@ -66,11 +65,7 @@ export type DetailsViewProps = EntityDetailsListSharedProps & {
 /**
  * Describes the shape of the data passed to the BaseTable
  */
-export type EntityFinderTableViewRowData = (
-  | EntityHeader
-  | ProjectHeader
-  | Hit
-) & {
+export type EntityFinderTableViewRowData = EntityFinderHeader & {
   entityId: string
   versionNumber?: number
   entityType: EntityType
@@ -134,7 +129,7 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
   type DetailsViewRowAppearance = 'hidden' | 'disabled' | 'selected' | 'default'
 
   const determineRowAppearance = (
-    entity: EntityHeader | ProjectHeader | Hit,
+    entity: EntityFinderHeader,
   ): DetailsViewRowAppearance => {
     if (!visibleTypes.includes(getEntityTypeFromHeader(entity))) {
       return 'hidden'
@@ -276,7 +271,7 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
   )
 
   const SelectAllCheckboxRenderer = useMemo(() => {
-    // Enabled if there's at least one visble & selectable entity, OR there's a page we haven't fetched
+    // Enabled if there's at least one visible & selectable entity, OR there's a page we haven't fetched
     const isEnabled =
       hasNextPage ||
       entities.filter(

--- a/src/lib/containers/entity_finder/tree/EntityTree.tsx
+++ b/src/lib/containers/entity_finder/tree/EntityTree.tsx
@@ -15,21 +15,20 @@ import { SYNAPSE_ENTITY_ID_REGEX } from '../../../utils/functions/RegularExpress
 import useGetEntityBundle from '../../../utils/hooks/SynapseAPI/entity/useEntityBundle'
 import { useGetProjectsInfinite } from '../../../utils/hooks/SynapseAPI/user/useProjects'
 import { useSynapseContext } from '../../../utils/SynapseContext'
-import {
-  EntityHeader,
-  EntityPath,
-  EntityType,
-  ProjectHeader,
-  Reference,
-} from '../../../utils/synapseTypes'
+import { EntityPath, EntityType, Reference } from '../../../utils/synapseTypes'
 import { SynapseSpinner } from '../../LoadingScreen'
 import { BreadcrumbItem } from '../Breadcrumbs'
+import { toEntityHeader } from '../details/configurations/ProjectListDetails'
 import {
   EntityDetailsListDataConfiguration,
   EntityDetailsListDataConfigurationType,
 } from '../details/EntityDetailsList'
-import { EntityTreeNodeType } from './VirtualizedTree'
-import { RootNodeConfiguration, VirtualizedTree } from './VirtualizedTree'
+import { EntityFinderHeader } from '../EntityFinderHeader'
+import {
+  EntityTreeNodeType,
+  RootNodeConfiguration,
+  VirtualizedTree,
+} from './VirtualizedTree'
 
 const isEntityIdInPath = (entityId: string, path: EntityPath): boolean => {
   for (const eh of path.path) {
@@ -131,7 +130,7 @@ export function EntityTree(props: EntityTreeProps) {
 
   const [isLoading, setIsLoading] = useState(false)
   const [topLevelEntities, setTopLevelEntities] = useState<
-    (Pick<EntityHeader, 'name' | 'id' | 'type'> | ProjectHeader)[]
+    Pick<EntityFinderHeader, 'name' | 'id' | 'type'>[]
   >([])
   const [scope, setScope] = useState(initialScope)
   const [initialContainerPath, setInitialContainerPath] = useState<EntityPath>()
@@ -184,7 +183,9 @@ export function EntityTree(props: EntityTreeProps) {
   useEffect(() => {
     if (useProjectData && isSuccessProjects) {
       if (projectData?.pages) {
-        setTopLevelEntities(projectData.pages.flatMap(page => page.results))
+        setTopLevelEntities(
+          projectData.pages.flatMap(page => page.results).map(toEntityHeader),
+        )
       }
     }
   }, [useProjectData, isSuccessProjects, projectData])

--- a/src/lib/containers/entity_finder/tree/VirtualizedTree.tsx
+++ b/src/lib/containers/entity_finder/tree/VirtualizedTree.tsx
@@ -18,15 +18,12 @@ import {
   isContainerType,
 } from '../../../utils/functions/EntityTypeUtils'
 import { useSynapseContext } from '../../../utils/SynapseContext'
-import {
-  EntityHeader,
-  EntityType,
-  ProjectHeader,
-} from '../../../utils/synapseTypes'
+import { EntityType } from '../../../utils/synapseTypes'
 import { Writable } from '../../../utils/types/Writable'
 import { EntityBadgeIcons } from '../../EntityBadgeIcons'
 import { EntityTypeIcon } from '../../EntityIcon'
 import { SynapseSpinner } from '../../LoadingScreen'
+import { EntityFinderHeader } from '../EntityFinderHeader'
 
 export enum EntityTreeNodeType {
   /** The tree component's appearance and interactions will facilitate selection. Nodes will be larger and styles will indicate primary selection */
@@ -35,10 +32,6 @@ export enum EntityTreeNodeType {
   DUAL_PANE,
 }
 
-type EntityFinderHeader =
-  | Pick<EntityHeader, 'id' | 'name' | 'type'>
-  | ProjectHeader
-
 type NodeChildren = Readonly<{
   /** The node's children. If undefined, then children have not been fetched. */
   children?: EntityHeaderNode[]
@@ -46,7 +39,8 @@ type NodeChildren = Readonly<{
   childrenNextPageToken?: string | null
 }>
 
-type EntityHeaderNode = EntityFinderHeader & NodeChildren
+type EntityHeaderNode = Pick<EntityFinderHeader, 'id' | 'name' | 'type'> &
+  NodeChildren
 type PaginationNode = { __paginationNode: true }
 
 type TreeNode = EntityHeaderNode | RootNodeConfiguration | PaginationNode

--- a/src/lib/utils/functions/EntityTypeUtils.ts
+++ b/src/lib/utils/functions/EntityTypeUtils.ts
@@ -19,6 +19,7 @@ import {
   ENTITY_VIEW_CONCRETE_TYPE_VALUE,
   DatasetCollection,
   DATASET_COLLECTION_CONCRETE_TYPE_VALUE,
+  FILE_ENTITY_CONCRETE_TYPE_VALUE,
 } from '../synapseTypes'
 import { Hit } from '../synapseTypes/Search'
 import {
@@ -106,7 +107,7 @@ export function convertToEntityType(
     case 'org.sagebionetworks.repo.model.Folder':
       return EntityType.FOLDER
     case EntityType.FILE:
-    case 'org.sagebionetworks.repo.model.FileEntity':
+    case FILE_ENTITY_CONCRETE_TYPE_VALUE:
       return EntityType.FILE
     case EntityType.LINK:
     case 'org.sagebionetworks.repo.model.Link':
@@ -115,25 +116,56 @@ export function convertToEntityType(
     case 'org.sagebionetworks.repo.model.docker.DockerRepository':
       return EntityType.DOCKER_REPO
     case EntityType.TABLE:
-    case 'org.sagebionetworks.repo.model.table.TableEntity':
+    case TABLE_ENTITY_CONCRETE_TYPE_VALUE:
       return EntityType.TABLE
     case EntityType.SUBMISSION_VIEW:
     case 'org.sagebionetworks.repo.model.table.SubmissionView':
       return EntityType.SUBMISSION_VIEW
     case EntityType.ENTITY_VIEW:
-    case 'org.sagebionetworks.repo.model.table.EntityView':
+    case ENTITY_VIEW_CONCRETE_TYPE_VALUE:
       return EntityType.ENTITY_VIEW
     case EntityType.DATASET:
-    case 'org.sagebionetworks.repo.model.table.Dataset':
+    case DATASET_CONCRETE_TYPE_VALUE:
       return EntityType.DATASET
     case EntityType.DATASET_COLLECTION:
-    case 'org.sagebionetworks.repo.model.table.DatasetCollection':
+    case DATASET_COLLECTION_CONCRETE_TYPE_VALUE:
       return EntityType.DATASET_COLLECTION
     case EntityType.MATERIALIZED_VIEW:
-    case 'org.sagebionetworks.repo.model.table.MaterializedView':
+    case MATERIALIZED_VIEW_CONCRETE_TYPE_VALUE:
       return EntityType.MATERIALIZED_VIEW
     default:
       throw new Error(`Unknown entity type: ${typeString}`)
+  }
+}
+
+export function convertToConcreteEntityType(
+  type: EntityType,
+): ENTITY_CONCRETE_TYPE {
+  switch (type) {
+    case EntityType.PROJECT:
+      return 'org.sagebionetworks.repo.model.Project'
+    case EntityType.FOLDER:
+      return 'org.sagebionetworks.repo.model.Folder'
+    case EntityType.FILE:
+      return 'org.sagebionetworks.repo.model.FileEntity'
+    case EntityType.LINK:
+      return 'org.sagebionetworks.repo.model.Link'
+    case EntityType.DOCKER_REPO:
+      return 'org.sagebionetworks.repo.model.docker.DockerRepository'
+    case EntityType.TABLE:
+      return 'org.sagebionetworks.repo.model.table.TableEntity'
+    case EntityType.SUBMISSION_VIEW:
+      return 'org.sagebionetworks.repo.model.table.SubmissionView'
+    case EntityType.ENTITY_VIEW:
+      return 'org.sagebionetworks.repo.model.table.EntityView'
+    case EntityType.DATASET:
+      return 'org.sagebionetworks.repo.model.table.Dataset'
+    case EntityType.DATASET_COLLECTION:
+      return 'org.sagebionetworks.repo.model.table.DatasetCollection'
+    case EntityType.MATERIALIZED_VIEW:
+      return 'org.sagebionetworks.repo.model.table.MaterializedView'
+    default:
+      throw new Error(`Unknown entity type: ${type}`)
   }
 }
 

--- a/src/lib/utils/synapseTypes/Entity/Entity.ts
+++ b/src/lib/utils/synapseTypes/Entity/Entity.ts
@@ -37,11 +37,21 @@ export interface Entity {
   uri?: string
 }
 
-type LINK_CONCRETE_TYPE = 'org.sagebionetworks.repo.model.Link'
-type DOCKER_REPOSITORY_CONCRETE_TYPE =
+export const LINK_CONCRETE_TYPE_VALUE = 'org.sagebionetworks.repo.model.Link'
+export type LINK_CONCRETE_TYPE = typeof LINK_CONCRETE_TYPE_VALUE
+
+export const DOCKER_REPOSITORY_CONCRETE_TYPE_VALUE =
   'org.sagebionetworks.repo.model.docker.DockerRepository'
-type FOLDER_CONCRETE_TYPE = 'org.sagebionetworks.repo.model.Folder'
-type PROJECT_CONCRETE_TYPE = 'org.sagebionetworks.repo.model.Project'
+export type DOCKER_REPOSITORY_CONCRETE_TYPE =
+  typeof DOCKER_REPOSITORY_CONCRETE_TYPE_VALUE
+
+export const FOLDER_CONCRETE_TYPE_VALUE =
+  'org.sagebionetworks.repo.model.Folder'
+export type FOLDER_CONCRETE_TYPE = typeof FOLDER_CONCRETE_TYPE_VALUE
+
+export const PROJECT_CONCRETE_TYPE_VALUE =
+  'org.sagebionetworks.repo.model.Project'
+export type PROJECT_CONCRETE_TYPE = typeof PROJECT_CONCRETE_TYPE_VALUE
 
 // This is not a real object in Synapse, merely a collection of potential string values to represent the "concreteType" field on Entities
 export type ENTITY_CONCRETE_TYPE =

--- a/src/mocks/entity/mockFileEntity.ts
+++ b/src/mocks/entity/mockFileEntity.ts
@@ -200,6 +200,7 @@ const mockFileEntityHeader: EntityHeader = {
   modifiedOn: mockFileEntity.modifiedOn!,
   createdBy: MOCK_USER_ID.toString(), // TODO: Replace with a valid mock user ID
   modifiedBy: MOCK_USER_ID_2.toString(),
+  isLatestVersion: true,
 }
 
 const mockFileEntityData: MockEntityData<FileEntity> = {


### PR DESCRIPTION
In order to handle the `modifiedOn` field in the tooltip, we need a consistent way to access the data fields within the EntityFinder. Let's convert all headers to a custom `EntityFinderHeader` type so we can handle all data in the same way.