### PR TITLE
PORTALS-2316: Add EntityPreview and register it with Markdown processor

### DIFF
--- a/src/__tests__/lib/containers/markdown/FilePreview/EntityPreview.test.tsx
+++ b/src/__tests__/lib/containers/markdown/FilePreview/EntityPreview.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, within } from '@testing-library/react'
+import React from 'react'
+import * as FileEntityPreviewModule from '../../../../../lib/containers/FilePreview/FileEntityPreview'
+import { createWrapper } from '../../../../../lib/testutils/TestingLibraryUtils'
+import mockFileEntityData from '../../../../../mocks/entity/mockFileEntity'
+import { server } from '../../../../../mocks/msw/server'
+import mockDatasetData from '../../../../../mocks/entity/mockDataset'
+import { SynapseContextType } from '../../../../../lib/utils/SynapseContext'
+import { MOCK_CONTEXT_VALUE } from '../../../../../mocks/MockSynapseContext'
+import EntityPreview, {
+  EntityPreviewProps,
+} from '../../../../../lib/containers/FilePreview/EntityPreview'
+
+jest.spyOn(FileEntityPreviewModule, 'default').mockImplementation(() => {
+  return <div data-testid="FileEntityPreview"></div>
+})
+
+const defaultWrapperProps: SynapseContextType = {
+  ...MOCK_CONTEXT_VALUE,
+  // Component is always wrapped in an error boundary
+  withErrorBoundary: true,
+}
+
+function renderComponent(
+  props: EntityPreviewProps,
+  wrapperProps: SynapseContextType = defaultWrapperProps,
+) {
+  return render(<EntityPreview {...props} />, {
+    wrapper: createWrapper(wrapperProps),
+  })
+}
+
+describe('EntityPreview tests', () => {
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  it('Passes a file entity bundle to the FileEntityPreview component', async () => {
+    renderComponent({
+      entityId: mockFileEntityData.id,
+    })
+
+    await screen.findByTestId('FileEntityPreview')
+
+    expect(FileEntityPreviewModule.default).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bundle: expect.anything(),
+      }),
+      expect.anything(),
+    )
+  })
+
+  it('Throws an error if the entity is not a FileEntity', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    renderComponent({
+      entityId: mockDatasetData.id,
+    })
+    const errorBoundary = await screen.findByRole('alert')
+    await within(errorBoundary).findByText(
+      /syn\d+ is not a File and cannot be previewed/,
+    )
+  })
+})

--- a/src/__tests__/lib/utils/functions/ResolveLinkEntity.test.ts
+++ b/src/__tests__/lib/utils/functions/ResolveLinkEntity.test.ts
@@ -1,0 +1,96 @@
+import { SynapseClient } from '../../../../lib'
+import { resolveLinkEntity } from '../../../../lib/utils/functions/ResolveLinkEntity'
+
+describe('ResolveLinkEntity tests', () => {
+  const fileEntity = {
+    id: 'syn123',
+    name: 'File Entity',
+    concreteType: 'org.sagebionetworks.repo.model.FileEntity',
+  }
+  const linksToFileEntity = {
+    id: 'syn124',
+    name: 'Link 1',
+    concreteType: 'org.sagebionetworks.repo.model.Link',
+    linksTo: {
+      targetId: fileEntity.id,
+    },
+  }
+
+  const linksToLinkToFileEntity = {
+    id: 'syn125',
+    name: 'Link 2',
+    concreteType: 'org.sagebionetworks.repo.model.Link',
+    linksTo: {
+      targetId: linksToFileEntity.id,
+    },
+  }
+
+  const linkCycleAId = 'syn126'
+  const linkCycleBId = 'syn127'
+  const linkCycleA = {
+    id: linkCycleAId,
+    name: 'Link Cycle A',
+    concreteType: 'org.sagebionetworks.repo.model.Link',
+    linksTo: {
+      targetId: linkCycleBId,
+    },
+  }
+
+  const linkCycleB = {
+    id: linkCycleBId,
+    name: 'Link Cycle B',
+    concreteType: 'org.sagebionetworks.repo.model.Link',
+    linksTo: {
+      targetId: linkCycleAId,
+    },
+  }
+
+  const selfLinkId = 'syn128'
+  const linksToSelf = {
+    id: selfLinkId,
+    name: 'Links to Self',
+    concreteType: 'org.sagebionetworks.repo.model.Link',
+    linksTo: {
+      targetId: selfLinkId,
+    },
+  }
+
+  beforeAll(() => {
+    jest.spyOn(SynapseClient, 'getEntity').mockImplementation((_token, id) => {
+      const entities = [
+        fileEntity,
+        linksToFileEntity,
+        linksToLinkToFileEntity,
+        linkCycleA,
+        linkCycleB,
+        linksToSelf,
+      ]
+      return Promise.resolve(entities.find(entity => entity.id === id))
+    })
+  })
+  it('Resolves a non-link', async () => {
+    const actual = await resolveLinkEntity(fileEntity.id!)
+    expect(actual).toEqual(fileEntity)
+  })
+  it('Resolves a link to a non-link', async () => {
+    const actual = await resolveLinkEntity(linksToFileEntity.id!)
+    expect(actual).toEqual(fileEntity)
+  })
+
+  it('Handles a chain of links', async () => {
+    const actual = await resolveLinkEntity(linksToLinkToFileEntity.id!)
+    expect(actual).toEqual(fileEntity)
+  })
+
+  it('Throws an error on a self referential link', async () => {
+    await expect(resolveLinkEntity(linksToSelf.id!)).rejects.toThrowError(
+      `${linksToSelf.id} could not be resolved.\nLink forms a cycle.`,
+    )
+  })
+
+  it('Throws an error on a cycle', async () => {
+    await expect(resolveLinkEntity(linkCycleA.id!)).rejects.toThrowError(
+      `${linkCycleA.id} could not be resolved.\nLink forms a cycle.`,
+    )
+  })
+})

