### PR TITLE
Refactor: replace duplicate logic in Infinite/QueryWrapper with useImmutableTableQuery

### DIFF
--- a/src/__tests__/lib/utils/hooks/useImmutableTableQuery.test.tsx
+++ b/src/__tests__/lib/utils/hooks/useImmutableTableQuery.test.tsx
@@ -1,0 +1,186 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import { cloneDeep } from 'lodash-es'
+import useImmutableTableQuery, {
+  UseImmutableTableQueryOptions,
+} from '../../../../lib/containers/useImmutableTableQuery'
+import * as DeepLinkingUtils from '../../../../lib/utils/functions/deepLinkingUtils'
+
+const options: UseImmutableTableQueryOptions = {
+  initQueryRequest: {
+    concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+    entityId: 'syn123',
+    partMask: 1,
+    query: {
+      sql: 'SELECT * FROM syn123.3 WHERE "foo"=\'bar\'',
+    },
+  },
+}
+
+describe('useImmutableTableQuery tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('Returns the entity ID and version in the passed query', () => {
+    const { result } = renderHook(() => useImmutableTableQuery(options))
+    expect(result.current.entityId).toEqual('syn123')
+    expect(result.current.versionNumber).toEqual(3)
+  })
+
+  it('Updates the query using a new query object', () => {
+    const { result } = renderHook(() => useImmutableTableQuery(options))
+    expect(result.current.getLastQueryRequest()).toEqual(
+      options.initQueryRequest,
+    )
+
+    const newQuery = cloneDeep(options.initQueryRequest)
+    newQuery.query.sql = 'SELECT * FROM syn123.3 WHERE "foo"=\'baz\''
+
+    // Call under test
+    act(() => {
+      result.current.setQuery(newQuery)
+    })
+    expect(result.current.getLastQueryRequest()).toEqual(newQuery)
+    expect(result.current.getLastQueryRequest()).not.toBe(newQuery)
+  })
+
+  it('Updates the query using a transformer function', () => {
+    const { result } = renderHook(() => useImmutableTableQuery(options))
+    expect(result.current.getLastQueryRequest()).toEqual(
+      options.initQueryRequest,
+    )
+
+    const newQuery = cloneDeep(options.initQueryRequest)
+    newQuery.query.sql = 'SELECT * FROM syn123.3 WHERE "foo"=\'baz\''
+
+    // Call under test
+    act(() => {
+      result.current.setQuery(currentQuery => {
+        currentQuery.query.sql = newQuery.query.sql
+        return currentQuery
+      })
+    })
+    expect(result.current.getLastQueryRequest()).toEqual(newQuery)
+  })
+
+  it('Returns a deep clone of the initial request', () => {
+    const { result } = renderHook(() => useImmutableTableQuery(options))
+    expect(result.current.getInitQueryRequest()).toEqual(
+      options.initQueryRequest,
+    )
+    expect(result.current.getInitQueryRequest()).not.toBe(
+      options.initQueryRequest,
+    )
+  })
+
+  it('Returns a deep clone of the most recent request', () => {
+    const { result } = renderHook(() => useImmutableTableQuery(options))
+    expect(result.current.getLastQueryRequest()).toEqual(
+      options.initQueryRequest,
+    )
+    expect(result.current.getLastQueryRequest()).not.toBe(
+      options.initQueryRequest,
+    )
+  })
+
+  it('Updates the page size', () => {
+    const { result } = renderHook(() => useImmutableTableQuery(options))
+    expect(result.current.pageSize).toEqual(25)
+
+    // Call under test
+    act(() => {
+      result.current.setPageSize(50)
+    })
+
+    expect(result.current.pageSize).toEqual(50)
+    expect(result.current.getLastQueryRequest().query.limit).toEqual(50)
+  })
+
+  it('Updates the page number', () => {
+    const { result } = renderHook(() => useImmutableTableQuery(options))
+    const pageSize = result.current.pageSize
+    expect(result.current.currentPage).toEqual(1)
+
+    // Call under test
+    act(() => {
+      result.current.goToPage(2)
+    })
+
+    expect(result.current.currentPage).toEqual(2)
+    expect(result.current.getLastQueryRequest().query.offset).toEqual(pageSize)
+  })
+
+  it('Calls onQueryChange when the query is modified', () => {
+    const onQueryChange = jest.fn()
+    const { result } = renderHook(() =>
+      useImmutableTableQuery({
+        ...options,
+        onQueryChange,
+      }),
+    )
+
+    expect(onQueryChange).not.toHaveBeenCalled()
+
+    const newQuery = cloneDeep(options.initQueryRequest)
+    newQuery.query.sql = 'SELECT * FROM syn123.3 WHERE "foo"=\'baz\''
+
+    // Call under test - change the query
+    act(() => {
+      result.current.setQuery(newQuery)
+    })
+    expect(onQueryChange).toHaveBeenCalledWith(JSON.stringify(newQuery))
+  })
+
+  it('Updates the URL if shouldDeepLink is true', () => {
+    const mockUpdateUrl = jest
+      .spyOn(DeepLinkingUtils, 'updateUrlWithNewSearchParam')
+      .mockImplementation(() => {})
+    const { result } = renderHook(() =>
+      useImmutableTableQuery({
+        ...options,
+        shouldDeepLink: true,
+        componentIndex: 4,
+      }),
+    )
+
+    expect(mockUpdateUrl).not.toHaveBeenCalled()
+
+    const newQuery = cloneDeep(options.initQueryRequest)
+    newQuery.query.sql = 'SELECT * FROM syn123.3 WHERE "foo"=\'baz\''
+
+    // Call under test - change the query
+    act(() => {
+      result.current.setQuery(newQuery)
+    })
+    expect(mockUpdateUrl).toHaveBeenCalledWith(
+      'QueryWrapper',
+      4,
+      encodeURIComponent(JSON.stringify(newQuery.query)),
+    )
+  })
+
+  it('Updates the query on mount one is found in the URL', () => {
+    const sqlInURL = 'SELECT * FROM syn123.3 WHERE "foo"=\'baz\''
+    const mockUpdateUrl = jest
+      .spyOn(DeepLinkingUtils, 'getQueryRequestFromLink')
+      .mockImplementation(() => {
+        return {
+          ...options.initQueryRequest,
+          query: {
+            sql: sqlInURL,
+          },
+        }
+      })
+    const { result } = renderHook(() =>
+      useImmutableTableQuery({
+        ...options,
+        shouldDeepLink: true,
+        componentIndex: 4,
+      }),
+    )
+
+    expect(mockUpdateUrl).toHaveBeenCalledTimes(1)
+
+    expect(result.current.getLastQueryRequest().query.sql).toEqual(sqlInURL)
+  })
+})

