### PR TITLE
PORTALS-2316: HtmlPreview component

### DIFF
--- a/src/__tests__/lib/containers/markdown/FilePreview/HtmlPreview.test.tsx
+++ b/src/__tests__/lib/containers/markdown/FilePreview/HtmlPreview.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react'
+import {
+  render,
+  screen,
+  renderHook,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import HtmlPreview, {
+  HtmlPreviewProps,
+  EXPORTED_FOR_UNIT_TESTING,
+} from '../../../../../lib/containers/FilePreview/HtmlPreview/HtmlPreview'
+import { createWrapper } from '../../../../../lib/testutils/TestingLibraryUtils'
+import { rest, server } from '../../../../../mocks/msw/server'
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '../../../../../lib/utils/functions/getEndpoint'
+import { TEAM_MEMBERS } from '../../../../../lib/utils/APIConstants'
+import { PaginatedResults } from '../../../../../lib/utils/synapseTypes'
+import { TeamMember } from '../../../../../lib/utils/synapseTypes/TeamMember'
+import {
+  MOCK_USER_ID,
+  MOCK_USER_ID_2,
+  MOCK_USER_NAME,
+} from '../../../../../mocks/user/mock_user_profile'
+import { TRUSTED_HTML_USERS_TEAM_ID } from '../../../../../lib/utils/SynapseConstants'
+import userEvent from '@testing-library/user-event'
+
+function renderComponent(props: HtmlPreviewProps) {
+  return render(<HtmlPreview {...props} />, { wrapper: createWrapper() })
+}
+
+const { useCleanHtml } = EXPORTED_FOR_UNIT_TESTING
+
+describe('HTML Preview tests', () => {
+  beforeAll(() => server.listen())
+  beforeEach(() => {
+    // Configure the team members request to indicate that MOCK_USER_ID is on the trusted users team
+    const results: TeamMember[] = [
+      {
+        teamId: TRUSTED_HTML_USERS_TEAM_ID.toString(),
+        member: {
+          userName: MOCK_USER_NAME,
+          ownerId: MOCK_USER_ID.toString(),
+          isIndividual: true,
+        },
+        isAdmin: false,
+      },
+    ]
+
+    server.use(
+      rest.get(
+        `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${TEAM_MEMBERS(
+          TRUSTED_HTML_USERS_TEAM_ID,
+        )}`,
+        (req, res, ctx) => {
+          const result: PaginatedResults<TeamMember> = {
+            results: results,
+          }
+          return res(ctx.status(200), ctx.json(result))
+        },
+      ),
+    )
+  })
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  describe('useCleanHtml unit tests', () => {
+    it('Returns undefined if isLoading is true', () => {
+      const { result } = renderHook(() =>
+        useCleanHtml({
+          isLoading: true,
+          rawHtml: '',
+          isTrusted: false,
+        }),
+      )
+      expect(result.current).toEqual(undefined)
+    })
+    it('Returns rawHtml if the user is trusted', () => {
+      const isTrustedUser = true
+      const rawHtml = "<script>alert('hello')</script>"
+      const { result } = renderHook(() =>
+        useCleanHtml({
+          isLoading: false,
+          rawHtml: rawHtml,
+          isTrusted: isTrustedUser,
+        }),
+      )
+      expect(result.current).toEqual(rawHtml)
+    })
+    it('Sanitizes HTML if the user is not trusted', () => {
+      const isTrustedUser = false
+      const rawHtml = "<script>alert('hello')</script>"
+      const { result } = renderHook(() =>
+        useCleanHtml({
+          isLoading: false,
+          rawHtml: rawHtml,
+          isTrusted: isTrustedUser,
+        }),
+      )
+      expect(result.current).not.toEqual(rawHtml)
+    })
+  })
+
+  it('Renders the raw HTML if the creator is on the trusted team', async () => {
+    const idOfUserOnTrustedTeam = MOCK_USER_ID.toString()
+    const rawHtml = "<script>alert('hello')</script>"
+    const fileHandle = {
+      createdBy: idOfUserOnTrustedTeam,
+    }
+    const { container } = renderComponent({
+      rawHtml,
+      fileHandle,
+    })
+
+    let frame: HTMLIFrameElement | null = null
+    await waitFor(() => {
+      frame = container.querySelector('iframe')
+      expect(frame).toBeDefined()
+      expect(frame).toHaveAttribute('srcdoc', rawHtml)
+    })
+    // Verify that no alert is shown since the content is trusted
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('Sanitizes the HTML if the creator is NOT on the trusted team', async () => {
+    // Use a user ID NOT on the trusted team
+    const idOfUserNotOnTrustedTeam = MOCK_USER_ID_2.toString()
+    const rawHtml = "<script>alert('hello')</script>"
+    const fileHandle = {
+      createdBy: idOfUserNotOnTrustedTeam,
+    }
+    const { container } = renderComponent({
+      rawHtml,
+      fileHandle,
+    })
+
+    let frame: HTMLIFrameElement | null = null
+    await waitFor(() => {
+      frame = container.querySelector('iframe')
+      expect(frame).toBeDefined()
+      // The HTML is sanitized, so the script tag is removed
+      expect(frame).toHaveAttribute('srcdoc', '')
+    })
+
+    // An alert should be shown to open the unsanitized content in a new window
+    const alert = await screen.findByRole('alert')
+    const openInNewWindowLink = within(alert).getByText(
+      'External view available.',
+    )
+
+    // Mock the window.open function to validate that we pass unsanitized HTML
+    const mockDocumentWrite = jest.fn()
+    const mockDocumentClose = jest.fn()
+    jest.spyOn(window, 'open').mockImplementation(() => ({
+      document: { write: mockDocumentWrite, close: mockDocumentClose },
+    }))
+
+    await userEvent.click(openInNewWindowLink)
+    const modalConfirmation = await screen.findByRole('dialog')
+    await userEvent.click(
+      within(modalConfirmation).getByRole('button', { name: 'OK' }),
+    )
+
+    await waitFor(() => {
+      expect(window.open).toHaveBeenCalled()
+      // Unsanitized HTML passed to new window
+      expect(mockDocumentWrite).toHaveBeenCalledWith(rawHtml)
+      expect(mockDocumentClose).toHaveBeenCalled()
+    })
+  })
+
+  it('Shows no alert if sanitized HTML is identical to unsanitized HTML', async () => {
+    // Use a user ID NOT on the trusted team
+    const idOfUserNotOnTrustedTeam = MOCK_USER_ID_2.toString()
+    const rawHtml = '<span>no restricted content here</span>'
+    const fileHandle = {
+      createdBy: idOfUserNotOnTrustedTeam,
+    }
+    const { container } = renderComponent({
+      rawHtml,
+      fileHandle,
+    })
+
+    let frame: HTMLIFrameElement | null = null
+    await waitFor(() => {
+      frame = container.querySelector('iframe')
+      expect(frame).toBeDefined()
+      // The HTML should be identical since it doesn't contain anything that would be stripped by sanitization
+      expect(frame).toHaveAttribute('srcdoc', rawHtml)
+    })
+
+    // Verify that no alert is shown since the content was unchanged by sanitization
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/src/lib/containers/FilePreview/HtmlPreview/HtmlPreview.tsx
+++ b/src/lib/containers/FilePreview/HtmlPreview/HtmlPreview.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo } from 'react'
+import xss from 'xss'
+import { xssOptions } from '../../../utils/functions/SanitizeHtmlUtils'
+import { useGetTeamMembers } from '../../../utils/hooks/SynapseAPI/team/useTeamMembers'
+import { TRUSTED_HTML_USERS_TEAM_ID } from '../../../utils/SynapseConstants'
+import { FileHandle } from '../../../utils/synapseTypes'
+import { SynapseSpinner } from '../../LoadingScreen'
+import { SanitizedWarning } from './SanitizedWarning'
+
+/**
+ * @param options
+ * @returns HTML that is cleaned if it is not trusted. undefined if `isLoading` is true.
+ */
+function useCleanHtml(options: {
+  rawHtml: string
+  isLoading: boolean
+  isTrusted: boolean
+}): string | undefined {
+  const { rawHtml, isLoading, isTrusted } = options
+  return useMemo(() => {
+    if (isLoading) {
+      return undefined
+    }
+    if (isTrusted) {
+      return rawHtml
+    } else {
+      return xss(rawHtml, xssOptions)
+    }
+  }, [isLoading, isTrusted, rawHtml])
+}
+
+export type HtmlPreviewProps = {
+  fileHandle: FileHandle
+  rawHtml: string
+}
+
+/**
+ * Renders raw HTML. Uses file handle data to determine if the content should be sanitized.
+ * @param props
+ * @returns
+ */
+export default function HtmlPreview(props: HtmlPreviewProps) {
+  const { fileHandle, rawHtml } = props
+  const { data: trustedHtmlUsersData, isLoading } = useGetTeamMembers(
+    TRUSTED_HTML_USERS_TEAM_ID,
+  )
+
+  const trustedHtmlUserIds = (trustedHtmlUsersData?.results ?? []).map(
+    member => member.member.ownerId,
+  )
+
+  const htmlIsCreatedByTrustedUser = trustedHtmlUserIds.includes(
+    fileHandle.createdBy,
+  )
+
+  const cleanHtml = useCleanHtml({
+    rawHtml,
+    isLoading,
+    isTrusted: htmlIsCreatedByTrustedUser,
+  })
+
+  if (isLoading) {
+    return <SynapseSpinner />
+  }
+
+  return (
+    <>
+      {rawHtml !== cleanHtml && <SanitizedWarning rawHtml={rawHtml} />}
+      <iframe srcDoc={cleanHtml} style={{ border: 0, width: '100%' }} />
+    </>
+  )
+}
+
+export const EXPORTED_FOR_UNIT_TESTING = {
+  useCleanHtml,
+}

--- a/src/lib/containers/FilePreview/HtmlPreview/HtmlPreview.tsx
+++ b/src/lib/containers/FilePreview/HtmlPreview/HtmlPreview.tsx
@@ -1,9 +1,8 @@
 import React, { useMemo } from 'react'
 import xss from 'xss'
 import { xssOptions } from '../../../utils/functions/SanitizeHtmlUtils'
-import { useGetTeamMembers } from '../../../utils/hooks/SynapseAPI/team/useTeamMembers'
+import { useGetIsUserMemberOfTeam } from '../../../utils/hooks/SynapseAPI/team/useTeamMembers'
 import { TRUSTED_HTML_USERS_TEAM_ID } from '../../../utils/SynapseConstants'
-import { FileHandle } from '../../../utils/synapseTypes'
 import { SynapseSpinner } from '../../LoadingScreen'
 import { SanitizedWarning } from './SanitizedWarning'
 
@@ -30,7 +29,7 @@ function useCleanHtml(options: {
 }
 
 export type HtmlPreviewProps = {
-  fileHandle: FileHandle
+  createdByUserId: string
   rawHtml: string
 }
 
@@ -40,18 +39,14 @@ export type HtmlPreviewProps = {
  * @returns
  */
 export default function HtmlPreview(props: HtmlPreviewProps) {
-  const { fileHandle, rawHtml } = props
-  const { data: trustedHtmlUsersData, isLoading } = useGetTeamMembers(
+  const { createdByUserId, rawHtml } = props
+
+  const { data: teamMembership, isLoading } = useGetIsUserMemberOfTeam(
     TRUSTED_HTML_USERS_TEAM_ID,
+    createdByUserId,
   )
 
-  const trustedHtmlUserIds = (trustedHtmlUsersData?.results ?? []).map(
-    member => member.member.ownerId,
-  )
-
-  const htmlIsCreatedByTrustedUser = trustedHtmlUserIds.includes(
-    fileHandle.createdBy,
-  )
+  const htmlIsCreatedByTrustedUser = !!teamMembership
 
   const cleanHtml = useCleanHtml({
     rawHtml,

--- a/src/lib/containers/FilePreview/HtmlPreview/SanitizedWarning.tsx
+++ b/src/lib/containers/FilePreview/HtmlPreview/SanitizedWarning.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react'
+import { Alert } from 'react-bootstrap'
+import WarningModal from '../../synapse_form_wrapper/WarningModal'
+
+export type SanitizedWarningProps = {
+  rawHtml: string
+}
+
+function openRawHtmlInNewWindow(rawHtml: string) {
+  const newWindow = window.open('', '')
+  newWindow?.document.write(rawHtml)
+  // close document, to run scripts inside html string
+  newWindow?.document.close()
+}
+
+export function SanitizedWarning(props: SanitizedWarningProps) {
+  const { rawHtml } = props
+  const [showModal, setShowModal] = useState(false)
+
+  return (
+    <>
+      <WarningModal
+        title={'Open Untrusted Content in New Window?'}
+        modalBody={
+          'Click "OK" to leave this page and open this content in a new window; this enables additional functionality, but should only be done if you trust the content.'
+        }
+        show={showModal}
+        confirmButtonText={'OK'}
+        confirmButtonVariant={'sds-primary'}
+        onConfirm={() => {
+          openRawHtmlInNewWindow(rawHtml)
+          setShowModal(false)
+        }}
+        onCancel={() => setShowModal(false)}
+      />
+      <Alert variant="info" dismissible={false} show={true} transition={false}>
+        Limited rendering only.{' '}
+        <a onClick={() => setShowModal(true)}>External view available.</a>
+      </Alert>
+    </>
+  )
+}

--- a/src/lib/umd.index.ts
+++ b/src/lib/umd.index.ts
@@ -53,6 +53,7 @@ import {
 
 // Also include scss in the bundle
 import './style/main.scss'
+import HtmlPreview from './containers/FilePreview/HtmlPreview/HtmlPreview'
 
 const SynapseContext = {
   SynapseContextProvider,
@@ -107,6 +108,7 @@ const SynapseComponents = {
   TrashCanList,
   OAuthManagement,
   CertificationQuiz,
+  HtmlPreview,
 }
 
 // Include the version in the build

--- a/src/lib/utils/APIConstants.ts
+++ b/src/lib/utils/APIConstants.ts
@@ -124,3 +124,6 @@ export const TRASHCAN = `${REPO}/trashcan`
 export const TRASHCAN_VIEW = `${TRASHCAN}/view`
 export const TRASHCAN_RESTORE = (id: string) => `${TRASHCAN}/restore/${id}`
 export const TRASHCAN_PURGE = (id: string) => `${TRASHCAN}/purge/${id}`
+
+export const TEAM_MEMBERS = (teamId: string | number) =>
+  `${REPO}/teamMembers/${teamId}`

--- a/src/lib/utils/APIConstants.ts
+++ b/src/lib/utils/APIConstants.ts
@@ -125,8 +125,13 @@ export const TRASHCAN_VIEW = `${TRASHCAN}/view`
 export const TRASHCAN_RESTORE = (id: string) => `${TRASHCAN}/restore/${id}`
 export const TRASHCAN_PURGE = (id: string) => `${TRASHCAN}/purge/${id}`
 
+export const TEAM = (teamId: string | number) => `${REPO}/team/${teamId}`
+export const TEAM_ID_MEMBER_ID = (
+  teamId: string | number,
+  memberId: string | number,
+) => TEAM(teamId) + `/member/${memberId}`
 export const TEAM_MEMBERS = (teamId: string | number) =>
   `${REPO}/teamMembers/${teamId}`
-  
+
 export const FORUM = `${REPO}/forum`
 export const FORUM_THREAD = (id: string) => `${FORUM}/${id}/threads`

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -36,6 +36,7 @@ import {
   SIGN_TERMS_OF_USE,
   TABLE_QUERY_ASYNC_GET,
   TABLE_QUERY_ASYNC_START,
+  TEAM_MEMBERS,
   TRASHCAN_PURGE,
   TRASHCAN_RESTORE,
   TRASHCAN_VIEW,
@@ -1224,7 +1225,7 @@ export const getTeamMembers = (
   limit: number = 10,
   offset: number = 0,
 ): Promise<PaginatedResults<TeamMember>> => {
-  const url = `/repo/v1/teamMembers/${teamId}?limit=${limit}&offset=${offset}${
+  const url = `${TEAM_MEMBERS(teamId)}?limit=${limit}&offset=${offset}${
     fragment ? `&fragment=${fragment}` : ''
   }`
   return doGet(url, accessToken, BackendDestinationEnum.REPO_ENDPOINT)
@@ -1776,11 +1777,14 @@ export const getFileHandleContentFromID = (
 export const getFileHandleContent = (
   fileHandle: FileHandle,
   presignedUrl: string,
+  maxFileSizeBytes?: number,
 ): Promise<string> => {
   // get the presigned URL, download the data, and send that back (via resolve())
   return new Promise((resolve, reject) => {
-    // sanity check!  must be less than 5MB
-    if (fileHandle.contentSize < MAX_JS_FILE_DOWNLOAD_SIZE) {
+    // sanity check!  must be less than 5MB (unless overridden)
+    if (
+      fileHandle.contentSize < (maxFileSizeBytes ?? MAX_JS_FILE_DOWNLOAD_SIZE)
+    ) {
       fetch(presignedUrl, {
         method: 'GET',
         mode: 'cors',

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -1780,14 +1780,11 @@ export const getFileHandleContentFromID = (
 export const getFileHandleContent = (
   fileHandle: FileHandle,
   presignedUrl: string,
-  maxFileSizeBytes?: number,
 ): Promise<string> => {
   // get the presigned URL, download the data, and send that back (via resolve())
   return new Promise((resolve, reject) => {
-    // sanity check!  must be less than 5MB (unless overridden)
-    if (
-      fileHandle.contentSize < (maxFileSizeBytes ?? MAX_JS_FILE_DOWNLOAD_SIZE)
-    ) {
+    // sanity check!  must be less than 5MB
+    if (fileHandle.contentSize < MAX_JS_FILE_DOWNLOAD_SIZE) {
       fetch(presignedUrl, {
         method: 'GET',
         mode: 'cors',

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -37,6 +37,7 @@ import {
   SIGN_TERMS_OF_USE,
   TABLE_QUERY_ASYNC_GET,
   TABLE_QUERY_ASYNC_START,
+  TEAM_ID_MEMBER_ID,
   TEAM_MEMBERS,
   TRASHCAN_PURGE,
   TRASHCAN_RESTORE,
@@ -349,7 +350,11 @@ const fetchWithExponentialTimeout = async <TResponse>(
 
   if (response.ok) {
     return responseObject as TResponse
-  } else if (typeof responseObject === 'object' && 'reason' in responseObject) {
+  } else if (
+    responseObject !== null &&
+    typeof responseObject === 'object' &&
+    'reason' in responseObject
+  ) {
     throw new SynapseClientError(
       response.status,
       responseObject.reason,
@@ -1232,6 +1237,22 @@ export const getTeamMembers = (
     fragment ? `&fragment=${fragment}` : ''
   }`
   return doGet(url, accessToken, BackendDestinationEnum.REPO_ENDPOINT)
+}
+
+/**
+ * Checks if a user is a member of a specific team.
+ *
+ * @returns a TeamMember if the user is a member of the team, or null if the user is not.
+ */
+export const getIsUserMemberOfTeam = (
+  teamId: string,
+  userId: string,
+  accessToken?: string,
+): Promise<TeamMember | null> => {
+  const url = TEAM_ID_MEMBER_ID(teamId, userId)
+  return allowNotFoundError(() =>
+    doGet<TeamMember>(url, accessToken, BackendDestinationEnum.REPO_ENDPOINT),
+  )
 }
 
 /**

--- a/src/lib/utils/SynapseConstants.ts
+++ b/src/lib/utils/SynapseConstants.ts
@@ -10,7 +10,7 @@ export const ANONYMOUS_PRINCIPAL_ID = 273950
 /** The Synapse Access and Compliance team */
 export const ACT_TEAM_ID = 464532
 /** The team containing Synapse users whose HTML files may be rendered without sanitization */
-export const TRUSTED_HTML_USERS_TEAM_ID = 3351236
+export const TRUSTED_HTML_USERS_TEAM_ID = '3351236'
 
 /** QueryBundleRequest constants */
 export const BUNDLE_MASK_QUERY_RESULTS: number = 1

--- a/src/lib/utils/SynapseConstants.ts
+++ b/src/lib/utils/SynapseConstants.ts
@@ -9,6 +9,8 @@ export const PUBLIC_PRINCIPAL_ID = 273949
 export const ANONYMOUS_PRINCIPAL_ID = 273950
 /** The Synapse Access and Compliance team */
 export const ACT_TEAM_ID = 464532
+/** The team containing Synapse users whose HTML files may be rendered without sanitization */
+export const TRUSTED_HTML_USERS_TEAM_ID = 3351236
 
 /** QueryBundleRequest constants */
 export const BUNDLE_MASK_QUERY_RESULTS: number = 1
@@ -118,3 +120,9 @@ export const ENTITY_HEADER_STORAGE_KEY = 'INFO_FROM_IDS_ENTITY_HEADER'
 
 export const DATETIME_UTC_COOKIE_KEY =
   'org.sagebionetworks.synapse.datetime.utc'
+
+export const BASE = 1024,
+  KB = BASE,
+  MB = KB * BASE,
+  GB = MB * BASE,
+  TB = GB * BASE

--- a/src/lib/utils/hooks/SynapseAPI/team/useTeamMembers.ts
+++ b/src/lib/utils/hooks/SynapseAPI/team/useTeamMembers.ts
@@ -1,0 +1,19 @@
+import { useQuery, UseQueryOptions } from 'react-query'
+import { SynapseClient } from '../../..'
+import { SynapseClientError } from '../../../SynapseClientError'
+import { useSynapseContext } from '../../../SynapseContext'
+import { PaginatedResults } from '../../../synapseTypes'
+import { TeamMember } from '../../../synapseTypes/TeamMember'
+
+export function useGetTeamMembers(
+  teamId: string | number,
+  options?: UseQueryOptions<PaginatedResults<TeamMember>, SynapseClientError>,
+) {
+  const { accessToken } = useSynapseContext()
+
+  return useQuery<PaginatedResults<TeamMember>, SynapseClientError>(
+    ['teamMembers', teamId],
+    () => SynapseClient.getTeamMembers(accessToken, teamId, '', 50, 0),
+    options,
+  )
+}

--- a/src/lib/utils/hooks/SynapseAPI/team/useTeamMembers.ts
+++ b/src/lib/utils/hooks/SynapseAPI/team/useTeamMembers.ts
@@ -12,8 +12,22 @@ export function useGetTeamMembers(
   const { accessToken } = useSynapseContext()
 
   return useQuery<PaginatedResults<TeamMember>, SynapseClientError>(
-    ['teamMembers', teamId],
+    ['team', teamId, 'membersList'],
     () => SynapseClient.getTeamMembers(accessToken, teamId, '', 50, 0),
+    options,
+  )
+}
+
+export function useGetIsUserMemberOfTeam(
+  teamId: string,
+  userId: string,
+  options?: UseQueryOptions<TeamMember | null, SynapseClientError>,
+) {
+  const { accessToken } = useSynapseContext()
+
+  return useQuery<TeamMember | null, SynapseClientError>(
+    ['team', teamId, 'member', userId],
+    () => SynapseClient.getIsUserMemberOfTeam(teamId, userId, accessToken),
     options,
   )
 }


### PR DESCRIPTION
Adds HtmlPreview component
- Given raw HTML and a file handle, renders the raw HTML (if the user is on the trusted team) or renders sanitized HTML.
- If the rendered HTML is different than the raw HTML, the user can open the untrusted content in a new window.


- Component has not yet been exposed via MarkdownSynapse - this PR does not include: 
  - Parsing the `preview` widget descriptor
  - Fetching the file referenced by the preview descriptor
  - Asking the user to log in if they can't download the referenced file as Anonymous
  - Determining how to preview the file (e.g. download the file contents or a preview file handle?)
  - Downloading the file handle contents.


![image](https://user-images.githubusercontent.com/17580037/193597569-ecb033a6-31b3-43b3-9a1f-dec33690c363.png)
