### PR TITLE
PORTALS-2316: Add FileHandleContentRenderer

### DIFF
--- a/src/__tests__/lib/containers/markdown/FilePreview/FileHandleContentRenderer.test.tsx
+++ b/src/__tests__/lib/containers/markdown/FilePreview/FileHandleContentRenderer.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import React from 'react'
+import FileHandleContentRenderer, {
+  FileHandleContentRendererProps,
+} from '../../../../../lib/containers/FilePreview/FileHandleContentRenderer'
+import * as HtmlPreviewModule from '../../../../../lib/containers/FilePreview/HtmlPreview/HtmlPreview'
+import { PreviewRendererType } from '../../../../../lib/containers/FilePreview/PreviewRendererType'
+import { createWrapper } from '../../../../../lib/testutils/TestingLibraryUtils'
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '../../../../../lib/utils/functions/getEndpoint'
+import { MB } from '../../../../../lib/utils/SynapseConstants'
+import {
+  BatchFileResult,
+  FileHandle,
+  FileHandleAssociateType,
+  FileHandleAssociation,
+} from '../../../../../lib/utils/synapseTypes'
+import mockFileEntityData from '../../../../../mocks/entity/mockFileEntity'
+import { MOCK_FILE_HANDLE_ID } from '../../../../../mocks/mock_file_handle'
+import { rest, server } from '../../../../../mocks/msw/server'
+
+jest.spyOn(HtmlPreviewModule, 'default').mockImplementation(() => {
+  return <div data-testid="HtmlPreview"></div>
+})
+
+function renderComponent(props: FileHandleContentRendererProps) {
+  return render(<FileHandleContentRenderer {...props} />, {
+    wrapper: createWrapper({
+      // Need to wrap in an error boundary
+      withErrorBoundary: true,
+      isInExperimentalMode: false,
+      utcTime: false,
+      downloadCartPageUrl: '/#!DownloadCart:0',
+    }),
+  })
+}
+
+const PRESIGNED_URL = 'https://fake-presigned-url.not-real.gov/file'
+
+describe('FileHandleContentRenderer tests', () => {
+  beforeAll(() => server.listen())
+  beforeEach(() => {
+    server.use(
+      // Handler to return the presigned URL for the requested file
+      rest.post(
+        `${getEndpoint(
+          BackendDestinationEnum.REPO_ENDPOINT,
+        )}/file/v1/fileHandle/batch`,
+        (req, res, ctx) => {
+          const result: BatchFileResult = {
+            requestedFiles: [
+              {
+                fileHandleId: MOCK_FILE_HANDLE_ID,
+                preSignedURL: PRESIGNED_URL,
+              },
+            ],
+          }
+          return res(ctx.status(200), ctx.json(result))
+        },
+      ),
+      // Handler for the presigned URL to return the file contents
+      rest.get(PRESIGNED_URL, (req, res, ctx) => {
+        return res(ctx.status(200), ctx.text('file contents here'))
+      }),
+    )
+  })
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  it('Will render HTML content', async () => {
+    const fileHandle: FileHandle = {
+      id: MOCK_FILE_HANDLE_ID,
+      fileName: 'test.html',
+      contentSize: 100,
+      contentType: 'text/html',
+      etag: '',
+      createdBy: '',
+      createdOn: '',
+      concreteType: 'org.sagebionetworks.repo.model.file.S3FileHandle',
+      storageLocationId: 0,
+    }
+    const fileHandleAssociation: FileHandleAssociation = {
+      fileHandleId: fileHandle.id,
+      associateObjectId: mockFileEntityData.id,
+      associateObjectType: FileHandleAssociateType.FileEntity,
+    }
+    renderComponent({
+      fileHandle,
+      fileHandleAssociation,
+      previewType: PreviewRendererType.HTML,
+    })
+
+    await screen.findByTestId('HtmlPreview')
+  })
+  it('Throws an error if the file content size is > 10MB', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    const fileSize = 100 * MB
+    const fileHandle: FileHandle = {
+      id: MOCK_FILE_HANDLE_ID,
+      fileName: 'test.html',
+      contentSize: fileSize,
+      contentType: 'text/html',
+      etag: '',
+      createdBy: '',
+      createdOn: '',
+      concreteType: 'org.sagebionetworks.repo.model.file.S3FileHandle',
+      storageLocationId: 0,
+    }
+    const fileHandleAssociation: FileHandleAssociation = {
+      fileHandleId: fileHandle.id,
+      associateObjectId: mockFileEntityData.id,
+      associateObjectType: FileHandleAssociateType.FileEntity,
+    }
+
+    renderComponent({
+      fileHandle,
+      fileHandleAssociation,
+      previewType: PreviewRendererType.HTML,
+    })
+    const errorBoundary = await screen.findByRole('alert')
+    await within(errorBoundary).findByText(
+      /File size \(100.00 MB\) exceeds the maximum size that can be downloaded \(10.00 MB\)/,
+    )
+  })
+
+  it('Renders nothing if the preview type is NONE', async () => {
+    const fileHandle: FileHandle = {
+      id: MOCK_FILE_HANDLE_ID,
+      fileName: 'test.html',
+      contentSize: 100,
+      contentType: 'text/html',
+      etag: '',
+      createdBy: '',
+      createdOn: '',
+      concreteType: 'org.sagebionetworks.repo.model.file.S3FileHandle',
+      storageLocationId: 0,
+    }
+    const fileHandleAssociation: FileHandleAssociation = {
+      fileHandleId: fileHandle.id,
+      associateObjectId: mockFileEntityData.id,
+      associateObjectType: FileHandleAssociateType.FileEntity,
+    }
+
+    const { container } = renderComponent({
+      fileHandle,
+      fileHandleAssociation,
+      previewType: PreviewRendererType.NONE, // !
+    })
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+  it('Renders nothing for unsupported render types', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const fileHandle: FileHandle = {
+      id: MOCK_FILE_HANDLE_ID,
+      fileName: 'test.html',
+      contentSize: 100,
+      contentType: 'text/html',
+      etag: '',
+      createdBy: '',
+      createdOn: '',
+      concreteType: 'org.sagebionetworks.repo.model.file.S3FileHandle',
+      storageLocationId: 0,
+    }
+    const fileHandleAssociation: FileHandleAssociation = {
+      fileHandleId: fileHandle.id,
+      associateObjectId: mockFileEntityData.id,
+      associateObjectType: FileHandleAssociateType.FileEntity,
+    }
+
+    const { container } = renderComponent({
+      fileHandle,
+      fileHandleAssociation,
+      previewType: PreviewRendererType.IMAGE, // !
+    })
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement()
+    })
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'Rendering a preview of type IMAGE is not supported in Portals',
+    )
+  })
+})