--- a/src/lib/containers/FilePreview/EntityPreview.tsx
+++ b/src/lib/containers/FilePreview/EntityPreview.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { useResolveLinkEntity } from '../../utils/functions/ResolveLinkEntity'
+import useGetEntityBundle from '../../utils/hooks/SynapseAPI/entity/useEntityBundle'
+import { ALL_ENTITY_BUNDLE_FIELDS } from '../../utils/SynapseConstants'
+import { FileEntity, isFileEntity } from '../../utils/synapseTypes'
+import { SynapseSpinner } from '../LoadingScreen'
+import FileEntityPreview from './FileEntityPreview'
+
+export type EntityPreviewProps = {
+  entityId: string
+  versionNumber?: number
+}
+
+/**
+ * Returns a preview of an entity. Currently only works for FileEntities, and Links that resolve to FileEntities.
+ * @param props
+ * @returns
+ */
+export default function EntityPreview(props: EntityPreviewProps) {
+  let { entityId, versionNumber } = props
+
+  // If the entity is a Link, follow it until we get a non-link
+  const { data: resolvedLink, isLoading: isLoadingLinkResolution } =
+    useResolveLinkEntity(entityId, versionNumber)
+  const isResolvedLinkFileEntity = resolvedLink && isFileEntity(resolvedLink)
+
+  const { data: bundle, isLoading: isLoadingBundle } = useGetEntityBundle(
+    resolvedLink?.id!,
+    (resolvedLink as FileEntity | undefined)?.versionNumber,
+    ALL_ENTITY_BUNDLE_FIELDS,
+    {
+      enabled: !!isResolvedLinkFileEntity,
+      useErrorBoundary: true,
+    },
+  )
+
+  const isLoading = isLoadingLinkResolution || isLoadingBundle
+
+  if (isLoading) {
+    return <SynapseSpinner />
+  }
+
+  // If the entity is NOT a FileEntity, throw an error
+  if (!isResolvedLinkFileEntity) {
+    throw new Error(`${entityId} is not a File and cannot be previewed.`)
+  } else {
+    return <FileEntityPreview bundle={bundle!} />
+  }
+}