--- a/src/__tests__/lib/utils/hooks/useImmutableTableQuery.test.tsx
+++ b/src/__tests__/lib/utils/hooks/useImmutableTableQuery.test.tsx
@@ -41,7 +41,6 @@ describe('useImmutableTableQuery tests', () => {
       result.current.setQuery(newQuery)
     })
     expect(result.current.getLastQueryRequest()).toEqual(newQuery)
-    expect(result.current.getLastQueryRequest()).not.toBe(newQuery)
   })
 
   it('Updates the query using a transformer function', () => {

--- a/src/lib/containers/InfiniteQueryWrapper.tsx
+++ b/src/lib/containers/InfiniteQueryWrapper.tsx
@@ -1,13 +1,9 @@
-import { cloneDeep } from 'lodash-es'
 import * as React from 'react'
 import { useEffect, useMemo, useState } from 'react'
-import useDeepCompareEffect from 'use-deep-compare-effect'
-import * as DeepLinkingUtils from '../utils/functions/deepLinkingUtils'
 import {
   isFacetAvailable,
   removeLockedColumnFromFacetData,
 } from '../utils/functions/queryUtils'
-import { parseEntityIdAndVersionFromSqlStatement } from '../utils/functions/sqlFunctions'
 import { useGetEntity } from '../utils/hooks/SynapseAPI/entity/useEntity'
 import { useInfiniteQueryResultBundle } from '../utils/hooks/SynapseAPI/entity/useGetQueryResultBundle'
 import {
@@ -21,6 +17,7 @@ import {
   LockedColumn,
   QueryContextProvider,
 } from './QueryContext'
+import useImmutableTableQuery from './useImmutableTableQuery'
 
 export const QUERY_FILTERS_EXPANDED_CSS: string = 'isShowingFacetFilters'
 export const QUERY_FILTERS_COLLAPSED_CSS: string = 'isHidingFacetFilters'
@@ -50,12 +47,30 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
     onQueryChange,
     onQueryResultBundleChange,
     lockedColumn,
+    componentIndex,
+    shouldDeepLink,
   } = props
-  const [lastQueryRequest, setLastQueryRequest] =
-    useState<QueryBundleRequest>(initQueryRequest)
   const [currentAsyncStatus, setCurrentAsyncStatus] = useState<
     AsynchronousJobStatus<QueryBundleRequest, QueryResultBundle> | undefined
   >(undefined)
+
+  const {
+    entityId,
+    versionNumber,
+    getInitQueryRequest,
+    getLastQueryRequest,
+    setQuery,
+  } = useImmutableTableQuery({
+    initQueryRequest,
+    componentIndex,
+    shouldDeepLink,
+    onQueryChange,
+  })
+
+  const lastQueryRequest = useMemo(() => {
+    return getLastQueryRequest()
+  }, [getLastQueryRequest])
+
   const {
     data: infiniteData,
     hasNextPage,
@@ -65,7 +80,6 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
     isLoading: queryIsLoading,
     error,
     isPreviousData: newQueryIsFetching,
-    remove,
   } = useInfiniteQueryResultBundle(
     lastQueryRequest,
     {
@@ -78,12 +92,12 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
   // Indicate if we're fetching data for the first time (queryIsLoading) or if we're fetching data for a brand new query (newQueryIsFetching)
   const isLoadingNewBundle = queryIsLoading || newQueryIsFetching
 
-  const { entityId, versionNumber } = parseEntityIdAndVersionFromSqlStatement(
-    lastQueryRequest.query.sql,
-  )!
-
   const { data: entity } = useGetEntity<Table>(entityId, versionNumber)
 
+  /**
+   * Since we're showing an infinite list of data, use custom pagination handling instead of pagination utils provided by
+   * useImmutableTableQuery
+   */
   const [currentPage, setCurrentPage] = useState<number | 'ALL'>(0)
 
   async function appendNextPageToResults(): Promise<void> {
@@ -150,94 +164,15 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
     return infiniteData?.pages[currentPage].responseBody
   }, [currentPage, infiniteData])
 
-  useDeepCompareEffect(() => {
-    if (onQueryChange) {
-      onQueryChange(JSON.stringify(lastQueryRequest.query))
-    }
-  }, [onQueryChange, lastQueryRequest.query])
-
   useEffect(() => {
     if (data && onQueryResultBundleChange) {
       onQueryResultBundleChange(JSON.stringify(data))
     }
   }, [data, onQueryResultBundleChange])
 
-  const componentIndex = props.componentIndex ?? 0
-
   const isFacetsAvailable = data
     ? isFacetAvailable(data.facets, data.selectColumns)
     : true
-
-  /**
-   * Inspect the URL to see if we have a particular query request that we must show.
-   */
-  useEffect(() => {
-    const query = DeepLinkingUtils.getQueryRequestFromLink(
-      'QueryWrapper',
-      componentIndex,
-    )
-    if (query) {
-      setLastQueryRequest(query)
-    }
-  }, [])
-
-  /**
-   * Pass down a deep clone (so no side affects on the child's part) of the
-   * last query request made
-   *
-   * @returns
-   * @memberof QueryWrapper
-   */
-  const getLastQueryRequest = React.useCallback(() => {
-    return cloneDeep(lastQueryRequest)
-  }, [lastQueryRequest])
-
-  /**
-   * Pass down a deep clone (so no side affects on the child's part) of the
-   * first query request made
-   *
-   * @returns
-   * @memberof QueryWrapper
-   */
-  function getInitQueryRequest(): QueryBundleRequest {
-    return cloneDeep(props.initQueryRequest)
-  }
-
-  /**
-   * Execute the given query request, updating all of the data in the QueryContext to match the new query
-   * @param {*} queryRequest Query request as specified by
-   *                         https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/Query.html
-   */
-  function executeQueryRequest(queryRequest: QueryBundleRequest) {
-    const clonedQueryRequest = cloneDeep(queryRequest)
-
-    setLastQueryRequest(clonedQueryRequest)
-    setCurrentPage(0)
-
-    if (clonedQueryRequest.query) {
-      const clonedQueryRequestJson = JSON.stringify(clonedQueryRequest.query)
-      const stringifiedQuery = encodeURIComponent(clonedQueryRequestJson)
-      if (props.shouldDeepLink) {
-        if (props.onQueryChange) {
-          props.onQueryChange(clonedQueryRequestJson)
-        } else {
-          DeepLinkingUtils.updateUrlWithNewSearchParam(
-            'QueryWrapper',
-            componentIndex,
-            stringifiedQuery,
-          )
-        }
-      }
-    }
-    /**
-     * TODO: We remove the cached data because it can interfere with user controls, such as the QueryFilter.
-     * For example, if you filter on a facet with value ["a"], then value ["a", "b"], then value ["a"] again,
-     * we'll have a cache hit on the last query, so we won't get a loading state, but the controls haven't been updated
-     * to handle cache hits. Forcing a cache miss here fixes this, but ideally the controls should handle this case.
-     */
-    remove()
-    // end TODO
-  }
 
   /**
    * remove a particular facet name (e.g. study) and its all possible values based on the parameter specified in the url
@@ -258,7 +193,7 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
     getInitQueryRequest,
     error: error,
     entity,
-    executeQueryRequest,
+    executeQueryRequest: setQuery,
     isFacetsAvailable,
     asyncJobStatus: currentAsyncStatus,
     appendNextPageToResults: appendNextPageToResults,

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -1,18 +1,12 @@
-import { cloneDeep } from 'lodash-es'
 import * as React from 'react'
-import { useEffect, useMemo, useState } from 'react'
-import useDeepCompareEffect, {
-  useDeepCompareEffectNoCheck,
-} from 'use-deep-compare-effect'
-import * as DeepLinkingUtils from '../utils/functions/deepLinkingUtils'
+import { useMemo, useState } from 'react'
+import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 import {
   isFacetAvailable,
   removeLockedColumnFromFacetData,
 } from '../utils/functions/queryUtils'
-import { parseEntityIdAndVersionFromSqlStatement } from '../utils/functions/sqlFunctions'
 import { useGetEntity } from '../utils/hooks/SynapseAPI/entity/useEntity'
 import { useGetQueryResultBundleWithAsyncStatus } from '../utils/hooks/SynapseAPI/entity/useGetQueryResultBundle'
-import { DEFAULT_PAGE_SIZE } from '../utils/SynapseConstants'
 import {
   AsynchronousJobStatus,
   QueryBundleRequest,
@@ -24,6 +18,7 @@ import {
   PaginatedQueryContextType,
   QueryContextProvider,
 } from './QueryContext'
+import useImmutableTableQuery from './useImmutableTableQuery'
 
 export const QUERY_FILTERS_EXPANDED_CSS: string = 'isShowingFacetFilters'
 export const QUERY_FILTERS_COLLAPSED_CSS: string = 'isHidingFacetFilters'
@@ -53,18 +48,40 @@ export function QueryWrapper(props: QueryWrapperProps) {
     onQueryChange,
     onQueryResultBundleChange,
     lockedColumn,
+    componentIndex,
+    shouldDeepLink,
   } = props
-  const [lastQueryRequest, setLastQueryRequest] =
-    useState<QueryBundleRequest>(initQueryRequest)
+
   const [currentAsyncStatus, setCurrentAsyncStatus] = useState<
     AsynchronousJobStatus<QueryBundleRequest, QueryResultBundle> | undefined
   >(undefined)
+
+  const {
+    entityId,
+    versionNumber,
+    getInitQueryRequest,
+    getLastQueryRequest,
+    setQuery,
+    currentPage,
+    pageSize,
+    goToPage,
+    setPageSize,
+  } = useImmutableTableQuery({
+    initQueryRequest,
+    shouldDeepLink,
+    componentIndex,
+    onQueryChange,
+  })
+
+  const lastQueryRequest = useMemo(() => {
+    return getLastQueryRequest()
+  }, [getLastQueryRequest])
+
   const {
     data: asyncJobStatus,
     isLoading: queryIsLoading,
     error,
     isPreviousData: newQueryIsFetching,
-    remove,
   } = useGetQueryResultBundleWithAsyncStatus(
     lastQueryRequest,
     {
@@ -79,117 +96,18 @@ export function QueryWrapper(props: QueryWrapperProps) {
   // Indicate if we're fetching data for the first time (queryIsLoading) or if we're fetching data for a brand new query (newQueryIsFetching)
   const isLoadingNewBundle = queryIsLoading || newQueryIsFetching
 
-  const { entityId, versionNumber } = parseEntityIdAndVersionFromSqlStatement(
-    lastQueryRequest.query.sql,
-  )!
-
   const { data: entity } = useGetEntity<Table>(entityId, versionNumber)
 
-  const pageSize = lastQueryRequest.query.limit ?? DEFAULT_PAGE_SIZE
-  const currentPage = Math.ceil(
-    ((lastQueryRequest.query.offset ?? 0) + Number(pageSize)) / pageSize,
-  )
-
-  const setPageSize = (pageSize: number) => {
-    const lastQueryRequestDeepClone = getLastQueryRequest()
-    lastQueryRequestDeepClone.query.limit = pageSize
-    executeQueryRequest(lastQueryRequestDeepClone)
-  }
-
-  const goToPage = (pageNum: number) => {
-    const lastQueryRequestDeepClone = getLastQueryRequest()
-    lastQueryRequestDeepClone.query.offset = (pageNum - 1) * pageSize
-    executeQueryRequest(lastQueryRequestDeepClone)
-  }
-
-  useDeepCompareEffect(() => {
-    if (onQueryChange) {
-      onQueryChange(JSON.stringify(lastQueryRequest.query))
-    }
-  }, [onQueryChange, lastQueryRequest.query])
-
-  // data is sometimes undefined, which useDeepCompareEffect doesn't like
+  // data is sometimes undefined, which useDeepCompareEffect doesn't like, so use useDeepCompareEffectNoCheck instead
   useDeepCompareEffectNoCheck(() => {
     if (data && onQueryResultBundleChange) {
       onQueryResultBundleChange(JSON.stringify(data))
     }
   }, [data, onQueryResultBundleChange])
 
-  const componentIndex = props.componentIndex ?? 0
-
   const isFacetsAvailable = data
     ? isFacetAvailable(data.facets, data.selectColumns)
     : true
-
-  /**
-   * Inspect the URL to see if we have a particular query request that we must show.
-   */
-  useEffect(() => {
-    const query = DeepLinkingUtils.getQueryRequestFromLink(
-      'QueryWrapper',
-      componentIndex,
-    )
-    if (query) {
-      setLastQueryRequest(query)
-    }
-  }, [])
-
-  /**
-   * Pass down a deep clone (so no side affects on the child's part) of the
-   * last query request made
-   *
-   * @returns
-   * @memberof QueryWrapper
-   */
-  const getLastQueryRequest = React.useCallback(() => {
-    return cloneDeep(lastQueryRequest)
-  }, [lastQueryRequest])
-
-  /**
-   * Pass down a deep clone (so no side affects on the child's part) of the
-   * first query request made
-   *
-   * @returns
-   * @memberof QueryWrapper
-   */
-  function getInitQueryRequest(): QueryBundleRequest {
-    return cloneDeep(props.initQueryRequest)
-  }
-
-  /**
-   * Execute the given query request, updating all of the data in the QueryContext to match the new query
-   * @param {*} queryRequest Query request as specified by
-   *                         https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/Query.html
-   */
-  function executeQueryRequest(queryRequest: QueryBundleRequest) {
-    const clonedQueryRequest = cloneDeep(queryRequest)
-
-    setLastQueryRequest(clonedQueryRequest)
-
-    if (clonedQueryRequest.query) {
-      const clonedQueryRequestJson = JSON.stringify(clonedQueryRequest.query)
-      const stringifiedQuery = encodeURIComponent(clonedQueryRequestJson)
-      if (props.shouldDeepLink) {
-        if (props.onQueryChange) {
-          props.onQueryChange(clonedQueryRequestJson)
-        } else {
-          DeepLinkingUtils.updateUrlWithNewSearchParam(
-            'QueryWrapper',
-            componentIndex,
-            stringifiedQuery,
-          )
-        }
-      }
-    }
-    /**
-     * TODO: We remove the cached data because it can interfere with user controls, such as the QueryFilter.
-     * For example, if you filter on a facet with value ["a"], then value ["a", "b"], then value ["a"] again,
-     * we'll have a cache hit on the last query, so we won't get a loading state, but the controls haven't been updated
-     * to handle cache hits. Forcing a cache miss here fixes this, but ideally the controls should handle this case.
-     */
-    remove()
-    // end TODO
-  }
 
   /**
    * remove a particular facet name (e.g. study) and its all possible values based on the parameter specified in the url
@@ -210,7 +128,7 @@ export function QueryWrapper(props: QueryWrapperProps) {
     getInitQueryRequest,
     error: error,
     entity,
-    executeQueryRequest,
+    executeQueryRequest: setQuery,
     isFacetsAvailable,
     asyncJobStatus: currentAsyncStatus,
     goToPage,

--- a/src/lib/containers/useImmutableTableQuery.ts
+++ b/src/lib/containers/useImmutableTableQuery.ts
@@ -5,7 +5,7 @@ import * as DeepLinkingUtils from '../utils/functions/deepLinkingUtils'
 import { DEFAULT_PAGE_SIZE } from '../utils/SynapseConstants'
 import { parseEntityIdAndVersionFromSqlStatement } from '../utils/functions/sqlFunctions'
 
-type ImmutableTableQueryResult = {
+export type ImmutableTableQueryResult = {
   /** The ID of the table parsed from the SQL query */
   entityId: string
   /** The version number of the table parsed from the SQL query */
@@ -34,7 +34,7 @@ type ImmutableTableQueryResult = {
    */
 }
 
-type UseImmutableTableQueryOptions = {
+export type UseImmutableTableQueryOptions = {
   /** The initial table query request object */
   initQueryRequest: QueryBundleRequest
   /** Whether the URL should update when the query is modified. */
@@ -64,7 +64,7 @@ export default function useImmutableTableQuery(
     useState<QueryBundleRequest>(initQueryRequest)
 
   /**
-   * Inspect the URL to see if we have a particular query request that we must show.
+   * Inspect the URL on mount to see if we have a particular query request that we must show.
    */
   useEffect(() => {
     const query = DeepLinkingUtils.getQueryRequestFromLink(
@@ -74,7 +74,7 @@ export default function useImmutableTableQuery(
     if (query) {
       setLastQueryRequest(query)
     }
-  }, [])
+  }, [componentIndex])
 
   /**
    * Pass down a deep clone (so no side effects on the child's part) of the
@@ -115,8 +115,8 @@ export default function useImmutableTableQuery(
       newQueryRequest = queryRequest
     }
 
+    // Clone the query request before storing it in state, in case the original is mutated
     const clonedQueryRequest = cloneDeep(newQueryRequest)
-
     setLastQueryRequest(clonedQueryRequest)
 
     if (clonedQueryRequest.query) {

--- a/src/lib/containers/useImmutableTableQuery.ts
+++ b/src/lib/containers/useImmutableTableQuery.ts
@@ -120,9 +120,9 @@ export default function useImmutableTableQuery(
     setLastQueryRequest(clonedQueryRequest)
 
     if (clonedQueryRequest.query) {
-      const clonedQueryRequestJson = JSON.stringify(clonedQueryRequest.query)
-      const stringifiedQuery = encodeURIComponent(clonedQueryRequestJson)
       if (shouldDeepLink) {
+        const clonedQueryRequestJson = JSON.stringify(clonedQueryRequest.query)
+        const stringifiedQuery = encodeURIComponent(clonedQueryRequestJson)
         DeepLinkingUtils.updateUrlWithNewSearchParam(
           'QueryWrapper',
           componentIndex,

--- a/src/lib/containers/useImmutableTableQuery.ts
+++ b/src/lib/containers/useImmutableTableQuery.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useState } from 'react'
+import { QueryBundleRequest } from '../utils/synapseTypes/Table/QueryBundleRequest'
+import { cloneDeep } from 'lodash-es'
+import * as DeepLinkingUtils from '../utils/functions/deepLinkingUtils'
+import { DEFAULT_PAGE_SIZE } from '../utils/SynapseConstants'
+import { parseEntityIdAndVersionFromSqlStatement } from '../utils/functions/sqlFunctions'
+
+type ImmutableTableQueryResult = {
+  /** The ID of the table parsed from the SQL query */
+  entityId: string
+  /** The version number of the table parsed from the SQL query */
+  versionNumber?: number
+  getInitQueryRequest: () => QueryBundleRequest
+  getLastQueryRequest: () => QueryBundleRequest
+  setQuery: (
+    queryRequest:
+      | QueryBundleRequest
+      | ((lastQueryRequest: QueryBundleRequest) => QueryBundleRequest),
+  ) => void
+  pageSize: number
+  /** The current page of results. The first page is `1` */
+  currentPage: number
+  setPageSize: (pageSize: number) => void
+  /** pageNumber is 1-indexed */
+  goToPage: (pageNumber: number) => void
+
+  /**
+   * TODO: This hook could handle all potential query transformations, such as
+   *    - addFacetFilter, removeFacetFilter, clearFacetFilters
+   *    - addAdditionalFilter, remove..., clear...
+   *
+   * This could be preferable to allowing any QueryContext subscriber to arbitrarily update the query with `setQuery`
+   *  because we could uniformly handle all complex stateful logic in this hook
+   */
+}
+
+type UseImmutableTableQueryOptions = {
+  /** The initial table query request object */
+  initQueryRequest: QueryBundleRequest
+  /** Whether the URL should update when the query is modified. */
+  shouldDeepLink?: boolean
+  /** Unique index for the component on the page so URL updates do not conflict between table query components */
+  componentIndex?: number
+  /** Callback invoked when the query is modified */
+  onQueryChange?: (newQueryJson: string) => void
+}
+
+/**
+ * Custom hook that maintains and manages the state of a Synapse Table query.
+ * @param options
+ * @returns
+ */
+export default function useImmutableTableQuery(
+  options: UseImmutableTableQueryOptions,
+): ImmutableTableQueryResult {
+  const {
+    initQueryRequest,
+    componentIndex = 0,
+    shouldDeepLink = false,
+    onQueryChange,
+  } = options
+
+  const [lastQueryRequest, setLastQueryRequest] =
+    useState<QueryBundleRequest>(initQueryRequest)
+
+  /**
+   * Inspect the URL to see if we have a particular query request that we must show.
+   */
+  useEffect(() => {
+    const query = DeepLinkingUtils.getQueryRequestFromLink(
+      'QueryWrapper',
+      componentIndex,
+    )
+    if (query) {
+      setLastQueryRequest(query)
+    }
+  }, [])
+
+  /**
+   * Pass down a deep clone (so no side effects on the child's part) of the
+   * last query request made
+   *
+   * @returns
+   * @memberof QueryWrapper
+   */
+  const getLastQueryRequest = useCallback(() => {
+    return cloneDeep(lastQueryRequest)
+  }, [lastQueryRequest])
+
+  /**
+   * Pass down a deep clone (so no side affects on the child's part) of the
+   * first query request made
+   *
+   * @returns
+   * @memberof QueryWrapper
+   */
+  function getInitQueryRequest(): QueryBundleRequest {
+    return cloneDeep(initQueryRequest)
+  }
+
+  /**
+   * Execute the given query request, updating all of the data in the QueryContext to match the new query
+   * @param {*} queryRequest Query request as specified by
+   *                         https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/Query.html
+   */
+  function setQuery(
+    queryRequest:
+      | QueryBundleRequest
+      | ((lastQueryRequest: QueryBundleRequest) => QueryBundleRequest),
+  ): void {
+    let newQueryRequest: QueryBundleRequest
+    if (typeof queryRequest === 'function') {
+      newQueryRequest = queryRequest(getLastQueryRequest())
+    } else {
+      newQueryRequest = queryRequest
+    }
+
+    const clonedQueryRequest = cloneDeep(newQueryRequest)
+
+    setLastQueryRequest(clonedQueryRequest)
+
+    if (clonedQueryRequest.query) {
+      const clonedQueryRequestJson = JSON.stringify(clonedQueryRequest.query)
+      const stringifiedQuery = encodeURIComponent(clonedQueryRequestJson)
+      if (shouldDeepLink) {
+        DeepLinkingUtils.updateUrlWithNewSearchParam(
+          'QueryWrapper',
+          componentIndex,
+          stringifiedQuery,
+        )
+      }
+      if (onQueryChange) {
+        onQueryChange(JSON.stringify(clonedQueryRequest))
+      }
+    }
+  }
+
+  const { entityId, versionNumber } = parseEntityIdAndVersionFromSqlStatement(
+    lastQueryRequest.query.sql,
+  )!
+
+  const pageSize = lastQueryRequest.query.limit ?? DEFAULT_PAGE_SIZE
+  const currentPage = Math.ceil(
+    ((lastQueryRequest.query.offset ?? 0) + Number(pageSize)) / pageSize,
+  )
+  function setPageSize(pageSize: number) {
+    setQuery(currentQuery => {
+      currentQuery.query.limit = pageSize
+      return currentQuery
+    })
+  }
+
+  function goToPage(pageNumber: number) {
+    setQuery(currentQuery => {
+      currentQuery.query.offset = (pageNumber - 1) * pageSize
+      return currentQuery
+    })
+  }
+
+  return {
+    entityId,
+    versionNumber,
+    getInitQueryRequest,
+    getLastQueryRequest,
+    setQuery,
+    pageSize,
+    currentPage,
+    setPageSize,
+    goToPage,
+  }
+}

--- a/src/lib/utils/functions/queryUtils.ts
+++ b/src/lib/utils/functions/queryUtils.ts
@@ -104,7 +104,7 @@ export const isSingleNotSetValue = (facet: FacetColumnResult): boolean => {
 export function removeLockedColumnFromFacetData(
   data?: QueryResultBundle,
   lockedColumn?: LockedColumn,
-) {
+): QueryResultBundle | undefined {
   const lockedColumnName = lockedColumn?.columnName
   if (lockedColumnName && data) {
     // for details page, return data without the "locked" facet


### PR DESCRIPTION
Most of the changes are refactoring I did to simplify PORTALS-2157 -- attempting to reduce duplicate code and improve test-ability. There is also one non-refactor change where we will now use the React Query cache in QueryWrapper and InfiniteQueryWrapper.

- Create custom hook `useImmutableTableQuery`, which has the following responsibilities
	- Stores the initial and current table queries in state
	- Provides clones of the table queries for consumers to read
	- Provides functions for consumers to perform actions on the query
		-	e.g. update the entire query object, change the page size or page number. We can provide more specific controls as needed, like adding/removing a facet filter, for example
	- Handles side effects related to query updates (calling callbacks, updating URL)
- QueryWrapper and InfiniteQueryWrapper were refactored to use `useImmutableTableQuery`
- Changed cache behavior in both QueryWrapper and InfiniteQueryWrapper
	- We were clearing the cache on every query change because of weird UX -- a delay in the controls without a loading state made it unclear that the query updated.
	- Since we made this decision I think the UI has changed in such a way that it is more clear when an updated query goes through, so let's take advantage of the cache!