### PR TITLE
PORTALS-2272: Check selectColumn for deep equality before resetting visible columns

### DIFF
--- a/src/__tests__/lib/containers/QueryVisualizationWrapper.test.tsx
+++ b/src/__tests__/lib/containers/QueryVisualizationWrapper.test.tsx
@@ -1,0 +1,230 @@
+import { act, render, waitFor } from '@testing-library/react'
+import * as React from 'react'
+import {
+  PaginatedQueryContextType,
+  usePaginatedQueryContext,
+} from '../../../lib/containers/QueryContext'
+import {
+  QueryVisualizationContextType,
+  QueryVisualizationWrapper,
+  useQueryVisualizationContext,
+} from '../../../lib/containers/QueryVisualizationWrapper'
+import {
+  QueryWrapper,
+  QueryWrapperProps,
+} from '../../../lib/containers/QueryWrapper'
+import { createWrapper } from '../../../lib/testutils/TestingLibraryUtils'
+import { SynapseConstants } from '../../../lib/utils/'
+import {
+  ColumnType,
+  QueryBundleRequest,
+} from '../../../lib/utils/synapseTypes/'
+import { MOCK_TABLE_ENTITY_ID } from '../../../mocks/entity/mockEntity'
+import queryResponse from '../../../mocks/mockQueryResponseDataWithManyEnumFacets'
+import { getHandlersForTableQuery } from '../../../mocks/msw/handlers/tableQueryHandlers'
+import { server } from '../../../mocks/msw/server'
+
+const onQueryContextReceived = jest.fn<void, [PaginatedQueryContextType]>()
+const onContextReceived = jest.fn<void, [QueryVisualizationContextType]>()
+
+function QueryVizWrapperConsumer(props: { mockFn?: jest.Mock }) {
+  const queryContext = usePaginatedQueryContext()
+  onQueryContextReceived(queryContext)
+  const context = useQueryVisualizationContext()
+  const fn = props.mockFn ?? onContextReceived
+  fn(context)
+  return null
+}
+
+function TestComponent(
+  props: Partial<QueryWrapperProps & { mockFn: jest.Mock }> = {},
+) {
+  return (
+    <QueryWrapper initQueryRequest={initialQueryRequest} {...props}>
+      <QueryVisualizationWrapper>
+        <QueryVizWrapperConsumer mockFn={props.mockFn} />
+      </QueryVisualizationWrapper>
+    </QueryWrapper>
+  )
+}
+
+const initialQueryRequest: QueryBundleRequest = {
+  concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+  partMask:
+    SynapseConstants.BUNDLE_MASK_QUERY_COLUMN_MODELS |
+    SynapseConstants.BUNDLE_MASK_QUERY_FACETS |
+    SynapseConstants.BUNDLE_MASK_QUERY_SELECT_COLUMNS |
+    SynapseConstants.BUNDLE_MASK_QUERY_RESULTS,
+  entityId: MOCK_TABLE_ENTITY_ID,
+  query: {
+    sql: `SELECT * FROM ${MOCK_TABLE_ENTITY_ID}`,
+    limit: 25,
+    offset: 0,
+  },
+}
+
+describe('QueryVisualizationWrapper', () => {
+  beforeAll(() => server.listen())
+  beforeEach(() => server.use(...getHandlersForTableQuery(queryResponse)))
+  afterEach(() => {
+    server.restoreHandlers()
+    jest.resetAllMocks()
+  })
+  afterAll(() => server.close())
+
+  test('Initialize selectColumns', async () => {
+    render(<TestComponent />, { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      const data = onQueryContextReceived.mock.calls.at(-1)![0].data
+      expect(data).toBeDefined()
+      expect(data!.selectColumns!.length).toBeGreaterThan(0)
+    })
+
+    await waitFor(() =>
+      expect(onContextReceived).toHaveBeenCalledWith(
+        expect.objectContaining({
+          columnsToShowInTable: queryResponse.selectColumns!.map(
+            col => col.name,
+          ),
+        }),
+      ),
+    )
+  })
+
+  test('Reset column visibility on sql change', async () => {
+    render(<TestComponent />, { wrapper: createWrapper() })
+
+    let firstSetOfVisibleColumns
+    await waitFor(() => {
+      expect(onContextReceived).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          columnsToShowInTable: queryResponse.selectColumns!.map(
+            col => col.name,
+          ),
+        }),
+      )
+      firstSetOfVisibleColumns =
+        onContextReceived.mock.calls.at(-1)![0].columnsToShowInTable
+    })
+
+    server.use(
+      ...getHandlersForTableQuery({
+        ...queryResponse,
+        selectColumns: [
+          {
+            id: '123',
+            name: 'someOtherColumns',
+            columnType: ColumnType.STRING,
+          },
+        ],
+      }),
+    )
+
+    act(() => {
+      onQueryContextReceived.mock.calls[0][0].executeQueryRequest({
+        ...initialQueryRequest,
+        query: {
+          ...initialQueryRequest.query,
+          sql: 'SELECT some, other, sql, query FROM syn123',
+        },
+      })
+    })
+
+    let secondSetOfVisibleColumns
+    await waitFor(() => {
+      const data = onQueryContextReceived.mock.calls.at(-1)![0].data
+      expect(data?.selectColumns).toEqual([
+        {
+          id: '123',
+          name: 'someOtherColumns',
+          columnType: ColumnType.STRING,
+        },
+      ])
+      expect(onContextReceived).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          columnsToShowInTable: ['someOtherColumns'],
+        }),
+      )
+      secondSetOfVisibleColumns =
+        onContextReceived.mock.calls.at(-1)![0].columnsToShowInTable
+    })
+
+    // The select columns should have changed
+    expect(firstSetOfVisibleColumns).not.toEqual(secondSetOfVisibleColumns)
+  })
+
+  test('Do not reset when selectColumns deep equals the previous value', async () => {
+    render(<TestComponent />, { wrapper: createWrapper() })
+
+    let firstSetOfVisibleColumns
+    await waitFor(() => {
+      const data = onQueryContextReceived.mock.calls.at(-1)![0].data
+      expect(data).toBeDefined()
+      expect(onContextReceived).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          columnsToShowInTable: queryResponse.selectColumns!.map(
+            col => col.name,
+          ),
+        }),
+      )
+      firstSetOfVisibleColumns =
+        onContextReceived.mock.calls.at(-1)![0].columnsToShowInTable
+    })
+
+    const prevData = onQueryContextReceived.mock.calls.at(-1)![0].data
+
+    // The results are different (e.g. on another page of data), but the selectColumns do not change
+    server.use(
+      ...getHandlersForTableQuery({
+        ...queryResponse,
+        queryResult: {
+          ...queryResponse.queryResult!,
+          queryResults: {
+            ...queryResponse.queryResult!.queryResults,
+            rows: [
+              {
+                rowId: 5,
+                values: [
+                  '2018',
+                  'Honda',
+                  'CR-V',
+                  'windows, doors, gps, car play',
+                  '8799',
+                  null,
+                  '1575305363000',
+                  '273978',
+                  null,
+                ],
+                versionNumber: 1,
+              },
+            ],
+          },
+        },
+      }),
+    )
+
+    // e.g. navigate to the next page of data:
+    act(() => {
+      onQueryContextReceived.mock.calls.at(-1)![0].goToPage(2)
+    })
+
+    let secondSetOfVisibleColumns
+
+    // Wait for the data to update.
+    await waitFor(() => {
+      const data = onQueryContextReceived.mock.calls.at(-1)![0].data
+      expect(data).toBeDefined()
+      expect(data?.queryResult?.queryResults.rows).not.toEqual(
+        prevData?.queryResult?.queryResults.rows,
+      )
+
+      expect(data!.queryResult!.queryResults.rows).toHaveLength(1)
+      secondSetOfVisibleColumns =
+        onContextReceived.mock.calls.at(-1)![0].columnsToShowInTable
+    })
+
+    // The array of visible columns should not have changed, and should have referential equality
+    expect(firstSetOfVisibleColumns).toBe(secondSetOfVisibleColumns)
+  })
+})