--- a/src/__tests__/lib/containers/markdown/FilePreview/HtmlPreview/HtmlPreview.test.tsx
+++ b/src/__tests__/lib/containers/markdown/FilePreview/HtmlPreview/HtmlPreview.test.tsx
@@ -10,21 +10,21 @@ import React from 'react'
 import HtmlPreview, {
   EXPORTED_FOR_UNIT_TESTING,
   HtmlPreviewProps,
-} from '../../../../../lib/containers/FilePreview/HtmlPreview/HtmlPreview'
-import { createWrapper } from '../../../../../lib/testutils/TestingLibraryUtils'
-import { TEAM_ID_MEMBER_ID } from '../../../../../lib/utils/APIConstants'
+} from '../../../../../../lib/containers/FilePreview/HtmlPreview/HtmlPreview'
+import { createWrapper } from '../../../../../../lib/testutils/TestingLibraryUtils'
+import { TEAM_ID_MEMBER_ID } from '../../../../../../lib/utils/APIConstants'
 import {
   BackendDestinationEnum,
   getEndpoint,
-} from '../../../../../lib/utils/functions/getEndpoint'
-import { TRUSTED_HTML_USERS_TEAM_ID } from '../../../../../lib/utils/SynapseConstants'
-import { TeamMember } from '../../../../../lib/utils/synapseTypes/TeamMember'
-import { rest, server } from '../../../../../mocks/msw/server'
+} from '../../../../../../lib/utils/functions/getEndpoint'
+import { TRUSTED_HTML_USERS_TEAM_ID } from '../../../../../../lib/utils/SynapseConstants'
+import { TeamMember } from '../../../../../../lib/utils/synapseTypes/TeamMember'
+import { rest, server } from '../../../../../../mocks/msw/server'
 import {
   MOCK_USER_ID,
   MOCK_USER_ID_2,
   MOCK_USER_NAME,
-} from '../../../../../mocks/user/mock_user_profile'
+} from '../../../../../../mocks/user/mock_user_profile'
 
 function renderComponent(props: HtmlPreviewProps) {
   return render(<HtmlPreview {...props} />, { wrapper: createWrapper() })

--- a/src/lib/containers/ErrorBanner.tsx
+++ b/src/lib/containers/ErrorBanner.tsx
@@ -31,20 +31,17 @@ export const ClientError = (props: { error: SynapseClientError }) => {
     issuePriority: '3',
   })
 
