### PR TITLE
PORTALS-2157: Small style fix

### DIFF
--- a/src/lib/style/components/_query-wrapper-plot-nav.scss
+++ b/src/lib/style/components/_query-wrapper-plot-nav.scss
@@ -118,7 +118,6 @@
 
   .TotalQueryResults.hasFilters {
     background-color: map.get(SRC.$colors, 'gray-100');
-    border-top: 1px solid map.get(SRC.$colors, 'gray-300');
     border-bottom: 1px solid map.get(SRC.$colors, 'gray-300');
     padding-left: 15px;
     padding-bottom: 13px;
@@ -147,12 +146,13 @@
     display: flex;
     justify-content: space-between;
     font-weight: bold;
-    margin: 0px 0px 0px 15px;
+    padding: 10px 10px 10px 15px;
     p {
       margin-top: 0px;
     }
   }
   background-color: rgba(map.get(SRC.$primary-color-palette, 500), 0.05);
+  border-bottom: 1px solid map.get(SRC.$colors, 'gray-300');
   &__showhidefacetfilters {
     display: none;
   }


### PR DESCRIPTION
The TopLevelControls bar needs more padding to match the design. Looks weird right now because it doesn't have enough space.

Also moved the border from the top of the filter panel to the bottom of the top bar so it is always shown.

Before:
![image](https://user-images.githubusercontent.com/17580037/197806285-5fe13244-3607-4bf0-bfdf-e2cca43bc6f6.png)

![image](https://user-images.githubusercontent.com/17580037/197806348-3dc6d194-16b8-404a-a544-49514de6d597.png)


After (ignore incorrect label on facet pill): 

![image](https://user-images.githubusercontent.com/17580037/197806035-e19bded6-5cb0-44bc-95ed-f5aafc2ed3a4.png)

![image](https://user-images.githubusercontent.com/17580037/197806088-0885f1aa-e5c5-4d84-a62e-cfbe95457a67.png)
