### PR TITLE
PORTALS-2157: Add NoContentPlaceholder to determine what to show when query results are empty

### DIFF
--- a/src/__tests__/lib/containers/CardContainerLogic.test.tsx
+++ b/src/__tests__/lib/containers/CardContainerLogic.test.tsx
@@ -8,6 +8,7 @@ import CardContainerLogic, {
 import { QueryVisualizationWrapper } from '../../../lib/containers/QueryVisualizationWrapper'
 import { InfiniteQueryWrapper } from '../../../lib/containers/InfiniteQueryWrapper'
 import { createWrapper } from '../../../lib/testutils/TestingLibraryUtils'
+import { NoContentPlaceholderType } from '../../../lib/containers/table/NoContentPlaceholderType'
 
 const renderComponent = (props: CardContainerLogicProps) => {
   return render(<CardContainerLogic {...props} />, { wrapper: createWrapper() })
@@ -90,6 +91,7 @@ describe('it performs basic functionality', () => {
           rgbIndex: props.rgbIndex,
           unitDescription: props.unitDescription,
           columnAliases: props.columnAliases,
+          noContentPlaceholderType: NoContentPlaceholderType.STATIC,
         }),
         expect.anything(),
       ),

--- a/src/__tests__/lib/containers/dataaccess/AccessSubmissionDashboard.test.tsx
+++ b/src/__tests__/lib/containers/dataaccess/AccessSubmissionDashboard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryHistory, MemoryHistory } from 'history'
 import React from 'react'
