### PR TITLE
SWC-6261: Bundle sanitize-html

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -68,7 +68,6 @@
 <script src="https://unpkg.com/markdown-it-inline-comments@1.0.1/dist/markdown-it-inline-comments.min.js"></script>
 <script src="https://unpkg.com/markdown-it-br@1.0.0/dist/markdown-it-br.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/markdown-it-container@2.0.0/dist/markdown-it-container.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/sanitize-html@1.20.0/dist/sanitize-html.min.js"></script>
 <!-- end synapse markdown imports -->
 <script crossorigin src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 <script

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -30,7 +30,6 @@ const globals = {
   markdownitInlineComments: 'markdownitInlineComments',
   markdownitBr: 'markdownitBr',
   markdownitMath: 'markdownitMath',
-  'sanitize-html': 'sanitizeHtml',
   'prop-types': 'PropTypes',
   'universal-cookie': 'UniversalCookie',
 }
@@ -57,7 +56,6 @@ const esBuildOptions = {
   external: [
     'react',
     'react-dom',
-    'sanitize-html',
     'prop-types',
     'react-router',
     'react-router-dom',

--- a/index.html
+++ b/index.html
@@ -50,7 +50,6 @@
     <script src="https://unpkg.com/markdown-it-inline-comments@1.0.1/dist/markdown-it-inline-comments.min.js"></script>
     <script src="https://unpkg.com/markdown-it-br@1.0.0/dist/markdown-it-br.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/markdown-it-container@2.0.0/dist/markdown-it-container.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/sanitize-html@1.20.0/dist/sanitize-html.min.js"></script>
     <!-- end synapse markdown imports -->
     <script crossorigin src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <script

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-window": "^1.8.6",
     "regenerator-runtime": "^0.13.2",
     "rss-parser": "^3.7.2",
-    "sanitize-html": "^2.7.0",
+    "sanitize-html": "^2.7.1",
     "sass": "^1.30.0",
     "shortid": "^2.2.16",
     "spark-md5": "^3.0.0",

--- a/src/lib/containers/MarkdownSynapse.tsx
+++ b/src/lib/containers/MarkdownSynapse.tsx
@@ -11,7 +11,7 @@ import { SynapseClientError } from '../utils/SynapseClientError'
 import { Button } from 'react-bootstrap'
 import { SynapseContext } from '../utils/SynapseContext'
 import IDUReport from './IDUReport'
-import SanitizeHtml from 'sanitize-html'
+import sanitizeHtml from 'sanitize-html'
 import MarkdownIt from 'markdown-it'
 
 const TOC_CLASS = {
@@ -38,7 +38,6 @@ declare const markdownitBr: any
 declare const markdownitMath: any
 
 declare const markdownit: typeof MarkdownIt
-declare const sanitizeHtml: typeof SanitizeHtml
 
 type WidgetParams = {
   reactKey?: string

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -20,7 +20,6 @@ global.markdownitContainer = require('markdown-it-container')
 global.markdownitEmphasisAlt = require('markdown-it-emphasis-alt')
 global.markdownitInlineComments = require('markdown-it-inline-comments')
 global.markdownitBr = require('markdown-it-br')
-global.sanitizeHtml = require('sanitize-html')
 global.markdownitMath = require('markdown-it-synapse-math')
 global.ResizeObserver = ResizeObserver
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14973,10 +14973,10 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sanitize-html@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.7.0.tgz#e106205b468aca932e2f9baf241f24660d34e279"
-  integrity sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==
+sanitize-html@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.7.1.tgz#a6c2c1a88054a79eeacfac9b0a43f1b393476901"
+  integrity sha512-oOpe8l4J8CaBk++2haoN5yNI5beekjuHv3JRPKUx/7h40Rdr85pemn4NkvUB3TcBP7yjat574sPlcMAyv4UQig==
   dependencies:
     deepmerge "^4.2.2"
     escape-string-regexp "^4.0.0"


### PR DESCRIPTION
v2 of sanitize-html removes the prebuilt version so it must be bundled.

Bundle size increases from ~2.32 MB to ~2.48 MB