### PR TITLE
PORTALS-2157 - Rename QueryFilter component to FacetFilterControls and small bugfix

### DIFF
--- a/src/__tests__/lib/containers/widgets/query-filter/FacetFilterControls.test.tsx
+++ b/src/__tests__/lib/containers/widgets/query-filter/FacetFilterControls.test.tsx
@@ -12,9 +12,9 @@ import {
   QueryVisualizationContextType,
 } from '../../../../../lib/containers/QueryVisualizationWrapper'
 import {
-  QueryFilter,
-  QueryFilterProps,
-} from '../../../../../lib/containers/widgets/query-filter/QueryFilter'
+  FacetFilterControls,
+  FacetFilterControlsProps,
+} from '../../../../../lib/containers/widgets/query-filter/FacetFilterControls'
 import { SynapseContextProvider } from '../../../../../lib/utils/SynapseContext'
 import { QueryResultBundle } from '../../../../../lib/utils/synapseTypes'
 import mockQueryResponseData from '../../../../../mocks/mockQueryResponseData.json'
@@ -89,7 +89,9 @@ const lastQueryRequestResult = {
 const mockExecuteQueryRequest = jest.fn(_selectedFacets => null)
 const mockGetQueryRequest = jest.fn(() => _.cloneDeep(lastQueryRequestResult))
 
-function createTestProps(overrides?: QueryFilterProps): QueryFilterProps {
+function createTestProps(
+  overrides?: FacetFilterControlsProps,
+): FacetFilterControlsProps {
   return {
     ...overrides,
   }
@@ -115,11 +117,11 @@ const defaultQueryVisualizationContext: Partial<QueryVisualizationContextType> =
     },
   }
 
-let props: QueryFilterProps
-function init(overrides?: QueryFilterProps) {
+let props: FacetFilterControlsProps
+function init(overrides?: FacetFilterControlsProps) {
   jest.clearAllMocks()
   props = createTestProps(overrides)
-  return render(<QueryFilter {...props} />, {
+  return render(<FacetFilterControls {...props} />, {
     wrapper: ({ children }) => {
       return (
         <SynapseContextProvider synapseContext={MOCK_CONTEXT_VALUE}>
@@ -136,7 +138,7 @@ function init(overrides?: QueryFilterProps) {
   })
 }
 
-describe('QueryFilter tests', () => {
+describe('FacetFilterControls tests', () => {
   it('should only show three facets and be expanded', () => {
     init()
     const facetFilters = screen.getAllByTestId(/(Enum|Range)FacetFilter/)
@@ -149,7 +151,7 @@ describe('QueryFilter tests', () => {
 
   it('should respect facetsToFilter', async () => {
     // set facetsToFilter to make the component only show a filter for Year (a range type facet) and not Make (a values/enum type)
-    init({ facetsToFilter: ['Year'] })
+    init({ facetFiltersToShow: ['Year'] })
     expect(screen.queryByTestId('EnumFacetFilter')).not.toBeInTheDocument()
     expect(screen.queryByTestId('RangeFacetFilter')).toBeInTheDocument()
     // expects the facet chips to only show facets within facetToFilter

--- a/src/__tests__/lib/containers/widgets/query-filter/FacetFilterControls.test.tsx
+++ b/src/__tests__/lib/containers/widgets/query-filter/FacetFilterControls.test.tsx
@@ -151,7 +151,7 @@ describe('FacetFilterControls tests', () => {
 
   it('should respect facetsToFilter', async () => {
     // set facetsToFilter to make the component only show a filter for Year (a range type facet) and not Make (a values/enum type)
-    init({ facetFiltersToShow: ['Year'] })
+    init({ facetsToFilter: ['Year'] })
     expect(screen.queryByTestId('EnumFacetFilter')).not.toBeInTheDocument()
     expect(screen.queryByTestId('RangeFacetFilter')).toBeInTheDocument()
     // expects the facet chips to only show facets within facetToFilter

--- a/src/lib/containers/TotalQueryResults.tsx
+++ b/src/lib/containers/TotalQueryResults.tsx
@@ -41,7 +41,7 @@ import SelectionCriteriaPill, {
 import {
   applyChangesToRangeColumn,
   applyChangesToValuesColumn,
-} from './widgets/query-filter/QueryFilter'
+} from './widgets/query-filter/FacetFilterControls'
 import { RadioValuesEnum } from './widgets/query-filter/RangeFacetFilter'
 import IconSvg from './IconSvg'
 

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -223,7 +223,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
                         {isFaceted && (
                           <>
                             <FacetFilterControls
-                              facetFiltersToShow={facetsToFilter}
+                              facetsToFilter={facetsToFilter}
                             />
                           </>
                         )}

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -28,7 +28,7 @@ import TopLevelControls, {
   TopLevelControlsProps,
 } from '../table/TopLevelControls'
 import FacetNav, { FacetNavProps } from '../widgets/facet-nav/FacetNav'
-import { QueryFilter } from '../widgets/query-filter/QueryFilter'
+import { FacetFilterControls } from '../widgets/query-filter/FacetFilterControls'
 import FilterAndView from './FilterAndView'
 
 const QUERY_FILTERS_EXPANDED_CSS = 'isShowingFacetFilters'
@@ -222,7 +222,9 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
                         />
                         {isFaceted && (
                           <>
-                            <QueryFilter facetsToFilter={facetsToFilter} />
+                            <FacetFilterControls
+                              facetFiltersToShow={facetsToFilter}
+                            />
                           </>
                         )}
                         <FacetNav facetsToPlot={facetsToPlot} />

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -43,7 +43,7 @@ import { EnumFacetFilter } from '../widgets/query-filter/EnumFacetFilter'
 import {
   applyChangesToValuesColumn,
   applyMultipleChangesToValuesColumn,
-} from '../widgets/query-filter/QueryFilter'
+} from '../widgets/query-filter/FacetFilterControls'
 import { unCamelCase } from './../../utils/functions/unCamelCase'
 import SearchResultsNotFound from './SearchResultsNotFound'
 import { ICON_STATE } from './SynapseTableConstants'

--- a/src/lib/containers/widgets/facet-nav/FacetNav.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNav.tsx
@@ -14,7 +14,7 @@ import {
   QUERY_FILTERS_EXPANDED_CSS,
 } from '../../QueryWrapper'
 import { useQueryContext } from '../../QueryContext'
-import { applyChangesToValuesColumn } from '../query-filter/QueryFilter'
+import { applyChangesToValuesColumn } from '../query-filter/FacetFilterControls'
 import FacetNavPanel, { PlotType } from './FacetNavPanel'
 import TotalQueryResults from '../../TotalQueryResults'
 

--- a/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
@@ -24,7 +24,7 @@ import { EnumFacetFilter } from '../query-filter/EnumFacetFilter'
 import {
   applyChangesToValuesColumn,
   applyMultipleChangesToValuesColumn,
-} from '../query-filter/QueryFilter'
+} from '../query-filter/FacetFilterControls'
 import Tooltip from '../../../utils/tooltip/Tooltip'
 
 const Plot = createPlotlyComponent(Plotly)

--- a/src/lib/containers/widgets/query-filter/FacetFilterControls.tsx
+++ b/src/lib/containers/widgets/query-filter/FacetFilterControls.tsx
@@ -23,7 +23,7 @@ import { FacetChip } from './FacetChip'
 import { RangeFacetFilter } from './RangeFacetFilter'
 
 export type FacetFilterControlsProps = {
-  facetFiltersToShow?: string[]
+  facetsToFilter?: string[]
 }
 
 const convertFacetToFacetColumnValuesRequest = (
@@ -138,7 +138,7 @@ export const applyChangesToRangeColumn = (
 }
 
 export function FacetFilterControls(props: FacetFilterControlsProps) {
-  const { facetFiltersToShow } = props
+  const { facetsToFilter: facetFiltersToShow } = props
   const { data, isLoadingNewBundle, getLastQueryRequest, executeQueryRequest } =
     useQueryContext()
 
@@ -191,7 +191,7 @@ export function FacetFilterControls(props: FacetFilterControlsProps) {
 
   return (
     <div
-      className={`QueryFilter ${
+      className={`FacetFilterControls ${
         showFacetFilter
           ? QUERY_FILTERS_EXPANDED_CSS
           : QUERY_FILTERS_COLLAPSED_CSS
@@ -206,7 +206,10 @@ export function FacetFilterControls(props: FacetFilterControlsProps) {
               model => model.name === facet.columnName,
             )
             return (
-              <div className="QueryFilter__facet" key={facet.columnName}>
+              <div
+                className="FacetFilterControls__facet"
+                key={facet.columnName}
+              >
                 {facet.facetType === 'enumeration' && columnModel && (
                   <EnumFacetFilter
                     containerAs="Collapsible"

--- a/src/lib/containers/widgets/query-filter/FacetFilterControls.tsx
+++ b/src/lib/containers/widgets/query-filter/FacetFilterControls.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 import { isSingleNotSetValue } from '../../../utils/functions/queryUtils'
 import { QueryBundleRequest } from '../../../utils/synapseTypes'
@@ -22,8 +22,8 @@ import { EnumFacetFilter } from './EnumFacetFilter'
 import { FacetChip } from './FacetChip'
 import { RangeFacetFilter } from './RangeFacetFilter'
 
-export type QueryFilterProps = {
-  facetsToFilter?: string[]
+export type FacetFilterControlsProps = {
+  facetFiltersToShow?: string[]
 }
 
 const convertFacetToFacetColumnValuesRequest = (
@@ -137,19 +137,23 @@ export const applyChangesToRangeColumn = (
   onChangeFn(result)
 }
 
-export const QueryFilter: React.FunctionComponent<QueryFilterProps> = ({
-  facetsToFilter,
-}): JSX.Element => {
+export function FacetFilterControls(props: FacetFilterControlsProps) {
+  const { facetFiltersToShow } = props
   const { data, isLoadingNewBundle, getLastQueryRequest, executeQueryRequest } =
     useQueryContext()
 
-  const facets = data?.facets
+  const facets = data?.facets?.filter(
+    facet =>
+      // Don't show facets where there are no values
+      !isSingleNotSetValue(facet),
+  )
 
   let shownChips: string[]
-  if (facetsToFilter == null) {
+  if (facetFiltersToShow == null) {
     shownChips = facets?.map(facet => facet.columnName) ?? []
   } else {
-    shownChips = facetsToFilter
+    // The facets to show have been explicitly specified
+    shownChips = facetFiltersToShow
   }
   const [facetFiltersShown, setFacetFiltersShown] = React.useState<string[]>([])
   const { facetAliases, topLevelControlsState } = useQueryVisualizationContext()
@@ -201,9 +205,6 @@ export const QueryFilter: React.FunctionComponent<QueryFilterProps> = ({
             const columnModel = columnModels!.find(
               model => model.name === facet.columnName,
             )
-            if (isSingleNotSetValue(facet)) {
-              return
-            }
             return (
               <div className="QueryFilter__facet" key={facet.columnName}>
                 {facet.facetType === 'enumeration' && columnModel && (

--- a/src/lib/style/components/_query-filter.scss
+++ b/src/lib/style/components/_query-filter.scss
@@ -1,7 +1,7 @@
 @use '../abstracts/variables' as SRC;
 @use 'sass:map';
 
-.QueryFilter {
+.FacetFilterControls {
   &__title {
     font-weight: bold;
   }

--- a/src/lib/style/components/_query-wrapper-plot-nav.scss
+++ b/src/lib/style/components/_query-wrapper-plot-nav.scss
@@ -23,7 +23,7 @@
     .SRC-wrapper {
       // column (depends on if we are showing facet filters)
       .isShowingFacetFilters {
-        &.QueryFilter {
+        &.FacetFilterControls {
           grid-column: 1 / span 1;
           grid-row: 3 / span 100;
         }
@@ -76,7 +76,7 @@
     }
     // This is the placement for mobile.  See above for desktop position
     // (when showing these facet filters we render a 2 column layout)
-    .QueryFilter {
+    .FacetFilterControls {
       grid-row: 7 / span 1;
     }
     .FacetNav {
@@ -88,7 +88,7 @@
   }
 
   .SRC-wrapper .isHidingFacetFilters {
-    &.QueryFilter {
+    &.FacetFilterControls {
       grid-column: 1 / span 1;
       > * {
         display: none;
@@ -100,7 +100,7 @@
   }
 
   .SRC-wrapper {
-    > .QueryFilter,
+    > .FacetFilterControls,
     > .download-confirmation,
     > .FacetNav,
     > .QueryWrapperSearchInput,


### PR DESCRIPTION
- Rename QueryFilter component to FacetFilterControls to avoid confusion with the [QueryFilter](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/QueryFilter.html) object. The QueryFilter object is not used by the FacetFilterControls, since QueryFilters are not used with facets.
- Fix case where a facet chip would be shown when the corresponding facet control could not be shown