### PR TITLE
PORTALS-2271: svg should be white if the background has the primary c…

### DIFF
--- a/src/lib/style/base/_core.scss
+++ b/src/lib/style/base/_core.scss
@@ -143,6 +143,12 @@ svg.SRC-hoverBox {
       }
     }
   }
+  .SRC-primary-background-color {
+    svg,
+    path {
+      fill: #fff;
+    }
+  }
 }
 
 .SRC-grey-background-hover {


### PR DESCRIPTION
…olor

Before: 
<img width="37" alt="Screen Shot 2022-08-23 at 2 25 22 PM" src="https://user-images.githubusercontent.com/1864447/186269619-d7103fcc-d2a2-4a17-b179-171fa2522bf2.png">

After: 
<img width="36" alt="Screen Shot 2022-08-23 at 2 28 33 PM" src="https://user-images.githubusercontent.com/1864447/186269684-97521926-cbfb-48d7-ab50-400e3ec8a73d.png">

