### PR TITLE
BREAKING CHANGE: Specify downloadCartPageUrl in context

### DIFF
--- a/src/__tests__/lib/containers/DownloadConfirmation.test.tsx
+++ b/src/__tests__/lib/containers/DownloadConfirmation.test.tsx
@@ -109,12 +109,6 @@ describe('DownloadConfirmation', () => {
     jest.clearAllMocks()
   })
 
-  it('should render without crashing with just a cancel button', () => {
-    renderComponent(props)
-    screen.getByRole('alert')
-    screen.getByRole('button', { name: 'Cancel' })
-  })
-
   it("should call the 'close' function on cancel", async () => {
     renderComponent(props)
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))

--- a/src/lib/containers/StyleGuidistComponentWrapper.tsx
+++ b/src/lib/containers/StyleGuidistComponentWrapper.tsx
@@ -39,6 +39,7 @@ export const StyleGuidistComponentWrapper: React.FC = props => {
         isInExperimentalMode: SynapseClient.isInSynapseExperimentalMode(),
         utcTime: SynapseClient.getUseUtcTimeFromCookie(),
         withErrorBoundary: true,
+        downloadCartPageUrl: '/?path=/story/download-downloadcartpage--demo',
       }}
     >
       <MemoryRouter>

--- a/src/lib/containers/download_list/DownloadConfirmation.tsx
+++ b/src/lib/containers/download_list/DownloadConfirmation.tsx
@@ -34,7 +34,6 @@ export type DownloadConfirmationProps = {
   setTopLevelControlsState?: React.Dispatch<
     React.SetStateAction<TopLevelControlsState>
   >
-  downloadCartPageUrl?: string
 }
 
 // add files to download list
@@ -171,9 +170,8 @@ export const DownloadConfirmation: React.FunctionComponent<
   fnClose,
   setTopLevelControlsState,
   topLevelControlsState,
-  downloadCartPageUrl = '/DownloadCart',
 }) => {
-  const { accessToken } = useSynapseContext()
+  const { accessToken, downloadCartPageUrl } = useSynapseContext()
   const { showDownloadConfirmation = true } = topLevelControlsState ?? {}
   const [status, setStatus] = useState<StatusEnum>(
     accessToken ? StatusEnum.LOADING_INFO : StatusEnum.SIGNED_OUT,
@@ -292,11 +290,7 @@ export const DownloadConfirmation: React.FunctionComponent<
 
   if (showDownloadList) {
     // go to the Download Cart Page
-    if (downloadCartPageUrl) window.location.href = downloadCartPageUrl
-    else
-      console.error(
-        'Missing the Download Cart Page URL in the component configuration.',
-      )
+    window.location.href = downloadCartPageUrl
   }
   const showFacetFilter = topLevelControlsState?.showFacetFilter
   return (

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.stories.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.stories.tsx
@@ -135,7 +135,6 @@ FileView.args = {
   name: 'Data',
   sqlOperator: '=',
   sql: 'SELECT * FROM syn11346063.28',
-  downloadCartPageUrl: '#/Other%20Components?id=downloadcartpage',
   hideSqlEditorControl: false,
 }
 
@@ -149,7 +148,6 @@ Dataset.args = {
   },
   name: 'Dataset Demo',
   sqlOperator: '=',
-  downloadCartPageUrl: '#/Other%20Components?id=downloadcartpage',
   hideSqlEditorControl: false,
   shouldDeepLink: false,
 }
@@ -163,7 +161,6 @@ DatasetCollection.args = {
   },
   name: 'Dataset Collection Demo',
   sqlOperator: '=',
-  downloadCartPageUrl: '#/Other%20Components?id=downloadcartpage',
   hideSqlEditorControl: false,
   shouldDeepLink: false,
 }

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -64,7 +64,6 @@ type OwnProps = {
   defaultColumn?: string
   defaultShowFacetVisualization?: boolean
   defaultShowSearchBox?: boolean
-  downloadCartPageUrl?: string
   showLastUpdatedOn?: boolean
 } & Omit<TopLevelControlsProps, 'entityId'>
 
@@ -100,7 +99,6 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
     hideSqlEditorControl,
     searchConfiguration,
     limit = DEFAULT_PAGE_SIZE,
-    downloadCartPageUrl,
     initQueryJson,
     showLastUpdatedOn,
   } = props
@@ -212,7 +210,6 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
                           setTopLevelControlsState={
                             queryVisualizationContext.setTopLevelControlsState
                           }
-                          downloadCartPageUrl={downloadCartPageUrl}
                         />
                         <TopLevelControls
                           showColumnSelection={tableConfiguration !== undefined}

--- a/src/lib/utils/SynapseContext.tsx
+++ b/src/lib/utils/SynapseContext.tsx
@@ -27,6 +27,8 @@ export type SynapseContextType = {
   utcTime: boolean
   /** Whether to wrap all children of this context in an error boundary. Useful if this context wraps just one component. */
   withErrorBoundary?: boolean
+  /** The URL of the download cart page in the current app. Used to properly link components */
+  downloadCartPageUrl: string
 }
 
 /**
@@ -37,7 +39,7 @@ export const SynapseContext = React.createContext<
 >(undefined)
 
 export type SynapseContextProviderProps = {
-  synapseContext?: SynapseContextType
+  synapseContext: SynapseContextType
   queryClient?: QueryClient
   theme?: SynapseTheme
   children?: React.ReactNode
@@ -51,6 +53,8 @@ export type SynapseContextProviderProps = {
 export const SynapseContextProvider: React.FunctionComponent<
   SynapseContextProviderProps
 > = ({ children, synapseContext, queryClient, theme }) => {
+  synapseContext.downloadCartPageUrl ??= '/DownloadCart'
+
   return (
     <SynapseContext.Provider value={synapseContext}>
       <QueryClientProvider client={queryClient ?? defaultQueryClient}>

--- a/src/mocks/MockSynapseContext.tsx
+++ b/src/mocks/MockSynapseContext.tsx
@@ -10,6 +10,7 @@ export const MOCK_CONTEXT_VALUE: SynapseContextType = {
   accessToken: MOCK_ACCESS_TOKEN,
   utcTime: false,
   isInExperimentalMode: false,
+  downloadCartPageUrl: '/DownloadCart',
 }
 
 export const MOCK_CONTEXT = React.createContext(MOCK_CONTEXT_VALUE)


### PR DESCRIPTION
When we add the Synapse Table renderer to the markdown component (PORTALS-2314), we need to specify the download cart page URL to ensure it links to the correct place. Instead of passing this information through the markdown renderer, it should be in global context.