### PR TITLE
Update type for QueryResultBundle: Row.values may include nulls

### DIFF
--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -115,7 +115,8 @@ export const CardContainer = (props: CardContainerProps) => {
       )
     }
     const listIds = data.queryResult!.queryResults.rows.map(
-      el => el.values[userIdColumnIndex],
+      el =>
+        el.values.filter((id): id is string => id !== null)[userIdColumnIndex],
     )
     cards = <UserCardList data={data} list={listIds} size={MEDIUM_USER_CARD} />
   } else {

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -16,6 +16,7 @@ import {
   Entity,
   FileHandleAssociateType,
   FileHandleAssociation,
+  Row,
   SelectColumn,
 } from '../utils/synapseTypes'
 import Tooltip from '../utils/tooltip/Tooltip'
@@ -213,7 +214,7 @@ type SynapseCardLabelProps = {
   columnModels: ColumnModel[] | undefined
   isHeader: boolean
   className?: string
-  rowData: string[]
+  rowData: Row['values']
 }
 
 export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
@@ -337,7 +338,7 @@ export const SynapseCardLabel: React.FC<SynapseCardLabelProps> = props => {
                 return (
                   <React.Fragment key={el}>
                     <a
-                      href={href}
+                      href={href ?? undefined}
                       target="_blank"
                       rel="noopener noreferrer"
                       key={el}

--- a/src/lib/containers/SubsectionRowRenderer.tsx
+++ b/src/lib/containers/SubsectionRowRenderer.tsx
@@ -179,12 +179,19 @@ const SubsectionRowRenderer: React.FunctionComponent<
                       const urlColumnIndex = rowSet.headers.findIndex(
                         col => col.name == columnLink.linkColumnName,
                       )
+                      const values = row.values as string[]
+                      if (values.some(value => value === null)) {
+                        console.warn(
+                          'Row has null value(s) when no nulls expected',
+                        )
+                      }
+
                       if (urlColumnIndex > -1) {
                         renderedValue = (
                           <a
                             rel="noopener noreferrer"
                             target="_blank"
-                            href={row.values[urlColumnIndex]}
+                            href={values[urlColumnIndex]}
                           >
                             {friendlyCellValue}
                           </a>

--- a/src/lib/containers/TableFeedCards.tsx
+++ b/src/lib/containers/TableFeedCards.tsx
@@ -67,10 +67,14 @@ const TableFeedCards: React.FunctionComponent<TableFeedCardsProps> = ({
           if (index > itemCountShowing - 1) {
             return
           }
-          const categoriesList = JSON.parse(row.values[categoriesColIndex])
-          const dateStringTimestamp = row.values[dateColIndex]
-          const title = row.values[titleColIndex]
-          const description = row.values[descriptionColIndex]
+          const values = row.values as string[]
+          if (values.some(value => value === null)) {
+            console.warn('Row has null value(s) when no nulls expected')
+          }
+          const categoriesList = JSON.parse(values[categoriesColIndex])
+          const dateStringTimestamp = values[dateColIndex]
+          const title = values[titleColIndex]
+          const description = values[descriptionColIndex]
 
           return (
             <div className="FeedItem" key={`row-${index}`}>

--- a/src/lib/containers/UpsetPlot.tsx
+++ b/src/lib/containers/UpsetPlot.tsx
@@ -93,7 +93,11 @@ const UpsetPlot: React.FunctionComponent<UpsetPlotProps> = ({
 
         for (const row of queryResult?.queryResults.rows ?? []) {
           for (let j = 1; j < row.values.length; j += 1) {
-            const rowValues: string[] = row.values
+            const rowValues: string[] = row.values as string[]
+            if (rowValues.some(value => value === null)) {
+              console.warn('Row has null value(s) when no nulls expected')
+            }
+
             const key = rowValues[0]
             let newValue = rowValues[j]
             keyValuesMap[key] = keyValuesMap[key] || {}

--- a/src/lib/containers/UserCardList.tsx
+++ b/src/lib/containers/UserCardList.tsx
@@ -96,11 +96,13 @@ export default class UserCardList extends React.Component<
     return nullOwnerIdsRows.map<UserProfile>(el => {
       const values = el.values
       return {
-        firstName: values[firstNameIndex],
-        lastName: values[lastNameIndex],
-        company: values[institutionIndex],
+        firstName: values[firstNameIndex] ?? '',
+        lastName: values[lastNameIndex] ?? '',
+        company: values[institutionIndex] ?? undefined,
         ownerId: '',
-        userName: values[firstNameIndex][0],
+        userName: values[firstNameIndex]
+          ? values[firstNameIndex]![0] ?? ''
+          : '',
       }
     })
   }

--- a/src/lib/containers/UserCardListRotate.tsx
+++ b/src/lib/containers/UserCardListRotate.tsx
@@ -119,9 +119,9 @@ const UserCardListRotate: React.FunctionComponent<UserCardListRotateProps> = ({
         const ownerIdColumnIndex = queryResult.queryResults.headers.findIndex(
           el => el.columnType === ColumnType.USERID,
         )
-        const ids: string[] = queryResult.queryResults.rows.map(
-          d => d.values[ownerIdColumnIndex],
-        )
+        const ids: string[] = queryResult.queryResults.rows
+          .map(d => d.values[ownerIdColumnIndex])
+          .filter((id): id is string => id !== null)
         if (mounted) {
           const newIds = getDisplayIds(ids, count, storageUidKey)
           setUserIds(newIds)

--- a/src/lib/containers/home_page/featured_tools/FeaturedToolsList.tsx
+++ b/src/lib/containers/home_page/featured_tools/FeaturedToolsList.tsx
@@ -72,12 +72,17 @@ export const FeaturedToolsList: React.FunctionComponent<
 
         const tools: ToolData[] =
           queryResultBundle?.queryResult!.queryResults.rows.map(row => {
+            if (row.values.some(value => value === null)) {
+              console.warn('Row has null value(s)')
+            }
+            // Cast to string, assuming there are no null values
+            const values = row.values as string[]
             return {
-              name: row.values[nameColumnIndex],
-              description: row.values[descriptionColumnIndex],
-              type: row.values[typeColumnIndex],
-              id: row.values[idIndex],
-              date: row.values[dateColumnIndex],
+              name: values[nameColumnIndex],
+              description: values[descriptionColumnIndex],
+              type: values[typeColumnIndex],
+              id: values[idIndex],
+              date: values[dateColumnIndex],
             }
           }) ?? []
         if (queryError) {

--- a/src/lib/containers/home_page/goals/Goals.tsx
+++ b/src/lib/containers/home_page/goals/Goals.tsx
@@ -63,10 +63,14 @@ export const Goals: React.FC<GoalsProps> = (props: GoalsProps) => {
           ExpectedColumns.ASSET,
           queryResultBundle,
         )
-        const assets =
-          queryResultBundle?.queryResult!.queryResults.rows.map(
-            el => el.values[assetColumnIndex],
-          ) ?? []
+        let assets = (queryResultBundle?.queryResult!.queryResults.rows.map(
+          el => el.values[assetColumnIndex],
+        ) ?? []) as string[]
+        if (assets.some(asset => asset === null)) {
+          // We cast assets above assuming there are no null values, emit a warning just in case.
+          console.warn('Row has null value(s) when no nulls expected')
+        }
+
         if (assets.length === 0) {
           // wait for data to load
           return
@@ -124,7 +128,11 @@ export const Goals: React.FC<GoalsProps> = (props: GoalsProps) => {
     <div className={`Goals${showDesktop ? '__Desktop' : ''}`}>
       {error && <ErrorBanner error={error} />}
       {queryResultBundle?.queryResult!.queryResults.rows.map((el, index) => {
-        const values = el.values
+        const values = el.values as string[]
+        if (values.some(value => value === null)) {
+          // We cast values above assuming there are no null values, emit a warning just in case.
+          console.warn('Row has null value(s) when no nulls expected')
+        }
         const tableId =
           tableIdColumnIndex > -1 ? values[tableIdColumnIndex] : undefined
         let countSql

--- a/src/lib/containers/home_page/programs/Programs.tsx
+++ b/src/lib/containers/home_page/programs/Programs.tsx
@@ -73,8 +73,13 @@ export const Programs: React.FC<ProgramsProps> = (props: ProgramsProps) => {
         showDesktop ? '__Desktop' : ''
       }`}
     >
-      {queryResultBundle?.queryResult!.queryResults.rows.map((el, index) => {
-        const values = el.values
+      {queryResultBundle?.queryResult!.queryResults.rows.map(el => {
+        const values = el.values as string[]
+        if (values.some(value => value === null)) {
+          // We cast values above assuming there are no null values, emit a warning just in case.
+          console.warn('Row has null value(s) when no nulls expected')
+        }
+
         const title = values[titleColumnIndex]
         const summary = values[summaryColumnIndex]
         const link = values[linkColumnIndex] ?? ''

--- a/src/lib/containers/home_page/project_view_carousel/ProjectViewCarousel.tsx
+++ b/src/lib/containers/home_page/project_view_carousel/ProjectViewCarousel.tsx
@@ -83,13 +83,17 @@ export const ProjectViewCarousel: React.FunctionComponent<
 
         const projects: ProjectData[] =
           queryResultBundle?.queryResult!.queryResults.rows.map(row => {
+            const values = row.values as string[]
+            if (values.some(value => value === null)) {
+              // We cast values above assuming there are no null values, emit a warning just in case.
+              console.warn('Row has null value(s) when no nulls expected')
+            }
             return {
               projectName:
-                row.values[displayNameColumnIndex] ??
-                row.values[nameColumnIndex],
-              projectDescription: row.values[descriptionColumnIndex],
-              imageFileName: row.values[imageColumnIndex],
-              entityId: row.values[entityIdIndex],
+                values[displayNameColumnIndex] ?? values[nameColumnIndex],
+              projectDescription: values[descriptionColumnIndex],
+              imageFileName: values[imageColumnIndex],
+              entityId: values[entityIdIndex],
             }
           }) ?? []
         if (queryError) {

--- a/src/lib/containers/home_page/resources/Resources.tsx
+++ b/src/lib/containers/home_page/resources/Resources.tsx
@@ -44,7 +44,11 @@ export const Resources: React.FC<ResourcesProps> = (props: ResourcesProps) => {
   const wikiIndex = getFieldIndex(ExpectedColumns.WIKI, queryResultBundle)
   const data: Data =
     queryResultBundle?.queryResult?.queryResults.rows.map(el => {
-      const values = el.values
+      const values = el.values as string[]
+      if (values.some(value => value === null)) {
+        console.warn('Row has null value(s) when no nulls expected')
+      }
+
       const name = values[nameIndex]
       const wikiValue = values[wikiIndex] ?? ''
       const split = wikiValue.split('/')

--- a/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
+++ b/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
@@ -11,6 +11,7 @@ import {
   ColumnModel,
   ColumnType,
   FileHandleAssociateType,
+  Row,
   SelectColumn,
   UserGroupHeader,
   UserProfile,
@@ -44,7 +45,7 @@ export type SynapseTableCellProps = {
   columnName: string
   selectColumns?: SelectColumn[]
   columnModels?: ColumnModel[]
-  rowData: string[]
+  rowData: Row['values']
   rowId?: number
   rowVersionNumber?: number
 }

--- a/src/lib/utils/synapseTypes/Table/QueryResult.ts
+++ b/src/lib/utils/synapseTypes/Table/QueryResult.ts
@@ -21,7 +21,7 @@ export type Row = {
   rowId?: number // The immutable ID issued to a new row.
   versionNumber?: number // The version number of this row. Each row version is immutable, so when a row is updated a new version is created
   etag?: string // For queries against EntityViews with query.includeEtag=true, this field will contain the etag of the entity. Will be null for all other cases.
-  values: string[] // The values for each column of this row.
+  values: (string | null)[] // The values for each column of this row.
 }
 
 // https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/QueryNextPageToken.html


### PR DESCRIPTION
- The change causes typing issues in many portal components where we make the assumption that the rows will not contain a null value. Since these are typically controlled, curated tables, this is a safe assumption. In those cases, emit a warning to the console. We can refine how we handle those cases as needed.
- In other cases, use filtering or nullish coalescing to resolve type errors