### PR TITLE
SWC-6077: Contextually update latest version text

### DIFF
--- a/src/__tests__/lib/containers/entity_finder/details/DetailsView.test.tsx
+++ b/src/__tests__/lib/containers/entity_finder/details/DetailsView.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../../../../lib/containers/entity_finder/details/view/DetailsView'
 import { NO_VERSION_NUMBER } from '../../../../../lib/containers/entity_finder/EntityFinder'
 import { EntityFinderHeader } from '../../../../../lib/containers/entity_finder/EntityFinderHeader'
+import { VersionSelectionType } from '../../../../../lib/containers/entity_finder/VersionSelectionType'
 import { createWrapper } from '../../../../../lib/testutils/TestingLibraryUtils'
 import { ENTITY_ID_VERSIONS } from '../../../../../lib/utils/APIConstants'
 import {
@@ -103,7 +104,7 @@ const PROJECT_INDEX = 1
 const mockSetCurrentContainer = jest.fn()
 
 const defaultProps: DetailsViewProps = {
-  showVersionSelection: true,
+  versionSelection: VersionSelectionType.TRACKED,
   selectColumnType: 'none',
   visibleTypes: Object.values(EntityType),
   selected: Map(),
@@ -117,7 +118,6 @@ const defaultProps: DetailsViewProps = {
   sort: undefined,
   setSort: mockSetSort,
   noResultsPlaceholder: <></>,
-  mustSelectVersionNumber: false,
   enableSelectAll: true,
   setCurrentContainer: mockSetCurrentContainer,
 }
@@ -259,7 +259,7 @@ describe('DetailsView tests', () => {
     it('shows both the selected and version columns', () => {
       renderComponent({
         selectColumnType: 'checkbox',
-        showVersionSelection: true,
+        versionSelection: VersionSelectionType.REQUIRED,
       })
 
       expect(screen.getAllByRole('columnheader').length).toBe(9)
@@ -267,7 +267,7 @@ describe('DetailsView tests', () => {
     it('hides the selected column', () => {
       renderComponent({
         selectColumnType: 'none',
-        showVersionSelection: true,
+        versionSelection: VersionSelectionType.REQUIRED,
       })
 
       expect(screen.getAllByRole('columnheader').length).toBe(8)
@@ -275,7 +275,7 @@ describe('DetailsView tests', () => {
     it('hides the version column', () => {
       renderComponent({
         selectColumnType: 'checkbox',
-        showVersionSelection: false,
+        versionSelection: VersionSelectionType.DISALLOWED,
       })
 
       expect(screen.getAllByRole('columnheader').length).toBe(8)
@@ -371,12 +371,12 @@ describe('DetailsView tests', () => {
       )
     })
 
-    it('Clicking select all toggles selection with version when mustSelectVersionNumber is true', async () => {
+    it('Clicking select all toggles selection with version when versionSelection is REQUIRED', async () => {
       renderComponent({
         enableSelectAll: true,
         selectAllIsChecked: false,
         hasNextPage: false,
-        mustSelectVersionNumber: true,
+        versionSelection: VersionSelectionType.REQUIRED,
         selectColumnType: 'checkbox',
       })
 
@@ -498,9 +498,9 @@ describe('DetailsView tests', () => {
       })
     })
 
-    it('toggles selection with version when mustSelectVersionNumber is true', () => {
+    it('toggles selection with version when versionSelection is REQUIRED', () => {
       renderComponent({
-        mustSelectVersionNumber: true,
+        versionSelection: VersionSelectionType.REQUIRED,
       })
 
       userEvent.click(screen.getAllByRole('row')[FILE_INDEX])
@@ -511,9 +511,9 @@ describe('DetailsView tests', () => {
       })
     })
 
-    it('mustSelectVersionNumber does not affect toggle for non-versionable entities', () => {
+    it('versionSelection is REQUIRED does not affect toggle for non-versionable entities', () => {
       renderComponent({
-        mustSelectVersionNumber: true,
+        versionSelection: VersionSelectionType.REQUIRED,
       })
 
       // Click the project--projects don't have versions
@@ -608,27 +608,42 @@ describe('DetailsView tests', () => {
         expect(screen.getAllByRole('option').length).toBe(3)
       })
 
-      it('Always Latest Version copy is configurable', async () => {
+      it('Always Latest Version text appears when versionSelection is TRACKED', async () => {
         mockAllIsIntersecting(true)
 
         renderComponent({
           selectableTypes: [EntityType.FILE],
           visibleTypes: [EntityType.FILE],
           selected: Map([[entityHeaders[0].id, NO_VERSION_NUMBER]]),
-          latestVersionText: 'The Most Recent Version',
+          versionSelection: VersionSelectionType.TRACKED,
         })
 
-        await screen.findByText('The Most Recent Version')
+        await screen.findByText('Always Latest Version')
       })
 
-      it('does not display Always Latest Version if mustSelectVersionNumber is true', async () => {
+      it('Always Latest Version text does not appear when versionSelection is UNTRACKED', async () => {
         mockAllIsIntersecting(true)
 
         renderComponent({
           selectableTypes: [EntityType.FILE],
           visibleTypes: [EntityType.FILE],
           selected: Map([[entityHeaders[0].id, NO_VERSION_NUMBER]]),
-          mustSelectVersionNumber: true,
+          versionSelection: VersionSelectionType.UNTRACKED,
+        })
+
+        expect(
+          await screen.queryByText('Always Latest Version'),
+        ).not.toBeInTheDocument()
+      })
+
+      it('does not display Always Latest Version if versionSelection is REQUIRED', async () => {
+        mockAllIsIntersecting(true)
+
+        renderComponent({
+          selectableTypes: [EntityType.FILE],
+          visibleTypes: [EntityType.FILE],
+          selected: Map([[entityHeaders[0].id, NO_VERSION_NUMBER]]),
+          versionSelection: VersionSelectionType.REQUIRED,
         })
 
         await screen.findByRole('listbox')
@@ -729,7 +744,7 @@ describe('DetailsView tests', () => {
           selectableTypes: [EntityType.FILE],
           visibleTypes: [EntityType.FILE],
           selected: Map([[entityHeaders[0].id, NO_VERSION_NUMBER]]),
-          mustSelectVersionNumber: true,
+          versionSelection: VersionSelectionType.REQUIRED,
         })
         expect(await screen.findByRole('listbox')).toBeDefined()
 

--- a/src/lib/containers/IconSvg.tsx
+++ b/src/lib/containers/IconSvg.tsx
@@ -29,6 +29,7 @@ import {
   GetAppTwoTone,
   Group,
   HelpOutlined,
+  HelpOutlineTwoTone,
   HistoryTwoTone,
   InfoOutlined,
   InsertDriveFileTwoTone,
@@ -123,6 +124,7 @@ export const IconStrings = [
   'time',
   'login',
   'helpOutlined',
+  'helpOutlineTwoTone',
   'expandLess',
   'expandMore',
   'rat',
@@ -307,6 +309,8 @@ const getIcon = (options: IconSvgOptions) => {
       return <WatchLater style={muiSvgStyle}></WatchLater>
     case 'login':
       return <Login fill={color} style={customSvgStyle}></Login>
+    case 'helpOutlineTwoTone':
+      return <HelpOutlineTwoTone style={muiSvgStyle}></HelpOutlineTwoTone>
     case 'helpOutlined':
       return <HelpOutlined style={muiSvgStyle}></HelpOutlined>
     case 'close':

--- a/src/lib/containers/entity_finder/EntityFinder.stories.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.stories.tsx
@@ -4,6 +4,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import EntityFinder from './EntityFinder'
 import { FinderScope } from './tree/EntityTree'
 import { EntityType } from '../../utils/synapseTypes'
+import { VersionSelectionType } from './VersionSelectionType'
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -20,14 +21,13 @@ const Template: ComponentStory<typeof EntityFinder> = args => (
 
 export const DualPane = Template.bind({})
 DualPane.args = {
-  mustSelectVersionNumber: true,
   treeOnly: false,
   initialScope: FinderScope.CURRENT_PROJECT,
   projectId: 'syn23567475',
   initialContainer: 'syn24183903',
   selectMultiple: true,
   visibleTypesInList: Object.values(EntityType),
-  showVersionSelection: true,
+  versionSelection: VersionSelectionType.TRACKED,
   onSelectedChange: selected => {
     console.log('Selection changed:', selected)
   },
@@ -46,7 +46,7 @@ SinglePane.args = {
   initialContainer: 'syn24183903',
   selectMultiple: false,
   visibleTypesInTree: [EntityType.PROJECT, EntityType.FOLDER, EntityType.TABLE],
-  showVersionSelection: true,
+  versionSelection: VersionSelectionType.DISALLOWED,
   onSelectedChange: selected => {
     console.log('Selection changed:', selected)
   },

--- a/src/lib/containers/entity_finder/EntityFinder.stories.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.stories.tsx
@@ -11,7 +11,14 @@ export default {
   title: 'Synapse/EntityFinder',
   component: EntityFinder,
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
-  argTypes: {},
+  argTypes: {
+    versionSelection: {
+      options: ['REQUIRED', 'DISABLED', 'TRACKED', 'UNTRACKED'],
+      control: {
+        type: 'select',
+      },
+    },
+  },
 } as ComponentMeta<typeof EntityFinder>
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args

--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -29,6 +29,7 @@ import { SelectionPane } from './SelectionPane'
 import { EntityTree, EntityTreeContainer, FinderScope } from './tree/EntityTree'
 import { EntityTreeNodeType } from './tree/VirtualizedTree'
 import { useEntitySelection } from './useEntitySelection'
+import { VersionSelectionType } from './VersionSelectionType'
 
 const DEFAULT_SELECTABLE_TYPES = Object.values(EntityType)
 const TABLE_DEFAULT_VISIBLE_TYPES = Object.values(EntityType)
@@ -63,10 +64,8 @@ export type EntityFinderProps = {
   projectId?: string
   /** The SynID of the entity that should open by default. If this is a Syn ID, then it must be in the project specified in `projectId` */
   initialContainer: string | 'root' | null
-  /** Whether or not versions may be specified when selecting applicable entities */
-  showVersionSelection?: boolean
-  /** For versionable entities, require the user to select a numbered version of an entity. This disallows selecting 'Always Latest Version'. Note that the latest version may still be mutable. Default true. */
-  mustSelectVersionNumber?: boolean
+  /** Determines if versions are selectable, and if so, how they should be shown. Default is "TRACKED" */
+  versionSelection?: VersionSelectionType
   /** The entity types to show in the details view (right pane). Any types specified in `selectableTypes` will automatically be included. */
   visibleTypesInList?: EntityType[]
   /** The entity types that may be selected. Types in `visibleTypesInList` that are not in `selectableTypes` will appear as disabled options. Only the types in `selectableTypes` will appear in search */
@@ -77,8 +76,6 @@ export type EntityFinderProps = {
   selectedCopy?: string | ((count: number) => string)
   /** Whether to show only the tree. If `true`, the tree will be used to make selections */
   treeOnly?: boolean
-  /** Text shown for the latest version, if selectable by the user. Defaults to "Always Latest Version" */
-  latestVersionText?: string
 }
 
 export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
@@ -87,14 +84,12 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
   initialContainer = null,
   selectMultiple,
   onSelectedChange,
-  showVersionSelection = true,
-  mustSelectVersionNumber = false,
+  versionSelection = VersionSelectionType.TRACKED,
   selectableTypes = DEFAULT_SELECTABLE_TYPES,
   visibleTypesInList = TABLE_DEFAULT_VISIBLE_TYPES,
   visibleTypesInTree = TREE_DEFAULT_VISIBLE_TYPES,
   selectedCopy = selectMultiple ? count => `Selected (${count})` : 'Selected',
   treeOnly = false,
-  latestVersionText,
 }: EntityFinderProps) => {
   const { accessToken } = useSynapseContext()
 
@@ -307,8 +302,7 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                       },
                     }
               }
-              showVersionSelection={showVersionSelection}
-              mustSelectVersionNumber={mustSelectVersionNumber}
+              versionSelection={versionSelection}
               selectColumnType={selectMultiple ? 'checkbox' : 'none'}
               selected={selectedEntities}
               isIdSelected={isIdSelected}
@@ -317,7 +311,6 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
               selectableTypes={selectableTypes}
               toggleSelection={toggleSelection}
               enableSelectAll={selectMultiple}
-              latestVersionText={latestVersionText}
               // Intentionally do not pass "setCurrentContainer" -- search does not use the tree so it has nothing to update
               setCurrentContainer={undefined}
             />
@@ -373,8 +366,7 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                         <ReflexElement className="DetailsViewReflexElement">
                           <EntityDetailsList
                             configuration={configFromTreeView}
-                            mustSelectVersionNumber={mustSelectVersionNumber}
-                            showVersionSelection={showVersionSelection}
+                            versionSelection={versionSelection}
                             selected={selectedEntities}
                             isIdSelected={isIdSelected}
                             isSelectable={isSelectable}
@@ -385,7 +377,6 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
                             }
                             toggleSelection={toggleSelection}
                             enableSelectAll={selectMultiple}
-                            latestVersionText={latestVersionText}
                             setCurrentContainer={setCurrentContainer}
                           />
                           <Breadcrumbs {...breadcrumbsProps} />

--- a/src/lib/containers/entity_finder/VersionSelectionType.ts
+++ b/src/lib/containers/entity_finder/VersionSelectionType.ts
@@ -1,0 +1,20 @@
+/**
+ * Documents the possible EntityFinder version selection configurations
+ */
+export enum VersionSelectionType {
+  /** Versions cannot be selected. In dual-pane mode, the version column will not be shown. */
+  DISALLOWED = 'DISALLOWED',
+  /** A numbered version must be selected. The current version of tables will not be shown. */
+  REQUIRED = 'REQUIRED',
+  /**
+   * Versions can be selected, including "Always Latest" version for any versionable entity type.
+   * This should be selected if updates to the entity will not be "tracked" by the use case,
+   * i.e. the widget will update when the entity is updated.
+   */
+  TRACKED = 'TRACKED',
+  /**
+   * Versions can be selected. Tables and views will allow selection of the "Current"/"Draft" version.
+   * This should be selected if updates to the entity will not be "tracked" by the use case.
+   */
+  UNTRACKED = 'UNTRACKED',
+}

--- a/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
+++ b/src/lib/containers/entity_finder/details/EntityDetailsList.tsx
@@ -8,6 +8,7 @@ import { SearchQuery } from '../../../utils/synapseTypes/Search'
 import { SynapseErrorBoundary } from '../../ErrorBanner'
 import { EntityFinderHeader } from '../EntityFinderHeader'
 import { EntityTreeContainer } from '../tree/EntityTree'
+import { VersionSelectionType } from '../VersionSelectionType'
 import { EntityChildrenDetails } from './configurations/EntityChildrenDetails'
 import { FavoritesDetails } from './configurations/FavoritesDetails'
 import { ProjectListDetails } from './configurations/ProjectListDetails'
@@ -40,8 +41,7 @@ export type EntityDetailsListDataConfiguration = {
  * We collect them into this type to simplify passing them through to the view.
  */
 export type EntityDetailsListSharedProps = {
-  showVersionSelection: boolean
-  mustSelectVersionNumber: boolean
+  versionSelection: VersionSelectionType
   selectColumnType: 'checkbox' | 'none'
   enableSelectAll: boolean
   visibleTypes: EntityType[]
@@ -50,7 +50,6 @@ export type EntityDetailsListSharedProps = {
   isIdSelected: (header: EntityFinderHeader) => boolean
   isSelectable: (header: EntityFinderHeader) => boolean
   toggleSelection: (entity: Reference | Reference[]) => void
-  latestVersionText?: string
   setCurrentContainer?: Dispatch<SetStateAction<EntityTreeContainer>>
 }
 

--- a/src/lib/containers/entity_finder/details/view/DetailsView.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsView.tsx
@@ -18,7 +18,6 @@ import {
   EntityType,
   SortBy,
 } from '../../../../utils/synapseTypes'
-import { HelpPopover } from '../../../HelpPopover'
 import { BlockingLoader } from '../../../LoadingScreen'
 import { Checkbox } from '../../../widgets/Checkbox'
 import { NO_VERSION_NUMBER } from '../../EntityFinder'
@@ -38,6 +37,7 @@ import {
   ModifiedOnRenderer,
   TypeIconRenderer,
 } from './DetailsViewTableRenderers'
+import { VersionColumnHeader } from './VersionColumnHeader'
 
 const MIN_TABLE_WIDTH = 1200
 const ROW_HEIGHT = 46
@@ -494,27 +494,9 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
                     {...props}
                   />
                 )}
-                headerRenderer={() => {
-                  return (
-                    <>
-                      Version
-                      <HelpPopover
-                        className="SRC-margin-left-5"
-                        markdownText={
-                          versionSelection === VersionSelectionType.UNTRACKED
-                            ? 'Choose which version of this item you would like to perform this action on.'
-                            : `Choose which version of this item you would like to reference.${
-                                versionSelection ===
-                                VersionSelectionType.TRACKED
-                                  ? ' If you would like the selected reference to update as new versions are created, choose "Always Latest Version".'
-                                  : ''
-                              }`
-                        }
-                        placement="right"
-                      />
-                    </>
-                  )
-                }}
+                headerRenderer={
+                  <VersionColumnHeader versionSelection={versionSelection} />
+                }
               />
             )}
             <Column<EntityFinderTableViewRowData>

--- a/src/lib/containers/entity_finder/details/view/DetailsView.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsView.tsx
@@ -501,10 +501,14 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
                       <HelpPopover
                         className="SRC-margin-left-5"
                         markdownText={
-                          'Allows you to choose which version of this item you would like to perform this action on.' +
-                          (versionSelection === VersionSelectionType.TRACKED
-                            ? `If you would like the selected reference to update as new versions are created, choose the "Always Latest" option.`
-                            : '')
+                          versionSelection === VersionSelectionType.UNTRACKED
+                            ? 'Choose which version of this item you would like to perform this action on.'
+                            : `Choose which version of this item you would like to reference.${
+                                versionSelection ===
+                                VersionSelectionType.TRACKED
+                                  ? ' If you would like the selected reference to update as new versions are created, choose "Always Latest Version".'
+                                  : ''
+                              }`
                         }
                         placement="right"
                       />

--- a/src/lib/containers/entity_finder/details/view/DetailsView.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsView.tsx
@@ -23,6 +23,7 @@ import { BlockingLoader } from '../../../LoadingScreen'
 import { Checkbox } from '../../../widgets/Checkbox'
 import { NO_VERSION_NUMBER } from '../../EntityFinder'
 import { EntityFinderHeader } from '../../EntityFinderHeader'
+import { VersionSelectionType } from '../../VersionSelectionType'
 import { EntityDetailsListSharedProps } from '../EntityDetailsList'
 import {
   BadgeIconsRenderer,
@@ -54,8 +55,6 @@ export type DetailsViewProps = EntityDetailsListSharedProps & {
   noResultsPlaceholder?: React.ReactElement
   /** We defer to the configuration component to determine this */
   selectAllIsChecked?: boolean
-  /** The text to show for selecting the latest version, if it can be selected. Default is "Always Latest Version" */
-  latestVersionText?: string
   /** This request object is only used to tell react-query to cancel fetching all children at once. */
   getChildrenInfiniteRequestObject?: EntityChildrenRequest
   /** The total number of entities that can be retrieved */
@@ -90,8 +89,7 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
   hasNextPage,
   fetchNextPage,
   isFetchingNextPage,
-  showVersionSelection,
-  mustSelectVersionNumber,
+  versionSelection,
   selectColumnType,
   selected,
   visibleTypes,
@@ -102,7 +100,6 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
   noResultsPlaceholder,
   enableSelectAll,
   selectAllIsChecked = false,
-  latestVersionText = 'Always Latest Version',
   getChildrenInfiniteRequestObject,
   totalEntities,
   setCurrentContainer,
@@ -190,10 +187,10 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
                   .map(async e => {
                     let latestVersion: number | undefined
                     if (
-                      mustSelectVersionNumber &&
+                      versionSelection === VersionSelectionType.REQUIRED &&
                       isVersionableEntityType(getEntityTypeFromHeader(e))
                     ) {
-                      // If `mustSelectVersionNumber` is true, then we need to supply a version with the entity.
+                      // If VersionSelectionType.REQUIRED, then we need to supply a version with the entity.
                       // We may already have the version from the header:
                       if (
                         Object.prototype.hasOwnProperty.call(e, 'versionNumber')
@@ -236,7 +233,7 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
     entities,
     fetchNextPage,
     hasNextPage,
-    mustSelectVersionNumber,
+    versionSelection,
     queryClient,
     isFetchingNextPage,
     selectAllIsChecked,
@@ -400,7 +397,7 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
                 if (!isDisabled) {
                   if (
                     isVersionableEntity &&
-                    mustSelectVersionNumber &&
+                    versionSelection === VersionSelectionType.REQUIRED &&
                     currentSelectedVersion == null &&
                     Object.prototype.hasOwnProperty.call(
                       rowData,
@@ -484,7 +481,7 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
               title="ID"
               minWidth={130}
             />
-            {showVersionSelection && (
+            {versionSelection !== VersionSelectionType.DISALLOWED && (
               <Column<EntityFinderTableViewRowData>
                 key="version"
                 minWidth={150}
@@ -492,9 +489,8 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
                 title="Version"
                 cellRenderer={props => (
                   <DetailsViewVersionRenderer
-                    mustSelectVersionNumber={mustSelectVersionNumber}
+                    versionSelection={versionSelection}
                     toggleSelection={toggleSelection}
-                    latestVersionText={latestVersionText}
                     {...props}
                   />
                 )}
@@ -506,9 +502,9 @@ export const DetailsView: React.FunctionComponent<DetailsViewProps> = ({
                         className="SRC-margin-left-5"
                         markdownText={
                           'Allows you to choose which version of this item you would like to perform this action on.' +
-                          (mustSelectVersionNumber
-                            ? ''
-                            : `If you would like the selected reference to update as new versions are created, choose "${latestVersionText}"`)
+                          (versionSelection === VersionSelectionType.TRACKED
+                            ? `If you would like the selected reference to update as new versions are created, choose the "Always Latest" option.`
+                            : '')
                         }
                         placement="right"
                       />

--- a/src/lib/containers/entity_finder/details/view/DetailsViewTableRenderers.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsViewTableRenderers.tsx
@@ -387,9 +387,13 @@ export const DetailsViewVersionRenderer = ({
     versions,
   ])
 
+  if (!isSelected || !isVersionableEntity) {
+    return <></>
+  }
+
   return (
     <div>
-      {isSelected && versions && versions.length > 0 && (
+      {versions && versions.length > 0 ? (
         <Form.Control
           role="listbox"
           size="sm"
@@ -419,6 +423,8 @@ export const DetailsViewVersionRenderer = ({
             )
           })}
         </Form.Control>
+      ) : (
+        latestVersionText
       )}
     </div>
   )

--- a/src/lib/containers/entity_finder/details/view/DetailsViewTableRenderers.tsx
+++ b/src/lib/containers/entity_finder/details/view/DetailsViewTableRenderers.tsx
@@ -353,19 +353,37 @@ function getLatestVersionText(
   versionSelection: VersionSelectionType,
   entityType: EntityType,
 ) {
-  // TODO: Consider adding help for Tables if VersionSelectionType.REQUIRED, saying something like "The Current/Draft version will be referenced until the first Snapshot/Stable Version is created"
   let versionDisplay = 'Latest'
+  let snapshotDisplay = ''
   if (isTableType(entityType)) {
     if (entityType === EntityType.DATASET) {
       versionDisplay = 'Draft'
+      snapshotDisplay = 'Stable Version'
     } else {
       versionDisplay = 'Current'
+      snapshotDisplay = 'Snapshot'
     }
   }
 
   if (versionSelection === VersionSelectionType.TRACKED) {
     return `Always ${versionDisplay} Version`
+  } else if (versionSelection === VersionSelectionType.REQUIRED) {
+    return (
+      <>
+        {versionDisplay}
+
+        <IconSvg
+          options={{
+            icon: 'helpOutlineTwoTone',
+            size: '12px',
+            padding: 'left',
+            label: `No ${snapshotDisplay} exists. The ${versionDisplay} version will be referenced until a new ${snapshotDisplay} is created.`,
+          }}
+        />
+      </>
+    )
   }
+
   return `${versionDisplay} Version`
 }
 

--- a/src/lib/containers/entity_finder/details/view/VersionColumnHeader.tsx
+++ b/src/lib/containers/entity_finder/details/view/VersionColumnHeader.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { HelpPopover } from '../../../HelpPopover'
+import { VersionSelectionType } from '../../VersionSelectionType'
+
+const CHOOSE_REFERENCE =
+  'Choose which version of this item you would like to reference.'
+const CHOOSE_ACTION =
+  'Choose which version of this item you would like to perform this action on.'
+const ALWAYS_LATEST_VERSION_EXPLANATION =
+  'If you would like the selection to update as new versions are created, choose "Always Latest Version".'
+
+export function VersionColumnHeader(props: {
+  versionSelection: VersionSelectionType
+}) {
+  const { versionSelection } = props
+  let helpCopy = ''
+  switch (versionSelection) {
+    case VersionSelectionType.REQUIRED:
+      helpCopy = CHOOSE_REFERENCE
+      break
+    case VersionSelectionType.TRACKED:
+      helpCopy = CHOOSE_REFERENCE + ' ' + ALWAYS_LATEST_VERSION_EXPLANATION
+      break
+    case VersionSelectionType.UNTRACKED:
+      // If the selected version isn't being tracked, then this is most likely a one-time action
+      helpCopy = CHOOSE_ACTION
+      break
+    case VersionSelectionType.DISALLOWED:
+    default:
+    // this column is not shown in these cases.
+  }
+  return (
+    <>
+      Version
+      <HelpPopover
+        className="SRC-margin-left-5"
+        markdownText={helpCopy}
+        placement="right"
+      />
+    </>
+  )
+}

--- a/src/lib/containers/table/datasets/DatasetItemsEditor.tsx
+++ b/src/lib/containers/table/datasets/DatasetItemsEditor.tsx
@@ -43,6 +43,7 @@ import {
 } from '../../entity_finder/details/view/DetailsViewTableRenderers'
 import { EntityFinderModal } from '../../entity_finder/EntityFinderModal'
 import { FinderScope } from '../../entity_finder/tree/EntityTree'
+import { VersionSelectionType } from '../../entity_finder/VersionSelectionType'
 import IconSvg from '../../IconSvg'
 import { BlockingLoader } from '../../LoadingScreen'
 import WarningModal from '../../synapse_form_wrapper/WarningModal'
@@ -270,7 +271,7 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
     oldDataSet: EntityRef[],
     changedItems: EntityRef[],
   ) {
-    let unchangedItems = oldDataSet.filter(
+    const unchangedItems = oldDataSet.filter(
       oldItem =>
         !changedItems.find(newItem => newItem.entityId === oldItem.entityId),
     )
@@ -540,7 +541,7 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
     )
   }
 
-  const selectableTypes = useMemo(() => {
+  const selectableTypes: EntityType[] | undefined = useMemo(() => {
     if (fetchedDataset) {
       return getSelectableTypes(fetchedDataset)
     } else {
@@ -557,7 +558,7 @@ export function DatasetItemsEditor(props: DatasetItemsEditorProps) {
           initialScope: FinderScope.CURRENT_PROJECT,
           initialContainer: projectId ?? null,
           selectableTypes: selectableTypes,
-          mustSelectVersionNumber: true,
+          versionSelection: VersionSelectionType.REQUIRED,
         }}
         titlePopoverProps={{
           markdownText: ENTITY_FINDER_POPOVER,

--- a/src/lib/utils/functions/EntityTypeUtils.ts
+++ b/src/lib/utils/functions/EntityTypeUtils.ts
@@ -66,6 +66,26 @@ export function isContainerType(type: EntityType): boolean {
   }
 }
 
+export function isTableType(type: EntityType): boolean {
+  switch (type) {
+    case EntityType.PROJECT:
+    case EntityType.FOLDER:
+    case EntityType.LINK:
+    case EntityType.DOCKER_REPO:
+    case EntityType.FILE:
+      return false
+    case EntityType.TABLE:
+    case EntityType.SUBMISSION_VIEW:
+    case EntityType.ENTITY_VIEW:
+    case EntityType.DATASET:
+    case EntityType.DATASET_COLLECTION:
+    case EntityType.MATERIALIZED_VIEW:
+      return true
+    default:
+      throw new Error(`Unknown entity type: ${type}`)
+  }
+}
+
 export function entityTypeToFriendlyName(entityType: EntityType): string {
   switch (entityType) {
     case EntityType.PROJECT:


### PR DESCRIPTION
Replace `showVersionSelection`, `mustSelectVersionNumber`, and `latestVersionText` with an enum `versionSelection` that captures each possible case where we would want to change how a user can select versions.

The possible values for `versionSelection`, with examples, are
|Value|Description|Example Scenario|
|---|---|---|
|DISALLOWED|the user cannot select a version|Moving an entity, adding projects to a project view|
|REQUIRED|the user must select a version|Adding files to a dataset|
|TRACKED|the user may select a version, and contextually, changes to the latest version will be tracked if selected|Adding items to an entity list widget in a wiki
|UNTRACKED|the user may select a version, and contextually, changes to the latest version will NOT be tracked if selected. | Importing table columns|

Additionally, add a help tooltip when selecting a table that has no snapshots when a version number is required (e.g. creating a dataset collection).

<img width="700" alt="image" src="https://user-images.githubusercontent.com/17580037/187206750-f840725f-cc0d-4c88-8309-b22fb2cf17b9.png">



This is a breaking change, so SWC must be updated accordingly.