### PR TITLE
PORTALS-2316: Replace sanitize-html with xss

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "react-window": "^1.8.6",
     "regenerator-runtime": "^0.13.2",
     "rss-parser": "^3.7.2",
-    "sanitize-html": "^2.7.1",
     "sass": "^1.30.0",
     "shortid": "^2.2.16",
     "spark-md5": "^3.0.0",
@@ -91,7 +90,8 @@
     "tslib": "^2.3.1",
     "ua-parser-js": "^1.0.2",
     "universal-cookie": "^4.0.3",
-    "use-deep-compare-effect": "^1.3.1"
+    "use-deep-compare-effect": "^1.3.1",
+    "xss": "^1.0.14"
   },
   "peerDependencies": {
     "react": "^18.2.0",
@@ -151,7 +151,6 @@
     "@types/react-transition-group": "^2.0.16",
     "@types/react-virtualized-auto-sizer": "^1.0.1",
     "@types/react-window": "^1.8.5",
-    "@types/sanitize-html": "^2.3.2",
     "@types/shortid": "^0.0.29",
     "@types/sinon": "^7.0.2",
     "@types/spark-md5": "^3.0.1",

--- a/src/lib/containers/markdown/MarkdownSynapse.tsx
+++ b/src/lib/containers/markdown/MarkdownSynapse.tsx
@@ -1,7 +1,8 @@
+import React from 'react'
 import MarkdownIt from 'markdown-it'
-import * as React from 'react'
-import sanitizeHtml from 'sanitize-html'
+import xss from 'xss'
 import { SynapseClient } from '../../utils'
+import { xssOptions } from '../../utils/functions/SanitizeHtmlUtils'
 import { SynapseClientError } from '../../utils/SynapseClientError'
 import { SynapseContext } from '../../utils/SynapseContext'
 import {
@@ -179,63 +180,7 @@ export default class MarkdownSynapse extends React.Component<
     const initText = this.props.renderInline
       ? this.state.md.renderInline(markdown)
       : this.state.md.render(markdown)
-    const cleanText = sanitizeHtml(initText, {
-      allowedAttributes: {
-        a: ['href', 'target'],
-        button: ['class'],
-        div: ['class'], // PORTALS-1450: including 'style' in the allow-list will cause string values to come through, which crashes the app when used (because it uses jsx).
-        h1: ['toc'],
-        h2: ['toc'],
-        h3: ['toc'],
-        h4: ['toc'],
-        h5: ['toc'],
-        h6: ['toc'],
-        li: ['class'],
-        ol: ['class'],
-        span: ['*'],
-        table: ['class'],
-        th: ['colspan'],
-        thead: ['class'],
-        ul: ['class'],
-        img: ['src', 'alt'],
-      },
-      allowedTags: [
-        'span',
-        'code',
-        'h1',
-        'h2',
-        'h3',
-        'h4',
-        'h5',
-        'p',
-        'b',
-        'i',
-        'em',
-        'strong',
-        'a',
-        'id',
-        'table',
-        'tr',
-        'td',
-        'tbody',
-        'th',
-        'thead',
-        'button',
-        'div',
-        'img',
-        'image',
-        'ol',
-        'ul',
-        'li',
-        'svg',
-        'g',
-        'br',
-        'hr',
-        'summary',
-        'details',
-        'strong',
-      ],
-    })
+    const cleanText = xss(initText, xssOptions)
     return { __html: cleanText }
   }
 

--- a/src/lib/utils/functions/SanitizeHtmlUtils.ts
+++ b/src/lib/utils/functions/SanitizeHtmlUtils.ts
@@ -91,6 +91,7 @@ export const xssOptions: IFilterXSSOptions = {
       // do not filter doctype
       return html
     }
+    return undefined
   },
   safeAttrValue: function (tag, name, value) {
     if (tag === 'img' && name === 'src') {

--- a/src/lib/utils/functions/SanitizeHtmlUtils.ts
+++ b/src/lib/utils/functions/SanitizeHtmlUtils.ts
@@ -1,0 +1,109 @@
+import { IFilterXSSOptions } from 'xss'
+
+// PORTALS-1450: including 'style' in the allow-list will cause string values to come through, which crashes the app when used (because it uses jsx).
+export const xssOptions: IFilterXSSOptions = {
+  whiteList: {
+    a: ['target', 'href', 'title', 'ref'],
+    abbr: ['title'],
+    address: [],
+    area: ['shape', 'coords', 'href', 'alt'],
+    article: [],
+    aside: [],
+    audio: ['autoplay', 'controls', 'loop', 'preload', 'src'],
+    b: [],
+    bdi: ['dir'],
+    bdo: ['dir'],
+    big: [],
+    blockquote: ['cite'],
+    body: [],
+    br: [],
+    button: ['class'],
+    caption: [],
+    center: [],
+    cite: [],
+    code: [],
+    col: ['align', 'valign', 'span', 'width'],
+    colgroup: ['align', 'valign', 'span', 'width'],
+    dd: [],
+    del: ['datetime'],
+    details: ['open'],
+    div: ['class'],
+    dl: [],
+    dt: [],
+    em: [],
+    font: ['color', 'size', 'face'],
+    footer: [],
+    g: [],
+    h1: ['toc'],
+    h2: ['toc'],
+    h3: ['toc'],
+    h4: ['toc'],
+    h5: ['toc'],
+    h6: ['toc'],
+    head: [],
+    header: [],
+    hr: [],
+    html: [],
+    i: [],
+    img: ['src', 'alt', 'title', 'width', 'height'],
+    ins: ['datetime'],
+    li: ['class'],
+    mark: [],
+    nav: [],
+    noscript: [],
+    ol: ['class'],
+    p: [],
+    pre: [],
+    s: [],
+    section: [],
+    small: [],
+    span: ['data-widgetparams', 'class', 'id'],
+    sub: [],
+    summary: [],
+    sup: [],
+    strong: [],
+    svg: [],
+    table: ['width', 'border', 'align', 'valign', 'class'],
+    tbody: ['align', 'valign'],
+    td: ['width', 'rowspan', 'colspan', 'align', 'valign'],
+    tfoot: ['align', 'valign'],
+    th: ['width', 'rowspan', 'colspan', 'align', 'valign', 'class'],
+    thead: ['class', 'align', 'valign'],
+    tr: ['rowspan', 'align', 'valign'],
+    tt: [],
+    u: [],
+    ul: ['class'],
+    video: [
+      'autoplay',
+      'controls',
+      'loop',
+      'preload',
+      'src',
+      'height',
+      'width',
+    ],
+  },
+  stripIgnoreTagBody: true, // filter out all tags not in the whitelist
+  allowCommentTag: false,
+  css: false,
+  onIgnoreTag: function (tag, html, options) {
+    if (tag === '!doctype') {
+      // do not filter doctype
+      return html
+    }
+  },
+  safeAttrValue: function (tag, name, value) {
+    if (tag === 'img' && name === 'src') {
+      if (
+        value &&
+        (value.startsWith('data:image/') || value.startsWith('http'))
+      ) {
+        return value
+      } else {
+        return ''
+      }
+    } else {
+      return value
+    }
+  },
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4269,13 +4269,6 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/sanitize-html@^2.3.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-2.6.2.tgz#9c47960841b9def1e4c9dfebaaab010a3f6e97b9"
-  integrity sha512-7Lu2zMQnmHHQGKXVvCOhSziQMpa+R2hMHFefzbYoYMHeaXR0uXqNeOc3JeQQQ8/6Xa2Br/P1IQTLzV09xxAiUQ==
-  dependencies:
-    htmlparser2 "^6.0.0"
-
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
@@ -6343,7 +6336,7 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@^2.18.0, commander@^2.19.0, commander@^2.20.0:
+commander@^2.18.0, commander@^2.19.0, commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -6716,6 +6709,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==
 
 cssom@^0.5.0:
   version "0.5.0"
@@ -9194,7 +9192,7 @@ htmlparser2-svelte@4.1.0:
     domutils "^2.0.0"
     entities "^2.0.0"
 
-htmlparser2@^6.0.0, htmlparser2@^6.1.0:
+htmlparser2@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
   integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
@@ -9725,7 +9723,7 @@ is-plain-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
-is-plain-object@5.0.0, is-plain-object@^5.0.0:
+is-plain-object@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
@@ -12362,11 +12360,6 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-parse-srcset@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
-  integrity sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==
-
 parse5@6.0.1, parse5@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
@@ -12705,15 +12698,6 @@ postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.36, postcss@^7.0
   dependencies:
     picocolors "^0.2.1"
     source-map "^0.6.1"
-
-postcss@^8.3.11:
-  version "8.4.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
-  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
-  dependencies:
-    nanoid "^3.3.4"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
 
 postcss@^8.4.16:
   version "8.4.16"
@@ -13936,18 +13920,6 @@ sane@^4.0.3:
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
-
-sanitize-html@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.7.1.tgz#a6c2c1a88054a79eeacfac9b0a43f1b393476901"
-  integrity sha512-oOpe8l4J8CaBk++2haoN5yNI5beekjuHv3JRPKUx/7h40Rdr85pemn4NkvUB3TcBP7yjat574sPlcMAyv4UQig==
-  dependencies:
-    deepmerge "^4.2.2"
-    escape-string-regexp "^4.0.0"
-    htmlparser2 "^6.0.0"
-    is-plain-object "^5.0.0"
-    parse-srcset "^1.0.2"
-    postcss "^8.3.11"
 
 sanitize.css@*:
   version "13.0.0"
@@ -16065,6 +16037,14 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xss@^1.0.14:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.14.tgz#4f3efbde75ad0d82e9921cc3c95e6590dd336694"
+  integrity sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
 
 xtend@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
We're using xss to clean HTML in SWC, which is more configurable. Let's simplify our configs by using the same library. I also have more confidence in the SWC configuration, which we have been been using to clean arbitrary HTML for far longer.

This also brings the bundle size down from 3.06 MB to 2.91 MB