@@ -109,10 +109,12 @@ describe('AccessSubmissionDashboard tests', () => {
     await screen.findByText(
       getOptionLabel(mockAccessRequirement.id, mockAccessRequirement.name),
     )
-    await selectEvent.select(
-      arNameInput,
-      getOptionLabel(mockAccessRequirement.id, mockAccessRequirement.name),
-    )
+    await act(async () => {
+      await selectEvent.select(
+        arNameInput,
+        getOptionLabel(mockAccessRequirement.id, mockAccessRequirement.name),
+      )
+    })
 
     await waitFor(() =>
       expect(
@@ -137,7 +139,9 @@ describe('AccessSubmissionDashboard tests', () => {
     const requesterInput = (await screen.findAllByRole('combobox'))[1]
     await userEvent.type(requesterInput, MOCK_USER_NAME.substring(0, 1))
     await screen.findByText(new RegExp('@' + MOCK_USER_NAME))
-    await selectEvent.select(requesterInput, new RegExp('@' + MOCK_USER_NAME))
+    await act(async () => {
+      await selectEvent.select(requesterInput, new RegExp('@' + MOCK_USER_NAME))
+    })
 
     await waitFor(() =>
       expect(
@@ -159,7 +163,9 @@ describe('AccessSubmissionDashboard tests', () => {
     const reviewerInput = (await screen.findAllByRole('combobox'))[2]
     await userEvent.type(reviewerInput, MOCK_USER_NAME.substring(0, 1))
     await screen.findByText(new RegExp('@' + MOCK_USER_NAME))
-    await selectEvent.select(reviewerInput, new RegExp('@' + MOCK_USER_NAME))
+    await act(async () => {
+      await selectEvent.select(reviewerInput, new RegExp('@' + MOCK_USER_NAME))
+    })
 
     await waitFor(() =>
       expect(

--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -19,8 +19,6 @@ import {
   LoadingObservationCard,
   ObservationCard,
 } from './row_renderers/ObservationCard'
-import NoContentAvailable from './table/NoContentAvailable'
-import SearchResultsNotFound from './table/SearchResultsNotFound'
 import TotalQueryResults from './TotalQueryResults'
 import UserCardList from './UserCardList'
 
@@ -59,10 +57,8 @@ export const CardContainer = (props: CardContainerProps) => {
     ...rest
   } = props
   const infiniteQueryContext = useInfiniteQueryContext()
-  const { data, getLastQueryRequest, appendNextPageToResults, hasNextPage } =
-    infiniteQueryContext
-
-  const queryRequest = getLastQueryRequest()
+  const { NoContentPlaceholder } = useQueryVisualizationContext()
+  const { data, appendNextPageToResults, hasNextPage } = infiniteQueryContext
 
   const queryVisualizationContext = useQueryVisualizationContext()
 
@@ -82,12 +78,8 @@ export const CardContainer = (props: CardContainerProps) => {
       </div>
     )
   } else if (data && data.queryResult!.queryResults.rows.length === 0) {
-    // data was retrieved from the backend but there is none to show.
-    if (queryRequest.query.additionalFilters) {
-      return <SearchResultsNotFound />
-    }
-    // else show "no results" UI (see PORTALS-1497)
-    return <NoContentAvailable />
+    // Show "no results" UI (see PORTALS-1497)
+    return <NoContentPlaceholder />
   }
   const schema = {}
   data.queryResult!.queryResults.headers.forEach((element, index) => {

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -17,6 +17,7 @@ import {
 import { QueryContextConsumer } from './QueryContext'
 import { InfiniteQueryWrapper } from './InfiniteQueryWrapper'
 import QuerySortSelector from './QuerySortSelector'
+import { NoContentPlaceholderType } from './table/NoContentPlaceholderType'
 
 /**
  *  Used when a column value should link to an external URL defined by a value in another column.
@@ -128,7 +129,10 @@ export type CardContainerLogicProps = {
 } & CardConfiguration &
   Pick<
     QueryVisualizationWrapperProps,
-    'rgbIndex' | 'unitDescription' | 'columnAliases'
+    | 'rgbIndex'
+    | 'unitDescription'
+    | 'columnAliases'
+    | 'noContentPlaceholderType'
   >
 
 /**
@@ -174,6 +178,9 @@ export const CardContainerLogic = (props: CardContainerLogicProps) => {
         rgbIndex={props.rgbIndex}
         unitDescription={props.unitDescription}
         columnAliases={columnAliases}
+        noContentPlaceholderType={
+          props.noContentPlaceholderType ?? NoContentPlaceholderType.STATIC
+        }
       >
         {sortConfig && <QuerySortSelector sortConfig={sortConfig} />}
         <CardContainer {...props} />

--- a/src/lib/containers/QueryContext.tsx
+++ b/src/lib/containers/QueryContext.tsx
@@ -13,7 +13,7 @@ export const QUERY_FILTERS_COLLAPSED_CSS: string = 'isHidingFacetFilters'
 
 /*
   For details page: to lock a column (e.g. study, grant) so that the facet values and active filters
-  will not appear on the details page. The facet name is given by the url's search param. 
+  will not appear on the details page. The facet name is given by the URL search param.
   The type is defined here so that other child components in SRC won't generate type errors.
  */
 export type LockedColumn = {
@@ -32,13 +32,13 @@ export type QueryContextType = {
   getInitQueryRequest: () => QueryBundleRequest
   /** Updates the current query with the passed request */
   executeQueryRequest: (param: QueryBundleRequest) => void
-  /** Returns true when loading a brand new query result bundle. Will not be true when just loading the next page of query results. */
+  /** Returns true when loading a brand-new query result bundle. Will not be true when just loading the next page of query results. */
   isLoadingNewBundle: boolean
   /** The error returned by the query request, if one is encountered */
   error: SynapseClientError | null
   /** The status of the asynchronous job. */
   asyncJobStatus?: AsynchronousJobStatus<QueryBundleRequest, QueryResultBundle>
-  /** Whether or not facets are available to be filtered upon based on the current data */
+  /** Whether facets are available to be filtered upon based on the current data */
   isFacetsAvailable: boolean
   /**
    * A column name may be "locked" so that it is both (1) not shown to the user that the filter is active, and (2) not modifiable by the user.
@@ -46,6 +46,8 @@ export type QueryContextType = {
    * The presence of a locked filter will result in a client-side modification of the active query and result bundle data.
    */
   lockedColumn?: LockedColumn
+  /** Returns true iff the current request has resettable filters applied via facet filters or additionalFilters. Excludes filters applied to a locked column */
+  hasResettableFilters: boolean
 }
 
 export type PaginatedQueryContextType = QueryContextType & {
@@ -62,13 +64,13 @@ export type PaginatedQueryContextType = QueryContextType & {
 export type InfiniteQueryContextType = QueryContextType & {
   /** Returns true when loading a new page of query results */
   isLoadingNewPage: boolean
-  /** Whether or not the query result bundle has a next page */
+  /** Whether the query result bundle has a next page */
   hasNextPage: boolean
   /** Invoke this method to fetch and append the next page of rows to the data  */
   appendNextPageToResults: () => Promise<void>
   /** Invoke to fetch and update the data with the next page of query results */
   goToNextPage: () => Promise<void>
-  /** Whether or not the query result bundle has a previous page */
+  /** Whether the query result bundle has a previous page */
   hasPreviousPage: boolean
   /** Invoke to fetch and update the data with the previous page of query results */
   goToPreviousPage: () => Promise<void>

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -34,6 +34,7 @@ import TopLevelControls, {
 import FacetNav, { FacetNavProps } from '../widgets/facet-nav/FacetNav'
 import { FacetFilterControls } from '../widgets/query-filter/FacetFilterControls'
 import FilterAndView from './FilterAndView'
+import { NoContentPlaceholderType } from '../table/NoContentPlaceholderType'
 
 const QUERY_FILTERS_EXPANDED_CSS = 'isShowingFacetFilters'
 const QUERY_FILTERS_COLLAPSED_CSS = 'isHidingFacetFilters'
@@ -59,9 +60,6 @@ type OwnProps = {
   >
   facetsToPlot?: string[]
   facetsToFilter?: string[]
-  hideDownload?: boolean
-  hideQueryCount?: boolean
-  hideSqlEditorControl?: boolean
   defaultColumn?: string
   defaultShowSearchBox?: boolean
   lockedColumn?: QueryWrapperProps['lockedColumn']
@@ -73,6 +71,7 @@ type OwnProps = {
     | 'columnAliases'
     | 'rgbIndex'
     | 'showLastUpdatedOn'
+    | 'noContentPlaceholderType'
   >
 
 type SearchParams = {
@@ -159,6 +158,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
             props.defaultShowSearchBox || isFullTextSearchEnabled
           }
           showLastUpdatedOn={showLastUpdatedOn}
+          noContentPlaceholderType={NoContentPlaceholderType.INTERACTIVE}
         >
           <QueryContextConsumer>
             {queryContext => {

--- a/src/lib/containers/table/NoContentPlaceholderType.ts
+++ b/src/lib/containers/table/NoContentPlaceholderType.ts
@@ -1,0 +1,11 @@
+/**
+ * When displaying that there are no results, there are two scenarios:
+ * 1. Interactive - the user can modify the query and may have chosen a query with no results
+ *    - If the user has not modified the query, show a message that the table is empty
+ *    - If the user has modified the query, show a message that there are no results and to try a different input
+ * 2. Static - the user cannot modify the query. Show a message that there is no content available.
+ */
+export enum NoContentPlaceholderType {
+  INTERACTIVE = 'INTERACTIVE',
+  STATIC = 'STATIC',
+}

--- a/src/lib/containers/table/StandaloneQueryWrapper.tsx
+++ b/src/lib/containers/table/StandaloneQueryWrapper.tsx
@@ -48,7 +48,11 @@ type OwnProps = {
 } & Omit<TopLevelControlsProps, 'entityId'> &
   Pick<
     QueryVisualizationWrapperProps,
-    'rgbIndex' | 'unitDescription' | 'columnAliases' | 'showLastUpdatedOn'
+    | 'rgbIndex'
+    | 'unitDescription'
+    | 'columnAliases'
+    | 'noContentPlaceholderType'
+    | 'showLastUpdatedOn'
   >
 
 export type StandaloneQueryWrapperProps = Partial<

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -2,7 +2,6 @@ import ColumnResizer from 'column-resizer'
 import { cloneDeep, eq } from 'lodash-es'
 import * as React from 'react'
 import { Modal } from 'react-bootstrap'
-import NoData from '../../assets/icons/NoData'
 import { SynapseClient } from '../../utils'
 import {
   hasFilesInView,
@@ -44,7 +43,6 @@ import {
   applyChangesToValuesColumn,
   applyMultipleChangesToValuesColumn,
 } from '../widgets/query-filter/FacetFilterControls'
-import SearchResultsNotFound from './SearchResultsNotFound'
 import { ICON_STATE } from './SynapseTableConstants'
 import {
   getColumnIndiciesWithType,
@@ -53,7 +51,6 @@ import {
   getUniqueEntities,
 } from './SynapseTableUtils'
 import { TablePagination } from './TablePagination'
-import NoContentAvailable from './NoContentAvailable'
 import EntityIDColumnCopyIcon from './EntityIDColumnCopyIcon'
 import ExpandableTableDataCell from './ExpandableTableDataCell'
 
@@ -359,7 +356,7 @@ export default class SynapseTable extends React.Component<
     // unpack all the data
     const {
       queryContext: { data },
-      showNoContentAvailableWhenEmpty,
+      queryVisualizationContext: { NoContentPlaceholder },
     } = this.props
     const { queryResult, columnModels = [] } = data
     const { facets = [] } = data
@@ -369,22 +366,7 @@ export default class SynapseTable extends React.Component<
     const hasResults = (data.queryResult?.queryResults.rows.length ?? 0) > 0
     // Show the No Results UI if the current page has no rows, and this is the first page of data (offset === 0).
     if (!hasResults && queryRequest.query.offset === 0) {
-      if (queryRequest.query.additionalFilters) {
-        return <SearchResultsNotFound />
-      } else {
-        if (showNoContentAvailableWhenEmpty) {
-          return <NoContentAvailable />
-        } else {
-          return (
-            <div className="text-center SRCBorderedPanel SRCBorderedPanel--padded2x">
-              {NoData}
-              <div style={{ marginTop: '20px', fontStyle: 'italic' }}>
-                This table is currently empty
-              </div>
-            </div>
-          )
-        }
-      }
+      return <NoContentPlaceholder />
     }
 
     const { rows, headers } = queryResult!.queryResults

--- a/src/lib/containers/table/TableIsEmpty.tsx
+++ b/src/lib/containers/table/TableIsEmpty.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import NoData from '../../assets/icons/NoData'
+
+export default function ThisTableIsEmpty() {
+  return (
+    <div className="text-center SRCBorderedPanel SRCBorderedPanel--padded2x">
+      {NoData}
+      <div style={{ marginTop: '20px', fontStyle: 'italic' }}>
+        This table is currently empty
+      </div>
+    </div>
+  )
+}

--- a/src/lib/containers/widgets/query-filter/FacetFilterControls.tsx
+++ b/src/lib/containers/widgets/query-filter/FacetFilterControls.tsx
@@ -1,17 +1,15 @@
 import React from 'react'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 import { isSingleNotSetValue } from '../../../utils/functions/queryUtils'
-import { QueryBundleRequest } from '../../../utils/synapseTypes'
 import {
+  QueryBundleRequest,
   FacetColumnRangeRequest,
   FacetColumnRequest,
   FacetColumnValuesRequest,
-} from '../../../utils/synapseTypes/Table/FacetColumnRequest'
-import {
   FacetColumnResult,
   FacetColumnResultRange,
   FacetColumnResultValues,
-} from '../../../utils/synapseTypes/Table/FacetColumnResult'
+} from '../../../utils/synapseTypes'
 import { useQueryContext } from '../../QueryContext'
 import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
 import {
@@ -32,21 +30,21 @@ const convertFacetToFacetColumnValuesRequest = (
   concreteType: 'org.sagebionetworks.repo.model.table.FacetColumnValuesRequest',
   columnName: facet.columnName,
   facetValues: facet.facetValues
-    .filter(facet => facet.isSelected === true)
+    .filter(facet => facet.isSelected)
     .map(facet => facet.value),
 })
 
 const convertFacetColumnRangeRequest = (
   facet: FacetColumnResultRange,
 ): FacetColumnRangeRequest => {
-  let result = {
+  let result: FacetColumnRangeRequest = {
     concreteType:
       'org.sagebionetworks.repo.model.table.FacetColumnRangeRequest',
     columnName: facet.columnName, // The name of the faceted column
   }
 
   if (facet.columnMin) {
-    result = { ...result, ...{ min: facet.columnMin, max: facet.columnMax } }
+    result = { ...result, min: facet.columnMin, max: facet.columnMax }
   }
   return result
 }

--- a/src/lib/utils/functions/queryUtils.ts
+++ b/src/lib/utils/functions/queryUtils.ts
@@ -133,7 +133,6 @@ export function hasResettableFilters(
   query: Query,
   lockedColumn?: LockedColumn,
 ): boolean {
-  console.log('query', query, lockedColumn)
   const hasFacetFilters =
     Array.isArray(query.selectedFacets) &&
     query.selectedFacets.filter(

--- a/src/lib/utils/synapseTypes/Table/FacetColumnRequest.ts
+++ b/src/lib/utils/synapseTypes/Table/FacetColumnRequest.ts
@@ -1,19 +1,41 @@
-// https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/FacetColumnValuesRequest.html
+import { isTypeViaConcreteTypeFactory } from '../../functions/TypeUtils'
 
+const FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE_VALUE =
+  'org.sagebionetworks.repo.model.table.FacetColumnValuesRequest'
+type FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE =
+  typeof FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE_VALUE
+
+// https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/FacetColumnValuesRequest.html
 export type FacetColumnValuesRequest = {
-  concreteType?: string
-  columnName?: string // The name of the faceted column
-  facetValues?: string[] // The set of facet values that were selected
+  concreteType: FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE
+  columnName: string // The name of the faceted column
+  facetValues: string[] // The set of facet values that were selected
 }
+
+const FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE =
+  'org.sagebionetworks.repo.model.table.FacetColumnRangeRequest'
+type FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE =
+  typeof FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE
 
 // https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/FacetColumnRangeRequest.html
 export type FacetColumnRangeRequest = {
-  concreteType?: string
-  columnName?: string // The name of the faceted column
+  concreteType: FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE
+  columnName: string // The name of the faceted column
   min?: string
   max?: string
 }
 
 // https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/FacetColumnRequest.html
-export type FacetColumnRequest = FacetColumnValuesRequest &
-  FacetColumnRangeRequest
+export type FacetColumnRequest =
+  | FacetColumnValuesRequest
+  | FacetColumnRangeRequest
+
+export const isFacetColumnValuesRequest =
+  isTypeViaConcreteTypeFactory<FacetColumnValuesRequest>(
+    FACET_COLUMN_VALUES_REQUEST_CONCRETE_TYPE_VALUE,
+  )
+
+export const isFacetColumnRangeRequest =
+  isTypeViaConcreteTypeFactory<FacetColumnRangeRequest>(
+    FACET_COLUMN_RANGE_REQUEST_CONCRETE_TYPE_VALUE,
+  )


### PR DESCRIPTION
Depends on #1854 

- Add `noContentPlaceholderType` prop to QueryWrapperPlotNav, CardContainerLogic, and StandaloneQueryWrapper, which can be used to specify whether the UI should guide the user to change interactive filters
