### PR TITLE
PORTALS-2157: Rename LockedFacet to LockedColumn

### DIFF
--- a/src/__tests__/lib/containers/InfiniteQueryWrapper.test.tsx
+++ b/src/__tests__/lib/containers/InfiniteQueryWrapper.test.tsx
@@ -6,6 +6,7 @@ import {
 import {
   useQueryContext,
   QueryContextType,
+  LockedColumn,
 } from '../../../lib/containers/QueryContext'
 import syn16787123Json from '../../../mocks/query/syn16787123'
 import { SynapseConstants } from '../../../lib/utils/'
@@ -208,16 +209,16 @@ describe('deep linking', () => {
 })
 
 describe('locked facet', () => {
-  const lockedFacet = {
-    facet: 'tumorType',
+  const lockedColumn: LockedColumn = {
+    columnName: 'tumorType',
     value: 'Cutaneous Neurofibroma',
   }
-  const noLockedFacet = {}
+  const noLockedColumn: LockedColumn = {}
 
-  it('removeLockedFacetData should remove locked facet data', async () => {
+  it('removeLockedColumnData should remove locked facet data', async () => {
     renderComponent({
       initQueryRequest: initialQueryRequest,
-      lockedFacet: lockedFacet,
+      lockedColumn: lockedColumn,
     })
 
     await waitFor(() => expect(providedContext).toBeDefined())
@@ -234,10 +235,10 @@ describe('locked facet', () => {
     ).not.toBeDefined()
   })
 
-  it('removeLockedFacetData should not remove any data if locked facet value is not set', async () => {
+  it('removeLockedColumnData should not remove any data if locked facet value is not set', async () => {
     renderComponent({
       initQueryRequest: initialQueryRequest,
-      lockedFacet: noLockedFacet,
+      lockedColumn: noLockedColumn,
     })
     await waitFor(() => expect(providedContext).toBeDefined())
 

--- a/src/__tests__/lib/containers/QueryWrapper.test.tsx
+++ b/src/__tests__/lib/containers/QueryWrapper.test.tsx
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash-es'
 import * as React from 'react'
 import { act } from '@testing-library/react'
 import {
+  LockedColumn,
   QueryContextType,
   useQueryContext,
 } from '../../../lib/containers/QueryContext'
@@ -205,16 +206,16 @@ describe('deep linking', () => {
 })
 
 describe('locked facet', () => {
-  const lockedFacet = {
-    facet: 'tumorType',
+  const lockedColumn: LockedColumn = {
+    columnName: 'tumorType',
     value: 'Cutaneous Neurofibroma',
   }
-  const noLockedFacet = {}
+  const noLockedColumn: LockedColumn = {}
 
-  it('removeLockedFacetData should remove locked facet data', async () => {
+  it('removeLockedColumnData should remove locked facet data', async () => {
     renderComponent({
       initQueryRequest: initialQueryRequest,
-      lockedFacet: lockedFacet,
+      lockedColumn: lockedColumn,
     })
 
     await waitFor(() => expect(providedContext).toBeDefined())
@@ -231,10 +232,10 @@ describe('locked facet', () => {
     ).not.toBeDefined()
   })
 
-  it('removeLockedFacetData should not remove any data if locked facet value is not set', async () => {
+  it('removeLockedColumnData should not remove any data if locked facet value is not set', async () => {
     renderComponent({
       initQueryRequest: initialQueryRequest,
-      lockedFacet: noLockedFacet,
+      lockedColumn: noLockedColumn,
     })
     await waitFor(() => expect(providedContext).toBeDefined())
 

--- a/src/lib/containers/InfiniteQueryWrapper.tsx
+++ b/src/lib/containers/InfiniteQueryWrapper.tsx
@@ -45,7 +45,12 @@ export type SearchQuery = {
  * either `useQueryContext` or `QueryContextConsumer`.
  */
 export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
-  const { initQueryRequest, onQueryChange, onQueryResultBundleChange } = props
+  const {
+    initQueryRequest,
+    onQueryChange,
+    onQueryResultBundleChange,
+    lockedColumn,
+  } = props
   const [lastQueryRequest, setLastQueryRequest] =
     useState<QueryBundleRequest>(initQueryRequest)
   const [currentAsyncStatus, setCurrentAsyncStatus] = useState<

--- a/src/lib/containers/QueryContext.tsx
+++ b/src/lib/containers/QueryContext.tsx
@@ -12,13 +12,12 @@ export const QUERY_FILTERS_EXPANDED_CSS: string = 'isShowingFacetFilters'
 export const QUERY_FILTERS_COLLAPSED_CSS: string = 'isHidingFacetFilters'
 
 /*
-  For details page: to lock a facet name (e.g. study, grant) so that the facet name
-  and its all possible values will not appear on the details page. The facet name is
-  given by the url's search param. The type is defined here so that other child components
-  in SRC won't generate type errors.
+  For details page: to lock a column (e.g. study, grant) so that the facet values and active filters
+  will not appear on the details page. The facet name is given by the url's search param. 
+  The type is defined here so that other child components in SRC won't generate type errors.
  */
-export type LockedFacet = {
-  facet?: string
+export type LockedColumn = {
+  columnName?: string
   value?: string
 }
 
@@ -42,10 +41,11 @@ export type QueryContextType = {
   /** Whether or not facets are available to be filtered upon based on the current data */
   isFacetsAvailable: boolean
   /**
-   * A facet may be "locked" so that it is not modifiable by the user, for example when showing only data relevant to a particular facet value on a Details Page.
-   * The value of a locked facet will result in a client-side modification of the result bundle data.
+   * A column name may be "locked" so that it is both (1) not shown to the user that the filter is active, and (2) not modifiable by the user.
+   * For example, we may show only the data matching a particular facet value on a Details Page without implying that the shown data is part of a larger table.
+   * The presence of a locked filter will result in a client-side modification of the active query and result bundle data.
    */
-  lockedFacet?: LockedFacet
+  lockedColumn?: LockedColumn
 }
 
 export type PaginatedQueryContextType = QueryContextType & {

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -48,7 +48,12 @@ export type SearchQuery = {
  * either `useQueryContext` or `QueryContextConsumer`.
  */
 export function QueryWrapper(props: QueryWrapperProps) {
-  const { initQueryRequest, onQueryChange, onQueryResultBundleChange } = props
+  const {
+    initQueryRequest,
+    onQueryChange,
+    onQueryResultBundleChange,
+    lockedColumn,
+  } = props
   const [lastQueryRequest, setLastQueryRequest] =
     useState<QueryBundleRequest>(initQueryRequest)
   const [currentAsyncStatus, setCurrentAsyncStatus] = useState<
@@ -209,7 +214,6 @@ export function QueryWrapper(props: QueryWrapperProps) {
     isFacetsAvailable,
     asyncJobStatus: currentAsyncStatus,
     goToPage,
-    isFiltered,
   }
   /**
    * Render the children without any formatting

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -5,7 +5,10 @@ import useDeepCompareEffect, {
   useDeepCompareEffectNoCheck,
 } from 'use-deep-compare-effect'
 import * as DeepLinkingUtils from '../utils/functions/deepLinkingUtils'
-import { isFacetAvailable } from '../utils/functions/queryUtils'
+import {
+  isFacetAvailable,
+  removeLockedColumnFromFacetData,
+} from '../utils/functions/queryUtils'
 import { parseEntityIdAndVersionFromSqlStatement } from '../utils/functions/sqlFunctions'
 import { useGetEntity } from '../utils/hooks/SynapseAPI/entity/useEntity'
 import { useGetQueryResultBundleWithAsyncStatus } from '../utils/hooks/SynapseAPI/entity/useGetQueryResultBundle'
@@ -17,7 +20,7 @@ import {
   Table,
 } from '../utils/synapseTypes'
 import {
-  LockedFacet,
+  LockedColumn,
   PaginatedQueryContextType,
   QueryContextProvider,
 } from './QueryContext'
@@ -32,7 +35,7 @@ export type QueryWrapperProps = {
   shouldDeepLink?: boolean
   onQueryChange?: (newQueryJson: string) => void
   onQueryResultBundleChange?: (newQueryResultBundleJson: string) => void
-  lockedFacet?: LockedFacet
+  lockedColumn?: LockedColumn
 }
 
 export type SearchQuery = {
@@ -188,24 +191,12 @@ export function QueryWrapper(props: QueryWrapperProps) {
    * this is to remove the facet from the charts, search and filter.
    * @return data: QueryResultBundle
    */
-  const dataWithLockedFacetRemoved = useMemo(() => {
-    const lockedFacet = props.lockedFacet?.facet
-    if (lockedFacet && data) {
-      // for details page, return data without the "locked" facet
-      const dataCopy: QueryResultBundle = cloneDeep(data)
-      const facets = dataCopy.facets?.filter(
-        item => item.columnName.toLowerCase() !== lockedFacet.toLowerCase(),
-      )
-      dataCopy.facets = facets
-      return dataCopy
-    } else {
-      // for other pages, just return the data
-      return data
-    }
-  }, [data, props.lockedFacet?.facet])
+  const dataWithLockedColumnFacetRemoved = useMemo(() => {
+    return removeLockedColumnFromFacetData(data, lockedColumn)
+  }, [data, lockedColumn])
 
   const context: PaginatedQueryContextType = {
-    data: dataWithLockedFacetRemoved,
+    data: dataWithLockedColumnFacetRemoved,
     currentPage,
     pageSize,
     setPageSize,
@@ -218,6 +209,7 @@ export function QueryWrapper(props: QueryWrapperProps) {
     isFacetsAvailable,
     asyncJobStatus: currentAsyncStatus,
     goToPage,
+    isFiltered,
   }
   /**
    * Render the children without any formatting

--- a/src/lib/containers/RssFeedCards.stories.tsx
+++ b/src/lib/containers/RssFeedCards.stories.tsx
@@ -19,6 +19,6 @@ Demo.args = {
   mailChimpListName: 'AMP-AD quarterly newsletter',
   mailChimpUrl:
     'https://sagebase.us7.list-manage.com/subscribe/post?u=b146de537186191a9d2110f3a&amp;id=96b614587a',
-  lockedFacet: { value: 'MSBB' },
+  lockedColumn: { value: 'MSBB' },
   viewAllNewsButtonText: 'VIEW ALL AD NEWS',
 }

--- a/src/lib/containers/RssFeedCards.tsx
+++ b/src/lib/containers/RssFeedCards.tsx
@@ -3,7 +3,7 @@ import Parser from 'rss-parser'
 import moment from 'moment'
 import { ReactComponent as SubscribePlus } from '../assets/icons/subscribe_plus.svg'
 import MailchimpSubscribe from 'react-mailchimp-subscribe'
-import { LockedFacet } from './QueryContext'
+import { LockedColumn } from './QueryContext'
 import NoData from '../assets/icons/NoData'
 import { Button } from 'react-bootstrap'
 
@@ -18,7 +18,7 @@ type RssState = {
 
 export type RssFeedCardsProps = {
   url: string
-  lockedFacet?: LockedFacet // optional tag to filter by, typically set by using this component on a DetailsPage
+  lockedColumn?: LockedColumn // optional tag to filter by, typically set by using this component on a DetailsPage
   itemsToShow: number
   allowCategories?: string[]
   mailChimpListName?: string
@@ -44,10 +44,10 @@ export default class RssFeedCards extends React.Component<
 
   componentDidMount() {
     this._isMounted = true
-    const { url, lockedFacet } = this.props
-    const lockedFacetValue = lockedFacet?.value
-    const tagPath = lockedFacetValue
-      ? `/tag/${lockedFacetValue.replace(' ', '-')}`
+    const { url, lockedColumn } = this.props
+    const lockedColumnValue = lockedColumn?.value
+    const tagPath = lockedColumnValue
+      ? `/tag/${lockedColumnValue.replace(' ', '-')}`
       : ''
     const allItems = `${url}${tagPath}`
     const feedUrl = `${allItems}/feed/`

--- a/src/lib/containers/SearchV2.tsx
+++ b/src/lib/containers/SearchV2.tsx
@@ -17,7 +17,7 @@ import {
   QUERY_FILTERS_COLLAPSED_CSS,
   QUERY_FILTERS_EXPANDED_CSS,
 } from './QueryWrapper'
-import { LockedFacet, QueryContextType } from './QueryContext'
+import { LockedColumn, QueryContextType } from './QueryContext'
 import IconSvg from './IconSvg'
 
 type SearchState = {
@@ -41,7 +41,7 @@ export type SearchV2Props = {
   isQueryWrapperMenuChild?: boolean
   defaultColumn?: string
   searchable?: SearchableColumnsV2
-  lockedFacet?: LockedFacet
+  lockedColumn?: LockedColumn
   fullTextSearchHelpURL?: string
 }
 
@@ -111,19 +111,19 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
     event.preventDefault()
     const { searchText } = this.state
     let { columnName } = this.state
-    const { searchable, lockedFacet } = this.props
+    const { searchable, lockedColumn } = this.props
     if (columnName === '') {
       if (searchable) {
         // If searchable column names are defined in the config, grab the first one (that is not locked)
         columnName = searchable.filter(
-          colName => colName !== lockedFacet?.facet,
+          colName => colName !== lockedColumn?.columnName,
         )[0]
       } else {
         // Otherwise, get the first column model that can be searched.
-        // And for study details page: if lockedFacet is defined, remove it from the search
+        // And for study details page: if lockedColumn is defined, remove it from the search
         const searchableColumnModels =
           this.props.queryContext?.data?.columnModels
-            ?.filter(el => el.name !== lockedFacet?.facet)
+            ?.filter(el => el.name !== lockedColumn?.columnName)
             .filter(el => this.isSupportedColumn(el))
         columnName = searchableColumnModels?.[0].name ?? ''
       }
@@ -216,7 +216,7 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
   render() {
     const {
       searchable,
-      lockedFacet,
+      lockedColumn,
       queryContext: { data },
       queryVisualizationContext: { topLevelControlsState, facetAliases },
     } = this.props
@@ -235,9 +235,11 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
         .map(el => el.name)
     }
 
-    // For study details page: if lockedFacet is defined, remove it from the radio dropdown
-    if (searchColumns.length && lockedFacet?.facet) {
-      searchColumns = searchColumns.filter(el => el !== lockedFacet?.facet)
+    // For study details page: if lockedColumn is defined, remove it from the radio dropdown
+    if (searchColumns.length && lockedColumn?.columnName) {
+      searchColumns = searchColumns.filter(
+        el => el !== lockedColumn?.columnName,
+      )
     }
     const showFacetFilter = topLevelControlsState?.showFacetFilter
     return (

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -769,7 +769,7 @@ export default class SynapseTable extends React.Component<
     const { sortedColumnSelection, columnIconSortState } = this.state
     const {
       queryVisualizationContext: { facetAliases = {}, columnsToShowInTable },
-      queryContext: { lockedFacet },
+      queryContext: { lockedColumn },
     } = this.props
     const tableColumnHeaderElements: JSX.Element[] = headers.map(
       (column: SelectColumn, index: number) => {
@@ -805,8 +805,9 @@ export default class SynapseTable extends React.Component<
             facetAliases,
           )
           const columnModel = columnModels.find(el => el.name === column.name)!
-          const isLockedFacetColumn =
-            column.name.toLowerCase() === lockedFacet?.facet?.toLowerCase() // used in details page to disable filter the column
+          const isLockedColumn =
+            column.name.toLowerCase() ===
+            lockedColumn?.columnName?.toLowerCase() // used in details page to disable filter the column
           const isEntityIDColumn =
             columnModel &&
             columnModel.name == 'id' &&
@@ -819,7 +820,7 @@ export default class SynapseTable extends React.Component<
                 </span>
                 <div className="SRC-centerContent">
                   {isFacetSelection &&
-                    !isLockedFacetColumn &&
+                    !isLockedColumn &&
                     this.configureFacetDropdown(
                       facet,
                       columnModel,

--- a/src/lib/utils/functions/queryUtils.ts
+++ b/src/lib/utils/functions/queryUtils.ts
@@ -1,11 +1,13 @@
+import { cloneDeep } from 'lodash-es'
+import { SynapseClient, SynapseConstants } from '..'
+import { LockedColumn } from '../../containers/QueryContext'
 import {
-  QueryBundleRequest,
   FacetColumnResult,
+  FacetColumnResultValues,
+  QueryBundleRequest,
+  QueryResultBundle,
   SelectColumn,
 } from '../synapseTypes/'
-import { SynapseClient, SynapseConstants } from '..'
-import { QueryResultBundle, FacetColumnResultValues } from '../synapseTypes/'
-import { cloneDeep } from 'lodash-es'
 
 type PartialStateObject = {
   hasMoreData: boolean
@@ -97,4 +99,23 @@ export const isSingleNotSetValue = (facet: FacetColumnResult): boolean => {
     (facet as FacetColumnResultValues).facetValues[0].value ==
       SynapseConstants.VALUE_NOT_SET
   )
+}
+
+export function removeLockedColumnFromFacetData(
+  data?: QueryResultBundle,
+  lockedColumn?: LockedColumn,
+) {
+  const lockedColumnName = lockedColumn?.columnName
+  if (lockedColumnName && data) {
+    // for details page, return data without the "locked" facet
+    const dataCopy: QueryResultBundle = cloneDeep(data)
+    const facets = dataCopy.facets?.filter(
+      item => item.columnName.toLowerCase() !== lockedColumnName.toLowerCase(),
+    )
+    dataCopy.facets = facets
+    return dataCopy
+  } else {
+    // for other pages, just return the data
+    return data
+  }
 }


### PR DESCRIPTION
Pre-work for PORTALS-2157

The "lock" we apply to hide charts/facets/active filters can be applied to any column; the locked column does not necessarily need to be faceted.

This is a breaking change, but it is easily caught by TypeScript.