--- a/src/__tests__/lib/containers/QueryVisualizationWrapper.test.tsx
+++ b/src/__tests__/lib/containers/QueryVisualizationWrapper.test.tsx
@@ -76,7 +76,7 @@ describe('QueryVisualizationWrapper', () => {
     render(<TestComponent />, { wrapper: createWrapper() })
 
     await waitFor(() => {
-      const data = onQueryContextReceived.mock.calls.at(-1)![0].data
+      const data = onQueryContextReceived.mock.lastCall[0].data
       expect(data).toBeDefined()
       expect(data!.selectColumns!.length).toBeGreaterThan(0)
     })
@@ -105,7 +105,7 @@ describe('QueryVisualizationWrapper', () => {
         }),
       )
       firstSetOfVisibleColumns =
-        onContextReceived.mock.calls.at(-1)![0].columnsToShowInTable
+        onContextReceived.mock.lastCall[0].columnsToShowInTable
     })
 
     server.use(
@@ -133,7 +133,7 @@ describe('QueryVisualizationWrapper', () => {
 
     let secondSetOfVisibleColumns
     await waitFor(() => {
-      const data = onQueryContextReceived.mock.calls.at(-1)![0].data
+      const data = onQueryContextReceived.mock.lastCall[0].data
       expect(data?.selectColumns).toEqual([
         {
           id: '123',
@@ -147,7 +147,7 @@ describe('QueryVisualizationWrapper', () => {
         }),
       )
       secondSetOfVisibleColumns =
-        onContextReceived.mock.calls.at(-1)![0].columnsToShowInTable
+        onContextReceived.mock.lastCall[0].columnsToShowInTable
     })
 
     // The select columns should have changed
@@ -159,7 +159,8 @@ describe('QueryVisualizationWrapper', () => {
 
     let firstSetOfVisibleColumns
     await waitFor(() => {
-      const data = onQueryContextReceived.mock.calls.at(-1)![0].data
+      expect(onQueryContextReceived).toHaveBeenCalled()
+      const data = onQueryContextReceived.mock.lastCall[0].data
       expect(data).toBeDefined()
       expect(onContextReceived).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -169,10 +170,10 @@ describe('QueryVisualizationWrapper', () => {
         }),
       )
       firstSetOfVisibleColumns =
-        onContextReceived.mock.calls.at(-1)![0].columnsToShowInTable
+        onContextReceived.mock.lastCall[0].columnsToShowInTable
     })
 
-    const prevData = onQueryContextReceived.mock.calls.at(-1)![0].data
+    const prevData = onQueryContextReceived.mock.lastCall[0].data
 
     // The results are different (e.g. on another page of data), but the selectColumns do not change
     server.use(
@@ -206,14 +207,14 @@ describe('QueryVisualizationWrapper', () => {
 
     // e.g. navigate to the next page of data:
     act(() => {
-      onQueryContextReceived.mock.calls.at(-1)![0].goToPage(2)
+      onQueryContextReceived.mock.lastCall[0].goToPage(2)
     })
 
     let secondSetOfVisibleColumns
 
     // Wait for the data to update.
     await waitFor(() => {
-      const data = onQueryContextReceived.mock.calls.at(-1)![0].data
+      const data = onQueryContextReceived.mock.lastCall[0].data
       expect(data).toBeDefined()
       expect(data?.queryResult?.queryResults.rows).not.toEqual(
         prevData?.queryResult?.queryResults.rows,
@@ -221,7 +222,7 @@ describe('QueryVisualizationWrapper', () => {
 
       expect(data!.queryResult!.queryResults.rows).toHaveLength(1)
       secondSetOfVisibleColumns =
-        onContextReceived.mock.calls.at(-1)![0].columnsToShowInTable
+        onContextReceived.mock.lastCall[0].columnsToShowInTable
     })
 
     // The array of visible columns should not have changed, and should have referential equality

--- a/src/lib/containers/QueryContext.tsx
+++ b/src/lib/containers/QueryContext.tsx
@@ -50,7 +50,7 @@ export type QueryContextType = {
 
 export type PaginatedQueryContextType = QueryContextType & {
   /** Navigates to a particular page, where the first page has value 1 */
-  goToPage: (pageNum: number) => Promise<void>
+  goToPage: (pageNum: number) => void
   /** The current page number, where page 1 is the first page. */
   currentPage: number
   /** Updates the page size */

--- a/src/lib/containers/QueryVisualizationWrapper.tsx
+++ b/src/lib/containers/QueryVisualizationWrapper.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
+import { useDeepCompareMemoize } from 'use-deep-compare-effect'
 import { useQueryContext } from './QueryContext'
 
 export type QueryVisualizationContextType = {
@@ -114,15 +115,17 @@ export function QueryVisualizationWrapper(
     }
   }, [isLoadingNewBundle])
 
-  const [isColumnSelected, setIsColumnSelected] = useState<string[]>([])
+  const [visibleColumns, setVisibleColumns] = useState<string[]>([])
   const [selectedRowIndices, setSelectedRowIndices] = useState<number[]>([])
 
   const lastQueryRequest = getLastQueryRequest()
-  const selectColumns = data?.selectColumns
+
+  // We deep-compare-memoize the selectColumns so we don't reset visible columns when the reference changes, but not the contents (e.g. on page change)
+  const selectColumns = useDeepCompareMemoize(data?.selectColumns)
 
   useEffect(() => {
     // SWC-6030: If sql changes, reset what columns are visible
-    setIsColumnSelected(
+    setVisibleColumns(
       selectColumns
         ?.slice(0, props.visibleColumnCount ?? Infinity)
         .map(el => el.name) ?? [],
@@ -132,8 +135,8 @@ export function QueryVisualizationWrapper(
   const context: QueryVisualizationContextType = {
     topLevelControlsState,
     setTopLevelControlsState,
-    columnsToShowInTable: isColumnSelected,
-    setColumnsToShowInTable: setIsColumnSelected,
+    columnsToShowInTable: visibleColumns,
+    setColumnsToShowInTable: setVisibleColumns,
     selectedRowIndices,
     setSelectedRowIndices,
 

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -88,7 +88,7 @@ export function QueryWrapper(props: QueryWrapperProps) {
     executeQueryRequest(lastQueryRequestDeepClone)
   }
 
-  const goToPage = async (pageNum: number) => {
+  const goToPage = (pageNum: number) => {
     const lastQueryRequestDeepClone = getLastQueryRequest()
     lastQueryRequestDeepClone.query.offset = (pageNum - 1) * pageSize
     executeQueryRequest(lastQueryRequestDeepClone)

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -129,7 +129,6 @@ export default class SynapseTable extends React.Component<
     this.shouldComponentUpdate = this.shouldComponentUpdate.bind(this)
     this.handleColumnSortPress = this.handleColumnSortPress.bind(this)
     this.findSelectionIndex = this.findSelectionIndex.bind(this)
-    this.toggleColumnSelection = this.toggleColumnSelection.bind(this)
     this.advancedSearch = this.advancedSearch.bind(this)
     this.getLengthOfPropsData = this.getLengthOfPropsData.bind(this)
     this.configureFacetDropdown = this.configureFacetDropdown.bind(this)
@@ -979,29 +978,6 @@ export default class SynapseTable extends React.Component<
   private getLengthOfPropsData() {
     const { data } = this.props.queryContext
     return data?.queryResult?.queryResults.headers.length ?? 0
-  }
-  /**
-   * Handles the toggle of a column select, this will cause the table to
-   * either show the column or hide depending on the prior state of the column
-   *
-   * @memberof SynapseTable
-   */
-  public toggleColumnSelection = (columnName: string) => {
-    const {
-      queryVisualizationContext: {
-        columnsToShowInTable,
-        setColumnsToShowInTable,
-      },
-    } = this.props
-    let columnsToShowInTableCopy = cloneDeep(columnsToShowInTable)
-    if (columnsToShowInTableCopy.includes(columnName)) {
-      columnsToShowInTableCopy = columnsToShowInTableCopy.filter(
-        el => el !== columnName,
-      )
-    } else {
-      columnsToShowInTableCopy.push(columnName)
-    }
-    setColumnsToShowInTable(columnsToShowInTableCopy)
   }
 
   /**

--- a/src/lib/containers/table/TopLevelControls.tsx
+++ b/src/lib/containers/table/TopLevelControls.tsx
@@ -200,7 +200,7 @@ const TopLevelControls = (props: TopLevelControlsProps) => {
               (key === 'showSqlEditor' && hideSqlEditorControl)
             ) {
               // needs to be a file view in order for download to make sense
-              return <></>
+              return <React.Fragment key={key}></React.Fragment>
             } else if (key === 'showDownloadConfirmation') {
               return (
                 <DownloadOptions

--- a/src/lib/containers/table/table-top/ColumnSelection.tsx
+++ b/src/lib/containers/table/table-top/ColumnSelection.tsx
@@ -70,6 +70,7 @@ export const ColumnSelection: React.FunctionComponent<ColumnSelectionProps> = (
           will unexpectedly render with the list going upwards instead of downwards.
         */}
       <Dropdown.Menu
+        id={`${tooltipColumnSelectionId}-dropdown`}
         className="SRC-primary-color-hover-dropdown"
         alignRight={true}
       >
@@ -86,7 +87,6 @@ export const ColumnSelection: React.FunctionComponent<ColumnSelectionProps> = (
             : ''
           return (
             <Dropdown.Item
-              // @ts-ignore
               onClick={() => toggleColumnSelection(name)}
               key={name}
             >

--- a/src/lib/containers/widgets/ElementWithTooltip.tsx
+++ b/src/lib/containers/widgets/ElementWithTooltip.tsx
@@ -79,8 +79,6 @@ export const ElementWithTooltip: FunctionComponent<ElementWithTooltipProps> = ({
       <button
         tabIndex={0}
         id={idForToolTip}
-        data-for={idForToolTip}
-        data-tip={tooltipText}
         className={`ElementWithTooltip SRC-hand-cursor SRC-primary-background-color-hover ${className} ${
           darkTheme ? 'dark-theme' : ''
         } `}
@@ -102,13 +100,7 @@ export const ElementWithTooltip: FunctionComponent<ElementWithTooltipProps> = ({
       </Dropdown.Toggle>
     )
   } else {
-    const outerChild = children as JSX.Element
-    tooltipTrigger = React.cloneElement(outerChild, {
-      className: `${outerChild.props.className} SRC-hand-cursor`,
-      id: idForToolTip,
-      'data-for': idForToolTip,
-      'data-tip': tooltipText,
-    })
+    tooltipTrigger = <div className="SRC-hand-cursor">{children}</div>
   }
 
   return (

--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -1205,7 +1205,7 @@ hr ~ .SRC-wrapper {
   padding: 0px;
 }
 
-#addAndRemoveColumns ~ div.dropdown-menu {
+#addAndRemoveColumns-dropdown.dropdown-menu {
   max-height: 300px;
   overflow: auto;
 }

--- a/src/mocks/msw/handlers/tableQueryHandlers.ts
+++ b/src/mocks/msw/handlers/tableQueryHandlers.ts
@@ -1,4 +1,4 @@
-import { uniqueId } from 'lodash-es'
+import { cloneDeep, uniqueId } from 'lodash-es'
 import { rest } from 'msw'
 import {
   ASYNCHRONOUS_JOB_TOKEN,
@@ -10,15 +10,50 @@ import {
   getEndpoint,
 } from '../../../lib/utils/functions/getEndpoint'
 import {
+  BUNDLE_MASK_LAST_UPDATED_ON,
+  BUNDLE_MASK_QUERY_COLUMN_MODELS,
+  BUNDLE_MASK_QUERY_COUNT,
+  BUNDLE_MASK_QUERY_FACETS,
+  BUNDLE_MASK_QUERY_MAX_ROWS_PER_PAGE,
+  BUNDLE_MASK_QUERY_RESULTS,
+  BUNDLE_MASK_QUERY_SELECT_COLUMNS,
+  BUNDLE_MASK_SUM_FILES_SIZE_BYTES,
+} from '../../../lib/utils/SynapseConstants'
+import {
   AsynchronousJobStatus,
   AsyncJobId,
   QueryBundleRequest,
   QueryResultBundle,
 } from '../../../lib/utils/synapseTypes'
 
+const BIT_TO_FIELD_MAP: Record<number, keyof QueryResultBundle> = {
+  [BUNDLE_MASK_QUERY_RESULTS]: 'queryResult',
+  [BUNDLE_MASK_QUERY_COUNT]: 'queryCount',
+  [BUNDLE_MASK_QUERY_SELECT_COLUMNS]: 'selectColumns',
+  [BUNDLE_MASK_QUERY_MAX_ROWS_PER_PAGE]: 'maxRowsPerPage',
+  [BUNDLE_MASK_QUERY_COLUMN_MODELS]: 'columnModels',
+  [BUNDLE_MASK_QUERY_FACETS]: 'facets',
+  [BUNDLE_MASK_SUM_FILES_SIZE_BYTES]: 'sumFileSizes',
+  [BUNDLE_MASK_LAST_UPDATED_ON]: 'lastUpdatedOn',
+}
+
+function removeBundleFieldsUsingMask(
+  queryResultBundle: QueryResultBundle,
+  partMask: number,
+): QueryResultBundle {
+  const result = cloneDeep(queryResultBundle)
+  Object.entries(BIT_TO_FIELD_MAP).forEach(([bit, field]) => {
+    if ((partMask & parseInt(bit)) === 0) {
+      delete result[field]
+    }
+  })
+  return result
+}
+
 export function getHandlersForTableQuery(response: QueryResultBundle) {
   const asyncJobId = uniqueId()
   let queryBundleRequest: QueryBundleRequest | undefined
+
   return [
     /**
      * Create a new entity
@@ -43,6 +78,11 @@ export function getHandlersForTableQuery(response: QueryResultBundle) {
         BackendDestinationEnum.REPO_ENDPOINT,
       )}${ASYNCHRONOUS_JOB_TOKEN(asyncJobId)}`,
       async (req, res, ctx) => {
+        const resultBundle = removeBundleFieldsUsingMask(
+          response,
+          queryBundleRequest!.partMask,
+        )
+
         return res(
           ctx.status(201),
           ctx.json<
@@ -53,7 +93,7 @@ export function getHandlersForTableQuery(response: QueryResultBundle) {
             requestBody: queryBundleRequest!,
             etag: '00000000-0000-0000-0000-000000000000',
             jobId: asyncJobId,
-            responseBody: response,
+            responseBody: resultBundle,
             startedByUserId: 0,
             startedOn: '',
             changedOn: '',
@@ -74,7 +114,12 @@ export function getHandlersForTableQuery(response: QueryResultBundle) {
         BackendDestinationEnum.REPO_ENDPOINT,
       )}${TABLE_QUERY_ASYNC_GET(':id', asyncJobId)}`,
       async (req, res, ctx) => {
-        return res(ctx.status(201), ctx.json<QueryResultBundle>(response))
+        const resultBundle = removeBundleFieldsUsingMask(
+          response,
+          queryBundleRequest!.partMask,
+        )
+
+        return res(ctx.status(201), ctx.json<QueryResultBundle>(resultBundle))
       },
     ),
   ]


### PR DESCRIPTION
- Remove unused toggleColumnSelection from SynapseTable
- Remove async from goToPage.
- Apply key to React.Fragment
- PORTALS-2272: Check selectColumn for deep equality before resetting visible columns