-  return (
-    <>
-      {loginError && (
-        <>
-          Please <SignInButton /> to view this resource.
-        </>
-      )}
-      {accessDenied && <>You are not authorized to access this resource.</>}
-      {
-        // if we don't have a friendly error message then show the error
-        !accessDenied && !loginError && <>{error.reason}</>
-      }
-    </>
-  )
+  if (loginError) {
+    return (
+      <>
+        Please <SignInButton /> to view this resource.
+      </>
+    )
+  } else if (accessDenied) {
+    return <>You are not authorized to access this resource.</>
+  } else {
+    return <>{error.reason}</>
+  }
 }
 
 export const ErrorBanner = (props: ErrorBannerProps) => {
@@ -92,7 +89,7 @@ export const ErrorFallbackComponent: React.FunctionComponent<FallbackProps> = ({
   resetErrorBoundary,
 }) => {
   return (
-    <div role="alert" className="bootstrap-4-backport SRC-marginBottomTop">
+    <div className="bootstrap-4-backport SRC-marginBottomTop">
       <ErrorBanner
         error={error}
         reloadButtonFn={resetErrorBoundary}

--- a/src/lib/containers/FilePreview/FileHandleContentRenderer.tsx
+++ b/src/lib/containers/FilePreview/FileHandleContentRenderer.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { useGetPresignedUrlContent } from '../../utils/hooks/SynapseAPI/file/useFiles'
+import { MB } from '../../utils/SynapseConstants'
+import {
+  FileHandle,
+  FileHandleAssociation,
+  BatchFileRequest,
+} from '../../utils/synapseTypes'
+import { SynapseSpinner } from '../LoadingScreen'
+import HtmlPreview from './HtmlPreview/HtmlPreview'
+import { PreviewRendererType } from './PreviewRendererType'
+
+const MAX_FILE_SIZE = 10 * MB
+
+export type FileHandleContentRendererProps = {
+  /** The file handle whose contents should be downloaded and rendered */
+  fileHandle: FileHandle
+  /** The association between the file handle and an object which will give the user permission to access the file data */
+  fileHandleAssociation: FileHandleAssociation
+  /** Informs how to render the file data */
+  previewType: PreviewRendererType
+}
+
+/**
+ * Fetches the content for and renders the contents of a file handle.
+ * @param props
+ * @returns
+ */
+export default function FileHandleContentRenderer(
+  props: FileHandleContentRendererProps,
+) {
+  const { fileHandle, fileHandleAssociation, previewType } = props
+
+  const batchFileRequest: BatchFileRequest = {
+    requestedFiles: [fileHandleAssociation],
+    includePreSignedURLs: true,
+    includeFileHandles: false,
+    includePreviewPreSignedURLs: false,
+  }
+
+  const { data: content, isLoading } = useGetPresignedUrlContent(
+    fileHandle,
+    batchFileRequest,
+    MAX_FILE_SIZE,
+    { useErrorBoundary: true },
+  )
+
+  if (isLoading) {
+    return <SynapseSpinner />
+  }
+  if (previewType === PreviewRendererType.HTML) {
+    return <HtmlPreview fileHandle={fileHandle} rawHtml={content!} />
+  } else {
+    if (previewType !== PreviewRendererType.NONE) {
+      console.warn(
+        `Rendering a preview of type ${previewType} is not supported in Portals`,
+      )
+    }
+    return <></>
+  }
+}

--- a/src/lib/containers/FilePreview/PreviewRendererType.ts
+++ b/src/lib/containers/FilePreview/PreviewRendererType.ts
@@ -1,0 +1,22 @@
+// Note: The PreviewRendererType is copied from SWC's PreviewWidget.PreviewFileType
+// Not all of these are supported by SRC, but we do need to support all of them for preview widget feature parity
+
+/**
+ * Types of files that can be previewed. The PreviewFileType of a file handle can be determined based on its MIME type.
+ * Each value corresponds to a particular renderer.
+ */
+export enum PreviewRendererType {
+  PLAINTEXT = 'PLAINTEXT',
+  CODE = 'CODE',
+  ZIP = 'ZIP',
+  CSV = 'CSV',
+  IMAGE = 'IMAGE',
+  NONE = 'NONE',
+  TAB = 'TAB',
+  HTML = 'HTML',
+  PDF = 'PDF',
+  IPYNB = 'IPYNB',
+  VIDEO = 'VIDEO',
+  MARKDOWN = 'MARKDOWN',
+  TIFF = 'TIFF',
+}

--- a/src/lib/utils/hooks/SynapseAPI/file/useFiles.ts
+++ b/src/lib/utils/hooks/SynapseAPI/file/useFiles.ts
@@ -1,0 +1,34 @@
+import { UseQueryOptions, useQuery } from 'react-query'
+import { SynapseClient } from '../../..'
+import { SynapseClientError } from '../../../SynapseClientError'
+import { useSynapseContext } from '../../../SynapseContext'
+import { BatchFileRequest, FileHandle } from '../../../synapseTypes'
+
+export function useGetPresignedUrlContent(
+  fileHandle: FileHandle,
+  request: BatchFileRequest,
+  maxFileSizeBytes?: number,
+  options?: Omit<UseQueryOptions<string, SynapseClientError>, 'staleTime'>,
+) {
+  if (request.requestedFiles.length !== 1) {
+    console.warn('useGetPresignedUrlContent only supports one file at a time')
+  }
+  const { accessToken } = useSynapseContext()
+  const queryFn = async () => {
+    const batchFileResult = await SynapseClient.getFiles(request, accessToken)
+    const data = await SynapseClient.getFileHandleContent(
+      fileHandle,
+      batchFileResult.requestedFiles[0].preSignedURL!,
+      maxFileSizeBytes,
+    )
+    return data
+  }
+  return useQuery<string, SynapseClientError>(
+    ['presignedUrlContent', fileHandle, request],
+    queryFn,
+    {
+      staleTime: Infinity,
+      ...options,
+    },
+  )
+}


### PR DESCRIPTION
Simply renders the contents of a file handle based on the predetermined type of preview shown.

 The next PR will include a component that will determine which file handle to render for a particular entity.