### PR TITLE
SWC-6279

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-react-client",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "private": false,
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/__tests__/lib/utils/hooks/useImmutableTableQuery.test.tsx
+++ b/src/__tests__/lib/utils/hooks/useImmutableTableQuery.test.tsx
@@ -127,7 +127,7 @@ describe('useImmutableTableQuery tests', () => {
     act(() => {
       result.current.setQuery(newQuery)
     })
-    expect(onQueryChange).toHaveBeenCalledWith(JSON.stringify(newQuery))
+    expect(onQueryChange).toHaveBeenCalledWith(JSON.stringify(newQuery.query))
   })
 
   it('Updates the URL if shouldDeepLink is true', () => {

--- a/src/lib/containers/useImmutableTableQuery.ts
+++ b/src/lib/containers/useImmutableTableQuery.ts
@@ -120,17 +120,17 @@ export default function useImmutableTableQuery(
     setLastQueryRequest(clonedQueryRequest)
 
     if (clonedQueryRequest.query) {
+      const clonedQueryJson = JSON.stringify(clonedQueryRequest.query)
       if (shouldDeepLink) {
-        const clonedQueryRequestJson = JSON.stringify(clonedQueryRequest.query)
-        const stringifiedQuery = encodeURIComponent(clonedQueryRequestJson)
+        const encodedQuery = encodeURIComponent(clonedQueryJson)
         DeepLinkingUtils.updateUrlWithNewSearchParam(
           'QueryWrapper',
           componentIndex,
-          stringifiedQuery,
+          encodedQuery,
         )
       }
       if (onQueryChange) {
-        onQueryChange(JSON.stringify(clonedQueryRequest))
+        onQueryChange(clonedQueryJson)
       }
     }
   }


### PR DESCRIPTION
In #1773, the call to `onQueryChange` was erroneously modified to receive the stringified QueryBundleRequest when it should receive the stringified Query object.