### PR TITLE
PORTALS-2157 - Rename facetAliases to columnAliases + related cleanup

### DIFF
--- a/src/__tests__/lib/containers/CardContainerLogic.test.tsx
+++ b/src/__tests__/lib/containers/CardContainerLogic.test.tsx
@@ -44,7 +44,7 @@ describe('it performs basic functionality', () => {
     unitDescription: 'files',
     type: SynapseConstants.STUDY,
     rgbIndex: 2,
-    facetAliases: { facetName: 'alias' },
+    columnAliases: { facetName: 'alias' },
   }
 
   it('renders without crashing', async () => {
@@ -89,7 +89,7 @@ describe('it performs basic functionality', () => {
         expect.objectContaining({
           rgbIndex: props.rgbIndex,
           unitDescription: props.unitDescription,
-          facetAliases: props.facetAliases,
+          columnAliases: props.columnAliases,
         }),
         expect.anything(),
       ),

--- a/src/__tests__/lib/containers/GenericCard.test.tsx
+++ b/src/__tests__/lib/containers/GenericCard.test.tsx
@@ -29,11 +29,20 @@ import {
   MOCK_USER_ID,
   MOCK_USER_NAME,
 } from '../../../mocks/user/mock_user_profile'
+import { QueryVisualizationContextProvider } from '../../../lib/containers/QueryVisualizationWrapper'
 
 const renderComponent = (props: GenericCardProps) => {
-  return render(<GenericCard {...props} />, {
-    wrapper: createWrapper(),
-  })
+  return render(
+    <GenericCard
+      {...props}
+      queryVisualizationContext={{
+        getColumnDisplayName: jest.fn().mockImplementation(col => col),
+      }}
+    />,
+    {
+      wrapper: createWrapper(),
+    },
+  )
 }
 
 mockAllIsIntersecting(true)

--- a/src/__tests__/lib/containers/QuerySortSelector.test.tsx
+++ b/src/__tests__/lib/containers/QuerySortSelector.test.tsx
@@ -24,14 +24,12 @@ import syn16787123Json from '../../../mocks/query/syn16787123'
 const renderComponent = (
   props: QuerySortSelectorProps,
   queryContext: Partial<QueryContextType>,
+  queryVisualizationContext: Partial<QueryVisualizationContextType>,
 ) => {
-  const defaultQueryVisualizationContext: Partial<QueryVisualizationContextType> =
-    {}
-
   return render(
     <QueryContextProvider queryContext={queryContext}>
       <QueryVisualizationContextProvider
-        queryVisualizationContext={defaultQueryVisualizationContext}
+        queryVisualizationContext={queryVisualizationContext}
       >
         <QuerySortSelector {...props} />
       </QueryVisualizationContextProvider>
@@ -69,7 +67,6 @@ describe('QuerySortSelector tests', () => {
       defaultDirection: 'ASC',
       sortableColumns: ['authors', 'title', 'createdOn', 'journal'],
     },
-    facetAliases: { journal: 'Open Access Journals' },
   }
 
   const queryContext: Partial<QueryContextType> = {
@@ -77,6 +74,10 @@ describe('QuerySortSelector tests', () => {
     hasNextPage: false,
     getLastQueryRequest: getLastQueryRequest,
     executeQueryRequest: executeQueryRequest,
+  }
+
+  const queryVisualizationContext: Partial<QueryVisualizationContextType> = {
+    getColumnDisplayName: jest.fn(() => 'Open Access Journals'),
   }
 
   const sortByOpenAccessJournals = async () => {
@@ -103,7 +104,7 @@ describe('QuerySortSelector tests', () => {
   }
 
   it('Executes query request on sort', async () => {
-    renderComponent(props, queryContext)
+    renderComponent(props, queryContext, queryVisualizationContext)
     await sortByOpenAccessJournals()
 
     const expectedSortItem: SortItem = {

--- a/src/__tests__/lib/containers/QuerySortSelector.test.tsx
+++ b/src/__tests__/lib/containers/QuerySortSelector.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { SynapseConstants } from '../../../lib/utils'
@@ -20,6 +20,7 @@ import {
   SortItem,
 } from '../../../lib/utils/synapseTypes'
 import syn16787123Json from '../../../mocks/query/syn16787123'
+import selectEvent from 'react-select-event'
 
 const renderComponent = (
   props: QuerySortSelectorProps,
@@ -84,7 +85,9 @@ describe('QuerySortSelector tests', () => {
     const input = screen.getByRole('combobox')
     await userEvent.type(input, 'journal')
     await screen.findAllByText(new RegExp('Open Access Journals'))
-    await userEvent.keyboard('{Enter}')
+    await act(async () => {
+      await selectEvent.select(input, 'Open Access Journals')
+    })
   }
 
   const verifyExpectedSortItem = async (expectedSortItem: SortItem) => {

--- a/src/__tests__/lib/containers/SynapseTable.test.tsx
+++ b/src/__tests__/lib/containers/SynapseTable.test.tsx
@@ -118,6 +118,7 @@ const queryVisualizationContext: Partial<QueryVisualizationContextType> = {
     showColumnSelectDropdown: false,
     showSqlEditor: false,
   },
+  getColumnDisplayName: jest.fn((col: string) => col),
 }
 
 const props: SynapseTableProps = {

--- a/src/__tests__/lib/containers/TotalQueryResults.test.tsx
+++ b/src/__tests__/lib/containers/TotalQueryResults.test.tsx
@@ -116,6 +116,7 @@ describe('TotalQueryResults test', () => {
 
   const queryVisualizationContext: Partial<QueryVisualizationContextType> = {
     unitDescription,
+    getColumnDisplayName: jest.fn(col => col),
   }
 
   it('Shows the display text, query count, and unit description', async () => {

--- a/src/__tests__/lib/containers/widgets/EnumFacetFilter.test.tsx
+++ b/src/__tests__/lib/containers/widgets/EnumFacetFilter.test.tsx
@@ -12,6 +12,7 @@ import { render, fireEvent, screen, waitFor } from '@testing-library/react'
 import { act } from '@testing-library/react'
 import { SynapseConstants } from '../../../../lib/utils'
 import { SynapseTestContext } from '../../../../mocks/MockSynapseContext'
+import { QueryVisualizationContextProvider } from '../../../../lib/containers/QueryVisualizationWrapper'
 
 const SynapseClient = require('../../../../lib/utils/SynapseClient')
 
@@ -83,7 +84,6 @@ function createTestProps(
     onClear: mockOnClear,
     ...overrides,
     containerAs: 'Collapsible',
-    facetAliases: {},
   }
 }
 
@@ -94,7 +94,13 @@ function init(overrides?: Partial<EnumFacetFilterProps>) {
   props = createTestProps(overrides)
   container = render(
     <SynapseTestContext>
-      <EnumFacetFilter {...props} />
+      <QueryVisualizationContextProvider
+        queryVisualizationContext={{
+          getColumnDisplayName: jest.fn(col => col),
+        }}
+      >
+        <EnumFacetFilter {...props} />
+      </QueryVisualizationContextProvider>
     </SynapseTestContext>,
   ).container
 }

--- a/src/__tests__/lib/containers/widgets/FacetChip.test.tsx
+++ b/src/__tests__/lib/containers/widgets/FacetChip.test.tsx
@@ -56,6 +56,7 @@ const defaultQueryVisualizationContext: Partial<QueryVisualizationContextType> =
       showColumnSelectDropdown: false,
       showSqlEditor: false,
     },
+    getColumnDisplayName: jest.fn(col => col),
   }
 
 function renderComponent(props: FacetChipProps) {

--- a/src/__tests__/lib/containers/widgets/RangeFacetFilter.test.tsx
+++ b/src/__tests__/lib/containers/widgets/RangeFacetFilter.test.tsx
@@ -14,6 +14,7 @@ import {
   ColumnType,
   FacetColumnResultRange,
 } from '../../../../lib/utils/synapseTypes'
+import { QueryVisualizationContextProvider } from '../../../../lib/containers/QueryVisualizationWrapper'
 
 let capturedOnChange:
   | ((range: { min: string | number; max: string | number }) => void)
@@ -85,7 +86,15 @@ describe('RangeFacetFilter tests', () => {
   let props: RangeFacetFilterProps
   function init(overrides?: RangeFacetFilterProps) {
     props = createTestProps(overrides)
-    return render(<RangeFacetFilter {...props} />)
+    return render(
+      <QueryVisualizationContextProvider
+        queryVisualizationContext={{
+          getColumnDisplayName: jest.fn(col => col),
+        }}
+      >
+        <RangeFacetFilter {...props} />
+      </QueryVisualizationContextProvider>,
+    )
   }
   describe('setting correct range value', () => {
     it('should set for any', () => {

--- a/src/__tests__/lib/containers/widgets/facet-nav/FacetNav.test.tsx
+++ b/src/__tests__/lib/containers/widgets/facet-nav/FacetNav.test.tsx
@@ -50,6 +50,7 @@ const defaultQueryVisualizationContext: Partial<QueryVisualizationContextType> =
       showDownloadConfirmation: false,
       showColumnSelectDropdown: false,
     },
+    getColumnDisplayName: jest.fn(col => col),
   }
 
 function getButtonOnFacet(

--- a/src/__tests__/lib/containers/widgets/facet-nav/FacetNavPanel.test.tsx
+++ b/src/__tests__/lib/containers/widgets/facet-nav/FacetNavPanel.test.tsx
@@ -70,7 +70,11 @@ function init(
         ...queryContextProps,
       }}
     >
-      <QueryVisualizationContextProvider queryVisualizationContext={{}}>
+      <QueryVisualizationContextProvider
+        queryVisualizationContext={{
+          getColumnDisplayName: jest.fn(col => col),
+        }}
+      >
         <FacetNavPanel {...props} />
       </QueryVisualizationContextProvider>
     </QueryContextProvider>,

--- a/src/__tests__/lib/containers/widgets/query-filter/FacetFilterControls.test.tsx
+++ b/src/__tests__/lib/containers/widgets/query-filter/FacetFilterControls.test.tsx
@@ -115,6 +115,7 @@ const defaultQueryVisualizationContext: Partial<QueryVisualizationContextType> =
       showColumnSelectDropdown: false,
       showSqlEditor: false,
     },
+    getColumnDisplayName: jest.fn(col => col),
   }
 
 let props: FacetFilterControlsProps

--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -8,11 +8,12 @@ import {
   MEDIUM_USER_CARD,
   OBSERVATION_CARD,
 } from '../utils/SynapseConstants'
-import { EntityHeader, Row, ColumnType } from '../utils/synapseTypes/'
+import { ColumnType, EntityHeader, Row } from '../utils/synapseTypes/'
 import { CardConfiguration } from './CardContainerLogic'
 import GenericCard from './GenericCard'
 import loadingScreen from './LoadingScreen'
 import { useInfiniteQueryContext } from './QueryContext'
+import { useQueryVisualizationContext } from './QueryVisualizationWrapper'
 import { Dataset, Funder } from './row_renderers'
 import {
   LoadingObservationCard,
@@ -27,7 +28,6 @@ export type CardContainerProps = {
   isHeader?: boolean
   isAlignToLeftNav?: boolean
   title?: string
-  facetAliases?: Record<string, string>
   isLoading?: boolean
   unitDescription?: string
 } & CardConfiguration
@@ -47,6 +47,9 @@ export const CardContainer = (props: CardContainerProps) => {
     infiniteQueryContext
 
   const queryRequest = getLastQueryRequest()
+
+  const queryVisualizationContext = useQueryVisualizationContext()
+
   const renderCard = (props: any, type: string) => {
     switch (type) {
       case DATASET:
@@ -54,7 +57,13 @@ export const CardContainer = (props: CardContainerProps) => {
       case FUNDER:
         return <Funder {...props} />
       case GENERIC_CARD:
-        return <GenericCard {...props} queryContext={infiniteQueryContext} />
+        return (
+          <GenericCard
+            {...props}
+            queryContext={infiniteQueryContext}
+            queryVisualizationContext={queryVisualizationContext}
+          />
+        )
       case OBSERVATION_CARD:
         return <ObservationCard {...props} />
       default:

--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -32,6 +32,22 @@ export type CardContainerProps = {
   unitDescription?: string
 } & CardConfiguration
 
+function Card(props: { propsToPass: any; type: string }) {
+  const { propsToPass, type } = props
+  switch (type) {
+    case DATASET:
+      return <Dataset {...propsToPass} />
+    case FUNDER:
+      return <Funder {...propsToPass} />
+    case GENERIC_CARD:
+      return <GenericCard {...propsToPass} />
+    case OBSERVATION_CARD:
+      return <ObservationCard {...propsToPass} />
+    default:
+      return <div /> // this should never happen
+  }
+}
+
 export const CardContainer = (props: CardContainerProps) => {
   const {
     isHeader = false,
@@ -49,27 +65,6 @@ export const CardContainer = (props: CardContainerProps) => {
   const queryRequest = getLastQueryRequest()
 
   const queryVisualizationContext = useQueryVisualizationContext()
-
-  const renderCard = (props: any, type: string) => {
-    switch (type) {
-      case DATASET:
-        return <Dataset {...props} />
-      case FUNDER:
-        return <Funder {...props} />
-      case GENERIC_CARD:
-        return (
-          <GenericCard
-            {...props}
-            queryContext={infiniteQueryContext}
-            queryVisualizationContext={queryVisualizationContext}
-          />
-        )
-      case OBSERVATION_CARD:
-        return <ObservationCard {...props} />
-      default:
-        return <div key={props.key} /> // this should never happen
-    }
-  }
 
   const ids = data?.queryResult!.queryResults.tableId
     ? [data?.queryResult.queryResults.tableId]
@@ -132,7 +127,7 @@ export const CardContainer = (props: CardContainerProps) => {
     // render the cards
     const cardsData = data.queryResult!.queryResults.rows
     cards = cardsData.length ? (
-      cardsData.map((rowData: Row) => {
+      cardsData.map((rowData: Row, index) => {
         const key = JSON.stringify(rowData.values)
         const propsForCard = {
           key,
@@ -147,9 +142,17 @@ export const CardContainer = (props: CardContainerProps) => {
           tableEntityConcreteType:
             tableEntityConcreteType[0] && tableEntityConcreteType[0].type,
           tableId: data?.queryResult!.queryResults.tableId,
+          queryContext: infiniteQueryContext,
+          queryVisualizationContext,
           ...rest,
         }
-        return renderCard(propsForCard, type)
+        return (
+          <Card
+            key={rowData.rowId ?? index}
+            propsToPass={propsForCard}
+            type={type}
+          />
+        )
       })
     ) : (
       <></>

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -153,7 +153,7 @@ export const CardContainerLogic = (props: CardContainerLogicProps) => {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
     entityId: parseEntityIdFromSqlStatement(sql),
     query: {
-      sql: props.sql,
+      sql: sql,
       limit: props.limit,
       sort: defaultSortItems,
     },

--- a/src/lib/containers/CardContainerLogic.tsx
+++ b/src/lib/containers/CardContainerLogic.tsx
@@ -1,8 +1,7 @@
-import * as React from 'react'
+import React from 'react'
 import { SynapseConstants } from '../utils'
 import {
   insertConditionsFromSearchParams,
-  KeyValue,
   parseEntityIdFromSqlStatement,
   SQLOperator,
 } from '../utils/functions/sqlFunctions'
@@ -11,7 +10,10 @@ import CardContainer from './CardContainer'
 import { ErrorBanner } from './ErrorBanner'
 import { GenericCardSchema, IconOptions } from './GenericCard'
 import { IconSvgOptions } from './IconSvg'
-import { QueryVisualizationWrapper } from './QueryVisualizationWrapper'
+import {
+  QueryVisualizationWrapper,
+  QueryVisualizationWrapperProps,
+} from './QueryVisualizationWrapper'
 import { QueryContextConsumer } from './QueryContext'
 import { InfiniteQueryWrapper } from './InfiniteQueryWrapper'
 import QuerySortSelector from './QuerySortSelector'
@@ -117,16 +119,17 @@ export type CardConfiguration = {
 export type CardContainerLogicProps = {
   limit?: number
   title?: string
-  unitDescription?: string
   sqlOperator?: SQLOperator
-  searchParams?: KeyValue
-  facetAliases?: Record<string, string>
-  rgbIndex?: number
+  searchParams?: Record<string, string>
   isHeader?: boolean
   isAlignToLeftNav?: boolean
   sql: string
   sortConfig?: SortConfiguration
-} & CardConfiguration
+} & CardConfiguration &
+  Pick<
+    QueryVisualizationWrapperProps,
+    'rgbIndex' | 'unitDescription' | 'columnAliases'
+  >
 
 /**
  * Class wraps around CardContainer and serves as a standalone logic container for rendering cards.
@@ -137,7 +140,7 @@ export const CardContainerLogic = (props: CardContainerLogicProps) => {
     props.searchParams,
     props.sqlOperator,
   )
-  const { sortConfig, facetAliases } = props
+  const { sortConfig, columnAliases } = props
   const defaultSortItems = sortConfig
     ? [
         {
@@ -150,7 +153,7 @@ export const CardContainerLogic = (props: CardContainerLogicProps) => {
     concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
     entityId: parseEntityIdFromSqlStatement(sql),
     query: {
-      sql: sql,
+      sql: props.sql,
       limit: props.limit,
       sort: defaultSortItems,
     },
@@ -170,14 +173,9 @@ export const CardContainerLogic = (props: CardContainerLogicProps) => {
       <QueryVisualizationWrapper
         rgbIndex={props.rgbIndex}
         unitDescription={props.unitDescription}
-        facetAliases={props.facetAliases}
+        columnAliases={columnAliases}
       >
-        {sortConfig && (
-          <QuerySortSelector
-            sortConfig={sortConfig}
-            facetAliases={facetAliases}
-          />
-        )}
+        {sortConfig && <QuerySortSelector sortConfig={sortConfig} />}
         <CardContainer {...props} />
         <QueryContextConsumer>
           {queryContext => <ErrorBanner error={queryContext?.error} />}

--- a/src/lib/containers/GenericCard.tsx
+++ b/src/lib/containers/GenericCard.tsx
@@ -7,7 +7,6 @@ import {
   DOI_REGEX,
   SYNAPSE_ENTITY_ID_REGEX,
 } from '../utils/functions/RegularExpressions'
-import { unCamelCase } from '../utils/functions/unCamelCase'
 import { SMALL_USER_CARD } from '../utils/SynapseConstants'
 import { SynapseContext } from '../utils/SynapseContext'
 import {
@@ -37,6 +36,7 @@ import { CardFooter, Icon } from './row_renderers/utils'
 import UserCard from './UserCard'
 import { FileHandleLink } from './widgets/FileHandleLink'
 import { ImageFileHandle } from './widgets/ImageFileHandle'
+import { QueryVisualizationContextType } from './QueryVisualizationWrapper'
 
 export type KeyToAlias = {
   key: string
@@ -56,7 +56,7 @@ export type GenericCardSchema = {
   icon?: string
   imageFileHandleColumnName?: string
   thumbnailRequiresPadding?: boolean
-  secondaryLabels?: any[]
+  secondaryLabels?: string[]
   link?: string
   dataTypeIconNames?: string
 }
@@ -68,7 +68,6 @@ export type IconOptions = {
 export type GenericCardProps = {
   selectColumns?: SelectColumn[]
   columnModels?: ColumnModel[]
-  facetAliases?: Record<string, string>
   iconOptions?: IconOptions
   useTypeColumnForIcon?: boolean
   isHeader?: boolean
@@ -81,6 +80,7 @@ export type GenericCardProps = {
   tableId: string | undefined
   columnIconOptions?: {}
   queryContext: QueryContextType
+  queryVisualizationContext: QueryVisualizationContextType
 } & CommonCardProps
 
 export type GenericCardState = {
@@ -638,11 +638,11 @@ export default class GenericCard extends React.Component<
       titleLinkConfig,
       ctaLinkConfig,
       labelLinkConfig,
-      facetAliases = {},
       descriptionConfig,
       rgbIndex,
       columnIconOptions,
       queryContext: { entity: table },
+      queryVisualizationContext: { getColumnDisplayName },
     } = this.props
     // GenericCard inherits properties from CommonCardProps so that the properties have the same name
     // and type, but theres one nuance which is that we can't override if one specific property will be
@@ -710,7 +710,7 @@ export default class GenericCard extends React.Component<
               rowData={data}
             />
           )
-          columnDisplayName = unCamelCase(columnName, facetAliases)
+          columnDisplayName = getColumnDisplayName(columnName)
         }
         const keyValue = [columnDisplayName, value, columnName]
         values.push(keyValue)
@@ -786,17 +786,14 @@ export default class GenericCard extends React.Component<
       )
     }
 
-    const titleSearchHandle = unCamelCase(
+    const titleSearchHandle = getColumnDisplayName(
       genericCardSchemaDefined.title,
-      facetAliases,
     )
-    const stubTitleSearchHandle = unCamelCase(
+    const stubTitleSearchHandle = getColumnDisplayName(
       genericCardSchemaDefined.subTitle,
-      facetAliases,
     )
-    const descriptionSubTitle = unCamelCase(
+    const descriptionSubTitle = getColumnDisplayName(
       genericCardSchemaDefined.description,
-      facetAliases,
     )
 
     let ctaHref: string | undefined = undefined,

--- a/src/lib/containers/QuerySortSelector.tsx
+++ b/src/lib/containers/QuerySortSelector.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { SortConfiguration } from './CardContainerLogic'
 import { useQueryContext } from './QueryContext'
 import { SortDirection, SortItem } from '../utils/synapseTypes'
-import { unCamelCase } from '../utils/functions/unCamelCase'
 import Typography from '../utils/typography/Typography'
 import Select from 'react-select'
 import {
@@ -10,19 +9,19 @@ import {
   findValueOption,
   Control,
 } from './entity/annotations/CustomSelectWidget'
+import { useQueryVisualizationContext } from './QueryVisualizationWrapper'
 
 export type QuerySortSelectorProps = {
   sortConfig: SortConfiguration
-  facetAliases?: Record<string, string>
 }
 
 const QuerySortSelector: React.FunctionComponent<QuerySortSelectorProps> = ({
   sortConfig,
-  facetAliases,
 }) => {
   const { defaultColumn, defaultDirection, sortableColumns } = sortConfig
   const queryContext = useQueryContext()
   const { getLastQueryRequest, executeQueryRequest } = queryContext
+  const { getColumnDisplayName } = useQueryVisualizationContext()
   const [sortColumn, setSortColumn] = useState<string | undefined>(
     defaultColumn,
   )
@@ -31,7 +30,7 @@ const QuerySortSelector: React.FunctionComponent<QuerySortSelectorProps> = ({
   const enumOptions: EnumOption[] = sortableColumns.map(sortableColumn => {
     return {
       value: sortableColumn,
-      label: unCamelCase(sortableColumn, facetAliases)!,
+      label: getColumnDisplayName(sortableColumn)!,
     }
   })
 

--- a/src/lib/containers/SearchV2.tsx
+++ b/src/lib/containers/SearchV2.tsx
@@ -1,7 +1,6 @@
 import { Collapse } from '@material-ui/core'
 import React from 'react'
 import { CSSTransition } from 'react-transition-group'
-import { unCamelCase } from '../utils/functions/unCamelCase'
 import { ColumnModel, ColumnType } from '../utils/synapseTypes'
 import {
   ColumnMultiValueFunction,
@@ -218,7 +217,10 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
       searchable,
       lockedColumn,
       queryContext: { data },
-      queryVisualizationContext: { topLevelControlsState, facetAliases },
+      queryVisualizationContext: {
+        topLevelControlsState,
+        getColumnDisplayName,
+      },
     } = this.props
     const { searchText, show, columnName } = this.state
     let searchColumns: string[] = []
@@ -302,7 +304,7 @@ class Search extends React.Component<InternalSearchProps, SearchState> {
                 <i> Search In Field: </i>
               </p>
               {searchColumns.map((name, index) => {
-                const displayName = unCamelCase(name, facetAliases)
+                const displayName = getColumnDisplayName(name)
                 const isSelected =
                   (columnName === '' && index === 0) || columnName === name
                 return (

--- a/src/lib/containers/home_page/featured-data/FacetPlotsCard.tsx
+++ b/src/lib/containers/home_page/featured-data/FacetPlotsCard.tsx
@@ -12,7 +12,6 @@ import {
 } from '../../../utils/synapseTypes'
 
 import { getColorPalette } from '../../../containers/ColorGradient'
-import { unCamelCase } from '../../../utils/functions/unCamelCase'
 import { useEffect, useState } from 'react'
 import loadingScreen from '../../LoadingScreen'
 import {
@@ -57,7 +56,7 @@ const FacetPlotsCard: React.FunctionComponent<FacetPlotsCardProps> = ({
 }: FacetPlotsCardProps): JSX.Element => {
   const { accessToken } = useSynapseContext()
   const { data, isLoadingNewBundle } = useQueryContext()
-  const { facetAliases, rgbIndex } = useQueryVisualizationContext()
+  const { getColumnDisplayName, rgbIndex } = useQueryVisualizationContext()
   const [facetPlotDataArray, setFacetPlotDataArray] = useState<GraphData[]>([])
   const [facetDataArray, setFacetDataArray] = useState<FacetColumnResult[]>([])
   const [selectedFacetValue, setSelectedFacetValue] = useState<string>('')
@@ -137,7 +136,7 @@ const FacetPlotsCard: React.FunctionComponent<FacetPlotsCardProps> = ({
       title ??
       (isShowingMultiplePlots
         ? selectedFacetValue
-        : unCamelCase(facetDataArray[0].columnName, facetAliases))
+        : getColumnDisplayName(facetDataArray[0].columnName))
     return (
       <div className="FacetPlotsCard cardContainer">
         <div
@@ -162,10 +161,7 @@ const FacetPlotsCard: React.FunctionComponent<FacetPlotsCardProps> = ({
                 {isShowingMultiplePlots && (
                   <div className="FacetPlotsCard__body__facetname">
                     <span>
-                      {unCamelCase(
-                        facetDataArray[index].columnName,
-                        facetAliases,
-                      )}
+                      {getColumnDisplayName(facetDataArray[index].columnName)}
                     </span>
                   </div>
                 )}

--- a/src/lib/containers/home_page/featured-data/QueryPerFacetPlotsCard.tsx
+++ b/src/lib/containers/home_page/featured-data/QueryPerFacetPlotsCard.tsx
@@ -12,7 +12,6 @@ export type QueryPerFacetPlotsCardProps = {
   description?: string
   rgbIndex?: number
   facetsToPlot?: string[]
-  facetAliases?: Record<string, string>
   selectFacetColumnName: string
   selectFacetColumnValue: string
   sql?: string

--- a/src/lib/containers/home_page/featured-data/SingleQueryFacetPlotsCards.tsx
+++ b/src/lib/containers/home_page/featured-data/SingleQueryFacetPlotsCards.tsx
@@ -10,7 +10,7 @@ import FacetPlotsCard from './FacetPlotsCard'
 export type SingleQueryFacetPlotsCardsProps = {
   rgbIndex?: number
   facetsToPlot?: string[]
-  facetAliases?: Record<string, string>
+  columnAliases?: Record<string, string>
   sql?: string
 }
 export function getQueryRequest(sql: string): QueryBundleRequest {
@@ -33,14 +33,14 @@ export function getQueryRequest(sql: string): QueryBundleRequest {
 const SingleQueryFacetPlotsCards: React.FunctionComponent<
   SingleQueryFacetPlotsCardsProps
 > = props => {
-  const { sql, facetsToPlot, rgbIndex, facetAliases } = props
+  const { sql, facetsToPlot, rgbIndex, columnAliases } = props
   const initQueryRequest: QueryBundleRequest = getQueryRequest(sql!)
   return (
     <div className="SingleQueryFacetPlotsCards">
       <QueryWrapper initQueryRequest={initQueryRequest}>
         <QueryVisualizationWrapper
           rgbIndex={rgbIndex}
-          facetAliases={facetAliases}
+          columnAliases={columnAliases}
         >
           <QueryWrapperErrorBanner />
           {facetsToPlot?.map(facetName => {

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -64,7 +64,7 @@ type OwnProps = {
   hideSqlEditorControl?: boolean
   defaultColumn?: string
   defaultShowSearchBox?: boolean
-  lockedColumn: QueryWrapperProps['lockedColumn']
+  lockedColumn?: QueryWrapperProps['lockedColumn']
 } & Omit<TopLevelControlsProps, 'entityId'> &
   Pick<
     QueryVisualizationWrapperProps,

--- a/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
+++ b/src/lib/containers/query_wrapper_plot_nav/QueryWrapperPlotNav.tsx
@@ -16,8 +16,12 @@ import ModalDownload from '../ModalDownload'
 import {
   QueryVisualizationContextConsumer,
   QueryVisualizationWrapper,
+  QueryVisualizationWrapperProps,
 } from '../QueryVisualizationWrapper'
-import { QueryWrapper as PaginatedQueryWrapper } from '../QueryWrapper'
+import {
+  QueryWrapper as PaginatedQueryWrapper,
+  QueryWrapperProps,
+} from '../QueryWrapper'
 import { InfiniteQueryWrapper } from '../InfiniteQueryWrapper'
 import { QueryContextConsumer } from '../QueryContext'
 import { QueryWrapperErrorBanner } from '../QueryWrapperErrorBanner'
@@ -53,19 +57,23 @@ type OwnProps = {
     SearchV2Props,
     'queryContext' | 'queryVisualizationContext'
   >
-  rgbIndex?: number
   facetsToPlot?: string[]
   facetsToFilter?: string[]
-  visibleColumnCount?: number
-  facetAliases?: Record<string, string>
   hideDownload?: boolean
   hideQueryCount?: boolean
   hideSqlEditorControl?: boolean
   defaultColumn?: string
-  defaultShowFacetVisualization?: boolean
   defaultShowSearchBox?: boolean
-  showLastUpdatedOn?: boolean
-} & Omit<TopLevelControlsProps, 'entityId'>
+  lockedColumn: QueryWrapperProps['lockedColumn']
+} & Omit<TopLevelControlsProps, 'entityId'> &
+  Pick<
+    QueryVisualizationWrapperProps,
+    | 'defaultShowFacetVisualization'
+    | 'visibleColumnCount'
+    | 'columnAliases'
+    | 'rgbIndex'
+    | 'showLastUpdatedOn'
+  >
 
 type SearchParams = {
   searchParams?: {
@@ -144,7 +152,7 @@ const QueryWrapperPlotNav: React.FunctionComponent<QueryWrapperPlotNavProps> = (
         <QueryVisualizationWrapper
           unitDescription={'results'}
           rgbIndex={props.rgbIndex}
-          facetAliases={props.facetAliases}
+          columnAliases={props.columnAliases}
           visibleColumnCount={props.visibleColumnCount}
           defaultShowFacetVisualization={props.defaultShowFacetVisualization}
           defaultShowSearchBar={

--- a/src/lib/containers/table/StandaloneQueryWrapper.tsx
+++ b/src/lib/containers/table/StandaloneQueryWrapper.tsx
@@ -20,6 +20,7 @@ import { useSynapseContext } from '../../utils/SynapseContext'
 import {
   QueryVisualizationContextConsumer,
   QueryVisualizationWrapper,
+  QueryVisualizationWrapperProps,
 } from '../QueryVisualizationWrapper'
 import { isTable } from '../../utils/functions/EntityTypeUtils'
 import LastUpdatedOn from '../query_wrapper_plot_nav/LastUpdatedOn'
@@ -39,16 +40,16 @@ export type QueryCount = {
 
 type OwnProps = {
   sql: string
-  rgbIndex?: number
-  unitDescription?: string
-  facetAliases?: Record<string, string>
   showTopLevelControls?: boolean
   searchConfiguration?: Omit<
     SearchV2Props,
     'queryContext' | 'queryVisualizationContext'
   >
-  showLastUpdatedOn?: boolean
-} & Omit<TopLevelControlsProps, 'entityId'>
+} & Omit<TopLevelControlsProps, 'entityId'> &
+  Pick<
+    QueryVisualizationWrapperProps,
+    'rgbIndex' | 'unitDescription' | 'columnAliases' | 'showLastUpdatedOn'
+  >
 
 export type StandaloneQueryWrapperProps = Partial<
   Omit<

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -44,7 +44,6 @@ import {
   applyChangesToValuesColumn,
   applyMultipleChangesToValuesColumn,
 } from '../widgets/query-filter/FacetFilterControls'
-import { unCamelCase } from './../../utils/functions/unCamelCase'
 import SearchResultsNotFound from './SearchResultsNotFound'
 import { ICON_STATE } from './SynapseTableConstants'
 import {
@@ -774,7 +773,7 @@ export default class SynapseTable extends React.Component<
   ) {
     const { sortedColumnSelection, columnIconSortState } = this.state
     const {
-      queryVisualizationContext: { facetAliases = {}, columnsToShowInTable },
+      queryVisualizationContext: { getColumnDisplayName, columnsToShowInTable },
       queryContext: { lockedColumn },
     } = this.props
     const tableColumnHeaderElements: JSX.Element[] = headers.map(
@@ -806,9 +805,8 @@ export default class SynapseTable extends React.Component<
             ? 'SRC-selected-table-icon tool-icon'
             : 'SRC-primary-text-color tool-icon'
           const sortSpanBackgoundClass = `SRC-tableHead SRC-hand-cursor SRC-sortPadding SRC-primary-background-color-hover  ${isSelectedSpanClass}`
-          const displayColumnName: string | undefined = unCamelCase(
+          const displayColumnName: string | undefined = getColumnDisplayName(
             column.name,
-            facetAliases,
           )
           const columnModel = columnModels.find(el => el.name === column.name)!
           const isLockedColumn =
@@ -831,7 +829,6 @@ export default class SynapseTable extends React.Component<
                       facet,
                       columnModel,
                       lastQueryRequest,
-                      facetAliases,
                     )}
                   {this.isSortableColumn(column.columnType) && (
                     <span
@@ -954,14 +951,12 @@ export default class SynapseTable extends React.Component<
     facetColumnResult: FacetColumnResultValues,
     columnModel: ColumnModel,
     lastQueryRequest: QueryBundleRequest,
-    facetAliases?: Record<string, string>,
   ) {
     return (
       <EnumFacetFilter
         containerAs="Dropdown"
         facetValues={facetColumnResult.facetValues}
         columnModel={columnModel}
-        facetAliases={facetAliases}
         onChange={(facetNamesMap: Record<string, string>) => {
           applyMultipleChangesToValuesColumn(
             lastQueryRequest,

--- a/src/lib/containers/table/TopLevelControls.tsx
+++ b/src/lib/containers/table/TopLevelControls.tsx
@@ -97,7 +97,6 @@ const TopLevelControls = (props: TopLevelControlsProps) => {
     setTopLevelControlsState,
     columnsToShowInTable,
     selectedRowIndices,
-    facetAliases,
     setColumnsToShowInTable,
   } = useQueryVisualizationContext()
 
@@ -237,7 +236,6 @@ const TopLevelControls = (props: TopLevelControlsProps) => {
               isColumnSelected={columnsToShowInTable}
               toggleColumnSelection={toggleColumnSelection}
               darkTheme={true}
-              facetAliases={facetAliases}
             />
           )}
         </div>

--- a/src/lib/containers/table/table-top/ColumnSelection.tsx
+++ b/src/lib/containers/table/table-top/ColumnSelection.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react'
 import { Dropdown } from 'react-bootstrap'
 import { ElementWithTooltip } from '../../widgets/ElementWithTooltip'
 import { SelectColumn } from '../../../utils/synapseTypes/'
-import { unCamelCase } from '../../../utils/functions/unCamelCase'
 import IconSvg from '../../IconSvg'
+import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
 
 type ColumnSelectionProps = {
   headers?: SelectColumn[]
@@ -16,7 +16,6 @@ type ColumnSelectionProps = {
   onChange?: () => void
   toggleColumnSelection: (name: string) => void
   darkTheme?: boolean
-  facetAliases?: Record<string, string>
 }
 
 type MetadataEvent = {
@@ -28,14 +27,9 @@ const tooltipColumnSelectionId = 'addAndRemoveColumns'
 export const ColumnSelection: React.FunctionComponent<ColumnSelectionProps> = (
   props: ColumnSelectionProps,
 ) => {
-  const {
-    headers,
-    isColumnSelected,
-    toggleColumnSelection,
-    darkTheme,
-    facetAliases,
-  } = props
+  const { headers, isColumnSelected, toggleColumnSelection, darkTheme } = props
 
+  const { getColumnDisplayName } = useQueryVisualizationContext()
   const [show, setShow] = useState(false)
   const onDropdownClick = (
     _show: boolean,
@@ -93,7 +87,7 @@ export const ColumnSelection: React.FunctionComponent<ColumnSelectionProps> = (
               <span className={maybeShowPrimaryColor} style={iconStyle}>
                 <IconSvg options={{ icon: 'check', size: '14px' }} />
               </span>
-              {unCamelCase(name, facetAliases)}
+              {getColumnDisplayName(name)}
             </Dropdown.Item>
           )
         })}

--- a/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
@@ -9,7 +9,6 @@ import { SkeletonInlineBlock } from '../../../assets/skeletons/SkeletonInlineBlo
 import getColorPalette from '../../../containers/ColorGradient'
 import { ElementWithTooltip } from '../../../containers/widgets/ElementWithTooltip'
 import { SynapseClient, SynapseConstants } from '../../../utils'
-import { unCamelCase } from '../../../utils/functions/unCamelCase'
 import { useSynapseContext } from '../../../utils/SynapseContext'
 import {
   ColumnType,
@@ -355,12 +354,12 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
   const { accessToken } = useSynapseContext()
   const { data, isLoadingNewBundle, getLastQueryRequest } = useQueryContext()
 
-  const { facetAliases } = useQueryVisualizationContext()
+  const { getColumnDisplayName } = useQueryVisualizationContext()
 
   const [plotData, setPlotData] = useState<GraphData>()
   const [showModal, setShowModal] = useState(false)
 
-  const plotTitle = unCamelCase(facetToPlot.columnName, facetAliases)
+  const plotTitle = getColumnDisplayName(facetToPlot.columnName)
 
   const getColumnType = useCallback(
     (): ColumnType | undefined =>
@@ -468,7 +467,6 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
                       el => el.name === facetToPlot.columnName,
                     )!
                   }
-                  facetAliases={facetAliases}
                   onChange={(facetNamesMap: Record<string, string>) => {
                     applyMultipleChangesToValuesColumn(
                       getLastQueryRequest(),
@@ -520,7 +518,6 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
                       el => el.name === facetToPlot.columnName,
                     )!
                   }
-                  facetAliases={facetAliases}
                   onChange={(facetNamesMap: Record<string, string>) => {
                     applyMultipleChangesToValuesColumn(
                       getLastQueryRequest(),

--- a/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
+++ b/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
@@ -2,13 +2,13 @@ import { Close } from '@material-ui/icons'
 import React from 'react'
 import { FunctionComponent } from 'react'
 import { SynapseConstants } from '../../../utils'
-import { unCamelCase } from '../../../utils/functions/unCamelCase'
 import {
   FacetColumnResult,
   FacetColumnResultRange,
   FacetColumnResultValueCount,
 } from '../../../utils/synapseTypes'
 import { ElementWithTooltip } from '../ElementWithTooltip'
+import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
 
 export type FacetWithSelection = {
   facet: FacetColumnResult
@@ -31,6 +31,7 @@ export type SelectionCriteriaPillProps = (
 const SelectionCriteriaPill: FunctionComponent<
   SelectionCriteriaPillProps
 > = props => {
+  const { getColumnDisplayName } = useQueryVisualizationContext()
   let innerText,
     tooltipText: string | null = ''
   if ('facetWithSelection' in props) {
@@ -45,8 +46,8 @@ const SelectionCriteriaPill: FunctionComponent<
         .selectedMin!} 
         - ${(facetWithSelection.facet as FacetColumnResultRange).selectedMax!}`
     }
-    tooltipText = `${unCamelCase(
-      facetWithSelection.facet.columnName!,
+    tooltipText = `${getColumnDisplayName(
+      facetWithSelection.facet.columnName,
     )}: ${innerText}`
   } else if ('filter' in props) {
     const { filter } = props
@@ -62,8 +63,12 @@ const SelectionCriteriaPill: FunctionComponent<
 
     // If searching in a specific column, use different inner/tooltip text
     if (filter.columnName) {
-      innerText = `"${filterValue}" in ${unCamelCase(filter?.columnName)}`
-      tooltipText = `${unCamelCase(filter?.columnName)}: ${filterValue}`
+      innerText = `"${filterValue}" in ${getColumnDisplayName(
+        filter?.columnName,
+      )}`
+      tooltipText = `${getColumnDisplayName(
+        filter?.columnName,
+      )}: ${filterValue}`
     }
   } else {
     console.warn(

--- a/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
@@ -20,7 +20,6 @@ export type EnumFacetFilterProps = {
   columnModel: SelectColumn
   onChange: (facetNamesMap: Record<string, string>) => void
   onClear: () => void
-  facetAliases?: Record<string, string>
   containerAs?: 'Collapsible' | 'Dropdown'
   dropdownType?: 'Icon' | 'SelectBox'
   collapsed?: boolean
@@ -79,7 +78,6 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
   columnModel,
   onClear,
   onChange,
-  facetAliases,
   containerAs = 'Collapsible',
   dropdownType = 'Icon',
   collapsed = false,
@@ -329,7 +327,6 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
     return (
       <>
         <FacetFilterHeader
-          facetAliases={facetAliases}
           isCollapsed={isCollapsed}
           label={columnModel.name}
           onClick={(isCollapsed: boolean) => setIsCollapsed(isCollapsed)}

--- a/src/lib/containers/widgets/query-filter/FacetChip.tsx
+++ b/src/lib/containers/widgets/query-filter/FacetChip.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { unCamelCase } from '../../../utils/functions/unCamelCase'
 import { FacetColumnResult } from '../../../utils/synapseTypes'
 import IconSvg from '../../IconSvg'
 import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
@@ -15,10 +14,10 @@ export const FacetChip: React.FC<FacetChipProps> = ({
   isChecked,
   onClick,
 }) => {
-  const { facetAliases } = useQueryVisualizationContext()
+  const { getColumnDisplayName } = useQueryVisualizationContext()
   return (
     <button className={`Chip ${isChecked ? 'Checked' : ''}`} onClick={onClick}>
-      {unCamelCase(facet.columnName, facetAliases)}
+      {getColumnDisplayName(facet.columnName)}
       <IconSvg
         options={{
           icon: isChecked ? 'check' : 'add',

--- a/src/lib/containers/widgets/query-filter/FacetFilterControls.tsx
+++ b/src/lib/containers/widgets/query-filter/FacetFilterControls.tsx
@@ -156,7 +156,7 @@ export function FacetFilterControls(props: FacetFilterControlsProps) {
     shownChips = facetFiltersToShow
   }
   const [facetFiltersShown, setFacetFiltersShown] = React.useState<string[]>([])
-  const { facetAliases, topLevelControlsState } = useQueryVisualizationContext()
+  const { topLevelControlsState } = useQueryVisualizationContext()
   const { showFacetFilter } = topLevelControlsState
 
   /**
@@ -216,7 +216,6 @@ export function FacetFilterControls(props: FacetFilterControlsProps) {
                     collapsed={false}
                     facetValues={facet.facetValues}
                     columnModel={columnModel}
-                    facetAliases={facetAliases}
                     onChange={(facetNamesMap: Record<string, string>) =>
                       applyMultipleChangesToValuesColumn(
                         lastRequest,
@@ -238,7 +237,6 @@ export function FacetFilterControls(props: FacetFilterControlsProps) {
                   <RangeFacetFilter
                     facetResult={facet}
                     columnModel={columnModel}
-                    facetAliases={facetAliases}
                     collapsed={false}
                     onChange={(values: string[]) =>
                       applyChangesToRangeColumn(

--- a/src/lib/containers/widgets/query-filter/FacetFilterHeader.tsx
+++ b/src/lib/containers/widgets/query-filter/FacetFilterHeader.tsx
@@ -1,21 +1,22 @@
 import * as React from 'react'
-import { unCamelCase } from '../../../utils/functions/unCamelCase'
 import IconPlus from '../../../assets/icons/IconPlus'
 import IconMinus from '../../../assets/icons/IconMinus'
+import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
 
 export type FacetFilterHeaderProps = {
   label: string
   isCollapsed: boolean
-  onClick: Function
-  facetAliases: {} | undefined
+  onClick: (newValue: boolean) => void
 }
+
 export const FacetFilterHeader: React.FunctionComponent<
   FacetFilterHeaderProps
-> = ({ label, isCollapsed, onClick, facetAliases }: FacetFilterHeaderProps) => {
+> = ({ label, isCollapsed, onClick }: FacetFilterHeaderProps) => {
+  const { getColumnDisplayName } = useQueryVisualizationContext()
   return (
     <div className="FacetFilterHeader">
       <label className="FacetFilterHeader__label">
-        {unCamelCase(label, facetAliases)}
+        {getColumnDisplayName(label)}
       </label>
       <button
         className="FacetFilterHeader__collapseToggleBtn"

--- a/src/lib/containers/widgets/query-filter/RangeFacetFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/RangeFacetFilter.tsx
@@ -22,7 +22,6 @@ export type RangeFacetFilterProps = {
   facetResult: FacetColumnResultRange
   columnModel: SelectColumn
   onChange: (range: (RadioValuesEnum | number | string | undefined)[]) => void
-  facetAliases?: Record<string, string>
   collapsed?: boolean
 }
 
@@ -37,7 +36,6 @@ export const RangeFacetFilter: React.FunctionComponent<
   facetResult,
   columnModel,
   onChange,
-  facetAliases,
   collapsed = false,
 }: RangeFacetFilterProps) => {
   const [isCollapsed, setIsCollapsed] = useState<boolean>(collapsed)
@@ -88,7 +86,6 @@ export const RangeFacetFilter: React.FunctionComponent<
         isCollapsed={isCollapsed}
         label={columnModel.name}
         onClick={(isCollapsed: boolean) => setIsCollapsed(isCollapsed)}
-        facetAliases={facetAliases}
       ></FacetFilterHeader>
       <Collapse in={!isCollapsed}>
         <RadioGroup

--- a/src/lib/utils/functions/unCamelCase.ts
+++ b/src/lib/utils/functions/unCamelCase.ts
@@ -1,19 +1,5 @@
-// SWC-5982: check once, which means this value should be set before loading the react component
-const forceDisplayOriginalColumnName =
-  localStorage.getItem('force-display-original-column-names') === 'true'
-
-export const unCamelCase = (
-  str: string | undefined,
-  facetAliases?: Record<string, string>,
-): string | undefined => {
+export const unCamelCase = (str: string): string => {
   // https://stackoverflow.com/questions/4149276/how-to-convert-camelcase-to-camel-case
-  // SWC-5982: if force-display-original-column-names is set, then just return the string
-  if (!str || forceDisplayOriginalColumnName) {
-    return str
-  }
-  if (facetAliases?.[str]) {
-    return facetAliases[str]
-  }
   return (
     str
       // insert a space between lower & upper


### PR DESCRIPTION
- Rename facetAliases to columnAliases (since it applies to all columns, regardless of whether they are faceted)
- columnAliases are only used within QueryVisualizationWrapper
- QueryVisualizationWrapper now passes `getColumnDisplayName` through context
- Alias consumers now use `getColumnDisplayName`
- Refactor unrelated logic from unCamelCase to QueryVisualizationWrapper