--- a/src/lib/containers/FilePreview/FileHandleContentRenderer.tsx
+++ b/src/lib/containers/FilePreview/FileHandleContentRenderer.tsx
@@ -49,7 +49,9 @@ export default function FileHandleContentRenderer(
     return <SynapseSpinner />
   }
   if (previewType === PreviewRendererType.HTML) {
-    return <HtmlPreview fileHandle={fileHandle} rawHtml={content!} />
+    return (
+      <HtmlPreview rawHtml={content!} createdByUserId={fileHandle.createdBy} />
+    )
   } else {
     if (previewType !== PreviewRendererType.NONE) {
       console.warn(

--- a/src/lib/containers/entity_finder/EntityFinder.tsx
+++ b/src/lib/containers/entity_finder/EntityFinder.tsx
@@ -11,7 +11,7 @@ import {
   entityTypeToFriendlyName,
   getEntityTypeFromHeader,
 } from '../../utils/functions/EntityTypeUtils'
-import { SYNAPSE_ENTITY_ID_REGEX } from '../../utils/functions/RegularExpressions'
+import { parseSynId } from '../../utils/functions/RegularExpressions'
 import { useSynapseContext } from '../../utils/SynapseContext'
 import { Reference } from '../../utils/synapseTypes'
 import { EntityType } from '../../utils/synapseTypes/EntityType'
@@ -168,19 +168,9 @@ export const EntityFinder: React.FunctionComponent<EntityFinderProps> = ({
 
   useEffect(() => {
     if (searchTerms?.length === 1) {
-      const synIdMatch = SYNAPSE_ENTITY_ID_REGEX.exec(searchTerms[0])
-      if (synIdMatch) {
-        SynapseClient.getEntityHeaders(
-          [
-            {
-              targetId: synIdMatch[1],
-              targetVersionNumber: synIdMatch[2]
-                ? parseInt(synIdMatch[2])
-                : undefined,
-            },
-          ],
-          accessToken,
-        )
+      const searchTermReference = parseSynId(searchTerms[0])
+      if (searchTermReference) {
+        SynapseClient.getEntityHeaders([searchTermReference], accessToken)
           .then(response => {
             setSearchByIdResults(response.results)
           })

--- a/src/lib/containers/markdown/MarkdownSynapse.stories.tsx
+++ b/src/lib/containers/markdown/MarkdownSynapse.stories.tsx
@@ -73,3 +73,9 @@ MarkdownProvenanceGraph.args = {
   markdown:
     '# Provenance Graphs\nMultiple start nodes\n${provenance?entityList=syn12548902%2Csyn33344762&depth=3&displayHeightPx=800&showExpand=false}\nSpecify the entity version\n${provenance?entityList=syn12548902%2Fversion%2F34&depth=1&displayHeightPx=500&showExpand=true}',
 }
+
+export const HtmlRenderingTest = Template.bind({})
+HtmlRenderingTest.args = {
+  ownerId: 'syn5585645',
+  wikiId: '493662',
+}

--- a/src/lib/containers/markdown/MarkdownWidget.tsx
+++ b/src/lib/containers/markdown/MarkdownWidget.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
+import { SynapseErrorBoundary } from '../ErrorBanner'
 import MarkdownButton, { ButtonLinkWidgetParams } from './widget/MarkdownButton'
+import MarkdownEntityPreview, {
+  MarkdownEntityPreviewProps,
+} from './widget/MarkdownEntityPreview'
 import MarkdownIDUReport, {
   MarkdownIDUReportProps,
 } from './widget/MarkdownIDUReport'
@@ -66,6 +70,11 @@ type ProvenanceGraph = {
   widgetParamsMapped: MarkdownProvenanceGraphProps
 }
 
+type Preview = {
+  widgetType: 'preview'
+  widgetParamsMapped: MarkdownEntityPreviewProps
+}
+
 type MarkdownWidgetDefinition =
   | ButtonLink
   | Image
@@ -76,12 +85,13 @@ type MarkdownWidgetDefinition =
   | Video
   | SynapseTable
   | ProvenanceGraph
+  | Preview
 
 export type MarkdownWidgetProps = MarkdownWidgetDefinition & {
   originalMarkup: string
 }
 
-export default function MarkdownWidget(props: MarkdownWidgetProps) {
+function MarkdownWidget(props: MarkdownWidgetProps) {
   const { widgetType, widgetParamsMapped, originalMarkup } = props
   switch (widgetType) {
     case 'buttonlink':
@@ -104,8 +114,19 @@ export default function MarkdownWidget(props: MarkdownWidgetProps) {
       return <MarkdownSynapseTable {...widgetParamsMapped} />
     case 'provenance':
       return <MarkdownProvenanceGraph {...widgetParamsMapped} />
+    case 'preview':
+      return <MarkdownEntityPreview {...widgetParamsMapped} />
     default:
       console.warn(`Unsupported widget: ${widgetType}.`)
       return <></>
   }
+}
+
+export default function MarkdownWidgetWithWrapper(props: MarkdownWidgetProps) {
+  // Wrap the widget in an error boundary.
+  return (
+    <SynapseErrorBoundary>
+      <MarkdownWidget {...props} />
+    </SynapseErrorBoundary>
+  )
 }

--- a/src/lib/containers/markdown/widget/MarkdownEntityPreview.tsx
+++ b/src/lib/containers/markdown/widget/MarkdownEntityPreview.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import EntityPreview from '../../FilePreview/EntityPreview'
+import { parseSynId } from '../../../utils/functions/RegularExpressions'
+
+export type MarkdownEntityPreviewProps = {
+  /** A Synapse Entity ID that may optionally contain a "dot" version, e.g. syn123 or syn123.2 */
+  entityId: string
+  /** An optional Entity version number. */
+  versionNumber?: string
+}
+
+export default function MarkdownEntityPreview(
+  props: MarkdownEntityPreviewProps,
+) {
+  const parsedReference = parseSynId(props.entityId)
+  if (parsedReference == null) {
+    throw new Error(`${props.entityId} is not a valid Synapse ID`)
+  }
+  const parsedVersionNumber = parseInt(props.versionNumber ?? '')
+
+  const entityId = parsedReference.targetId
+  const versionNumber = Number.isNaN(parsedVersionNumber)
+    ? parsedReference.targetVersionNumber
+    : parsedVersionNumber
+
+  return <EntityPreview entityId={entityId} versionNumber={versionNumber} />
+}

--- a/src/lib/utils/functions/RegularExpressions.ts
+++ b/src/lib/utils/functions/RegularExpressions.ts
@@ -1,3 +1,5 @@
+import { Reference } from '../synapseTypes'
+
 // doi regex here - https://www.crossref.org/blog/dois-and-matching-regular-expressions/
 // note - had to add an escape character for the second and third forward slash in the regex above
 export const DOI_REGEX = /^10.\d{4,9}\/[-._;()\/:a-z0-9]+$/i
@@ -16,3 +18,21 @@ export const DOI_REGEX = /^10.\d{4,9}\/[-._;()\/:a-z0-9]+$/i
  * '9'
  */
 export const SYNAPSE_ENTITY_ID_REGEX = /^(syn\d+)(?:\.(\d+))?$/
+
+/**
+ * Given a Synapse Entity ID of the form `syn123` or `syn123.4`, returns the
+ * Reference object containing the entity ID and optional version number.
+ * If the ID is not a valid Synapse Entity ID, returns null.
+ * @param synId
+ */
+export function parseSynId(synId: string): Reference | null {
+  const synIdMatch = SYNAPSE_ENTITY_ID_REGEX.exec(synId)
+  if (synIdMatch) {
+    return {
+      targetId: synIdMatch[1],
+      targetVersionNumber: synIdMatch[2] ? parseInt(synIdMatch[2]) : undefined,
+    }
+  } else {
+    return synIdMatch
+  }
+}

--- a/src/lib/utils/functions/ResolveLinkEntity.ts
+++ b/src/lib/utils/functions/ResolveLinkEntity.ts
@@ -1,0 +1,49 @@
+import { QueryOptions, useQuery } from 'react-query'
+import { getEntity } from '../SynapseClient'
+import { useSynapseContext } from '../SynapseContext'
+import { Entity, isLink } from '../synapseTypes'
+
+/**
+ * Follows a Synapse entity ID to the end of the chain of links
+ * @param synId the ID of a Synapse entity that may be a link
+ * @returns the ID of the entity at the end of the chain of links
+ * @throws an error if a link is found that does not resolve, or if a cycle is found
+ */
+export async function resolveLinkEntity(
+  synId: string,
+  versionNumber?: number,
+  accessToken?: string,
+): Promise<Entity> {
+  // Track visited entities to prevent infinitely fetching a cycle of Links
+  const seen: Set<string> = new Set()
+  try {
+    let currentEntity = await getEntity(accessToken, synId, versionNumber)
+    while (isLink(currentEntity)) {
+      if (seen.has(currentEntity.id!)) {
+        throw new Error('Link forms a cycle.')
+      }
+      seen.add(currentEntity.id!)
+      currentEntity = await getEntity(
+        accessToken,
+        currentEntity.linksTo.targetId,
+        currentEntity.linksTo.targetVersionNumber,
+      )
+    }
+    return currentEntity
+  } catch (e) {
+    throw new Error(`${synId} could not be resolved.\n${(e as Error).message}`)
+  }
+}
+
+export function useResolveLinkEntity(
+  synId: string,
+  versionNumber?: number,
+  options?: QueryOptions<Entity>,
+) {
+  const { accessToken } = useSynapseContext()
+  return useQuery(
+    ['resolveLinkEntity', synId, versionNumber],
+    () => resolveLinkEntity(synId, versionNumber, accessToken),
+    options,
+  )
+}


### PR DESCRIPTION
Depends on #1825 

* Add `EntityPreview`. `EntityPreview` takes a SynID and renders the appropriate preview based on the Entity type. For now, it only handles `FileEntity` and `Link`, if the `Link` resolves to a `FileEntity`.
* Add `MarkdownEntityPreview` which renders an `EntityPreview`, and register the component to handle the `preview` widget descriptor