### PR TITLE
SWC-6277: Add lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
   },
   "rules": {
     "react/prop-types": [0],
+    "react/no-unstable-nested-components": "warn",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": [
       "warn",


### PR DESCRIPTION
SWC-6277 was caused by an unstable component definition. Let's enable warnings for an ESLint rule that would have caught this.