### PR TITLE
PORTALS-2157: Refactor TotalQueryResults and SelectionCriteriaPill

### DIFF
--- a/src/__tests__/lib/containers/widgets/ElementWithTooltip.test.tsx
+++ b/src/__tests__/lib/containers/widgets/ElementWithTooltip.test.tsx
@@ -18,7 +18,6 @@ function createTestProps(
     image: { icon: 'check' },
     callbackFn: mockCallback,
     tooltipText: 'my tooltip',
-    idForToolTip: 'someId',
     ...overrides,
   }
 }

--- a/src/lib/containers/InfiniteQueryWrapper.tsx
+++ b/src/lib/containers/InfiniteQueryWrapper.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   isFacetAvailable,
   hasResettableFilters as isFilteredUtil,
@@ -58,6 +58,11 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
     getInitQueryRequest,
     getLastQueryRequest,
     setQuery,
+    resetQuery,
+    removeQueryFilter,
+    removeValueFromQueryFilter,
+    removeSelectedFacet,
+    removeValueFromSelectedFacet,
   } = useImmutableTableQuery({
     initQueryRequest,
     componentIndex,
@@ -186,6 +191,13 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
     return isFilteredUtil(request.query, lockedColumn)
   }, [getLastQueryRequest, lockedColumn])
 
+  const getColumnModel = useCallback(
+    (columnName: string) => {
+      return data?.columnModels?.find(cm => cm.name === columnName) ?? null
+    },
+    [data?.columnModels],
+  )
+
   const context: InfiniteQueryContextType = {
     data: dataWithLockedColumnFacetRemoved,
     isLoadingNewPage: isFetchingNextPage,
@@ -203,6 +215,13 @@ export function InfiniteQueryWrapper(props: InfiniteQueryWrapperProps) {
     goToNextPage,
     goToPreviousPage,
     hasResettableFilters,
+    resetQuery,
+    removeQueryFilter,
+    removeValueFromQueryFilter,
+    removeSelectedFacet,
+    removeValueFromSelectedFacet,
+    lockedColumn,
+    getColumnModel,
   }
   /**
    * Render the children without any formatting

--- a/src/lib/containers/QueryContext.tsx
+++ b/src/lib/containers/QueryContext.tsx
@@ -3,10 +3,12 @@ import { createContext, useContext } from 'react'
 import { SynapseClientError } from '../utils/SynapseClientError'
 import {
   AsynchronousJobStatus,
+  ColumnModel,
   QueryBundleRequest,
   QueryResultBundle,
   Table,
 } from '../utils/synapseTypes'
+import { ImmutableTableQueryResult } from './useImmutableTableQuery'
 
 export const QUERY_FILTERS_EXPANDED_CSS: string = 'isShowingFacetFilters'
 export const QUERY_FILTERS_COLLAPSED_CSS: string = 'isHidingFacetFilters'
@@ -32,6 +34,14 @@ export type QueryContextType = {
   getInitQueryRequest: () => QueryBundleRequest
   /** Updates the current query with the passed request */
   executeQueryRequest: (param: QueryBundleRequest) => void
+  /** Resets the query to its initial state, clearing all filters added by the user */
+  resetQuery: ImmutableTableQueryResult['resetQuery']
+  removeSelectedFacet: ImmutableTableQueryResult['removeSelectedFacet']
+  removeValueFromSelectedFacet: ImmutableTableQueryResult['removeValueFromSelectedFacet']
+  /** Removes a matching QueryFilter from the query */
+  removeQueryFilter: ImmutableTableQueryResult['removeQueryFilter']
+  /** Removes a value from a QueryFilter. If no more values remain in the filter, the filter is also removed */
+  removeValueFromQueryFilter: ImmutableTableQueryResult['removeValueFromQueryFilter']
   /** Returns true when loading a brand-new query result bundle. Will not be true when just loading the next page of query results. */
   isLoadingNewBundle: boolean
   /** The error returned by the query request, if one is encountered */
@@ -48,6 +58,7 @@ export type QueryContextType = {
   lockedColumn?: LockedColumn
   /** Returns true iff the current request has resettable filters applied via facet filters or additionalFilters. Excludes filters applied to a locked column */
   hasResettableFilters: boolean
+  getColumnModel: (columnName: string) => ColumnModel | null
 }
 
 export type PaginatedQueryContextType = QueryContextType & {

--- a/src/lib/containers/QueryVisualizationWrapper.tsx
+++ b/src/lib/containers/QueryVisualizationWrapper.tsx
@@ -30,6 +30,7 @@ export type QueryVisualizationContextType = {
   showLastUpdatedOn?: boolean
   /** Given a column name, return the display name for the column */
   getColumnDisplayName: (columnName?: string) => string | undefined
+  /** Given a cell value and a column type, returns the displayed value for the data */
   getDisplayValue: (value: string, columnType: ColumnType) => string
   /** React node to display in place of cards/table when there are no results. */
   NoContentPlaceholder: () => JSX.Element

--- a/src/lib/containers/QueryVisualizationWrapper.tsx
+++ b/src/lib/containers/QueryVisualizationWrapper.tsx
@@ -12,6 +12,8 @@ import { NoContentPlaceholderType } from './table/NoContentPlaceholderType'
 import SearchResultsNotFound from './table/SearchResultsNotFound'
 import ThisTableIsEmpty from './table/TableIsEmpty'
 import { unCamelCase } from '../utils/functions/unCamelCase'
+import { ColumnType } from '../utils/synapseTypes'
+import { getDisplayValue } from '../utils/functions/getDataFromFromStorage'
 
 export type QueryVisualizationContextType = {
   topLevelControlsState: TopLevelControlsState
@@ -28,6 +30,7 @@ export type QueryVisualizationContextType = {
   showLastUpdatedOn?: boolean
   /** Given a column name, return the display name for the column */
   getColumnDisplayName: (columnName?: string) => string | undefined
+  getDisplayValue: (value: string, columnType: ColumnType) => string
   /** React node to display in place of cards/table when there are no results. */
   NoContentPlaceholder: () => JSX.Element
 }
@@ -201,6 +204,7 @@ export function QueryVisualizationWrapper(
     unitDescription: props.unitDescription,
     showLastUpdatedOn: props.showLastUpdatedOn,
     getColumnDisplayName,
+    getDisplayValue,
     NoContentPlaceholder,
   }
   /**

--- a/src/lib/containers/QueryWrapper.tsx
+++ b/src/lib/containers/QueryWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { useMemo, useState } from 'react'
 import { useDeepCompareEffectNoCheck } from 'use-deep-compare-effect'
 import {
@@ -64,6 +64,11 @@ export function QueryWrapper(props: QueryWrapperProps) {
     pageSize,
     goToPage,
     setPageSize,
+    resetQuery,
+    removeSelectedFacet,
+    removeValueFromSelectedFacet,
+    removeQueryFilter,
+    removeValueFromQueryFilter,
   } = useImmutableTableQuery({
     initQueryRequest,
     shouldDeepLink,
@@ -108,7 +113,7 @@ export function QueryWrapper(props: QueryWrapperProps) {
     : true
 
   /**
-   * remove a particular facet name (e.g. study) and all possible values based on the parameter specified in the url
+   * Remove a particular facet name (e.g. study) and all possible values based on the parameter specified in the url
    * this is to remove the facet from the charts, search and filter.
    * @return data: QueryResultBundle
    */
@@ -120,6 +125,13 @@ export function QueryWrapper(props: QueryWrapperProps) {
     const request = getLastQueryRequest()
     return hasResettableFiltersUtil(request.query, lockedColumn)
   }, [getLastQueryRequest, lockedColumn])
+
+  const getColumnModel = useCallback(
+    (columnName: string) => {
+      return data?.columnModels?.find(cm => cm.name === columnName) ?? null
+    },
+    [data?.columnModels],
+  )
 
   const context: PaginatedQueryContextType = {
     data: dataWithLockedColumnFacetRemoved,
@@ -136,6 +148,13 @@ export function QueryWrapper(props: QueryWrapperProps) {
     asyncJobStatus: currentAsyncStatus,
     goToPage,
     hasResettableFilters,
+    removeSelectedFacet,
+    removeValueFromSelectedFacet,
+    resetQuery,
+    removeQueryFilter,
+    removeValueFromQueryFilter,
+    lockedColumn,
+    getColumnModel,
   }
   /**
    * Render the children without any formatting

--- a/src/lib/containers/TotalQueryResults.tsx
+++ b/src/lib/containers/TotalQueryResults.tsx
@@ -1,51 +1,14 @@
-import { cloneDeep } from 'lodash-es'
-import React, {
-  FunctionComponent,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react'
+import React from 'react'
 import { SkeletonInlineBlock } from '../assets/skeletons/SkeletonInlineBlock'
-import {
-  getStoredEntityHeaders,
-  getStoredUserProfiles,
-  getStoredEvaluation,
-} from '../utils/functions/getDataFromFromStorage'
-import {
-  ColumnModel,
-  ColumnType,
-  EntityHeader,
-  Evaluation,
-  FacetColumnRequest,
-  FacetColumnResult,
-  FacetColumnResultRange,
-  FacetColumnResultValues,
-  QueryBundleRequest,
-  UserProfile,
-} from '../utils/synapseTypes'
-import {
-  isColumnMultiValueFunctionQueryFilter,
-  isColumnSingleValueQueryFilter,
-  isTextMatchesQueryFilter,
-  QueryFilter,
-  TextMatchesQueryFilter,
-} from '../utils/synapseTypes/Table/QueryFilter'
+import { FacetColumnRequest } from '../utils/synapseTypes'
 import { useQueryVisualizationContext } from './QueryVisualizationWrapper'
 import {
   QUERY_FILTERS_COLLAPSED_CSS,
   QUERY_FILTERS_EXPANDED_CSS,
 } from './QueryWrapper'
 import { useQueryContext } from './QueryContext'
-import SelectionCriteriaPill, {
-  FacetWithSelection,
-  SelectionCriteriaPillProps,
-} from './widgets/facet-nav/SelectionCriteriaPill'
-import {
-  applyChangesToRangeColumn,
-  applyChangesToValuesColumn,
-} from './widgets/query-filter/FacetFilterControls'
-import { RadioValuesEnum } from './widgets/query-filter/RangeFacetFilter'
 import IconSvg from './IconSvg'
+import SelectionCriteriaPills from './widgets/facet-nav/SelectionCriteriaPills'
 
 export type TotalQueryResultsProps = {
   style?: React.CSSProperties
@@ -55,300 +18,19 @@ export type TotalQueryResultsProps = {
   hideIfUnfiltered?: boolean
 }
 
-// This is a stateful component so that during load the component can hold onto the previous
-// total instead of showing 0 results for the intermittent loading state.
-
-const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
-  style,
-  frontText,
-  endText = '',
-  hideIfUnfiltered = false,
-}) => {
-  const {
-    data,
-    isLoadingNewBundle,
-    getLastQueryRequest,
-    executeQueryRequest,
-    getInitQueryRequest,
-    error,
-  } = useQueryContext()
+function TotalQueryResults(props: TotalQueryResultsProps) {
+  const { style, frontText, endText = '', hideIfUnfiltered = false } = props
+  const { data, isLoadingNewBundle, resetQuery, error, hasResettableFilters } =
+    useQueryContext()
 
   const { topLevelControlsState, unitDescription } =
     useQueryVisualizationContext()
 
   const total = data?.queryCount
-  const [facetsWithSelection, setFacetsWithSelection] = useState<
-    FacetWithSelection[]
-  >([])
 
-  const applyChanges = (facets: FacetColumnRequest[]) => {
-    const queryRequest: QueryBundleRequest = cloneDeep(getLastQueryRequest())
-    queryRequest.query.selectedFacets = facets
-    queryRequest.query.offset = 0
-    executeQueryRequest(queryRequest)
-  }
-
-  const getEnumFacetsWithSelections = (
-    facets: FacetColumnResult[],
-  ): FacetColumnResultValues[] => {
-    const enumFacets = facets.filter(
-      facet => facet.facetType === 'enumeration',
-    ) as FacetColumnResultValues[]
-    const enumFacetsWithSelections = enumFacets.filter(
-      facet =>
-        facet.facetValues.filter(value => value.isSelected === true).length > 0,
-    )
-    return enumFacetsWithSelections
-  }
-
-  const getRangeFacetsWithSelections = (
-    facets: FacetColumnResult[],
-  ): FacetColumnResultRange[] => {
-    const rangeFacets = facets.filter(
-      facet => facet.facetType === 'range',
-    ) as FacetColumnResultRange[]
-    const rangeFacetsWithSelections = rangeFacets.filter(
-      facet => facet.selectedMax || facet.selectedMin,
-    )
-    return rangeFacetsWithSelections
-  }
-
-  const getDisplayValueForEntityColumn = (
-    entityHeaders: EntityHeader[],
-    facetValue: string,
-  ): string => {
-    const entity = entityHeaders.find(item => item.id === facetValue)
-    return entity?.name ?? facetValue
-  }
-
-  const getDisplayValueEvaluationIdColumn = (
-    evaluations: Evaluation[],
-    facetValue: string,
-  ): string => {
-    const evaluation = evaluations.find(item => item.id === facetValue)
-    return evaluation?.name || facetValue
-  }
-
-  const getDisplayValueUserIdColumn = (
-    userProfiles: UserProfile[],
-    facetValue: string,
-  ): string => {
-    const userProfile = userProfiles.find(item => item.ownerId === facetValue)
-    return userProfile?.userName || facetValue
-  }
-
-  const transformEnumFacetsForSelectionDisplay = useCallback(
-    (
-      facets: FacetColumnResultValues[],
-      columnModels: ColumnModel[],
-    ): FacetWithSelection[] => {
-      const lookUpEntityHeaders = getStoredEntityHeaders()
-      const lookUpUserProfiles = getStoredUserProfiles()
-      const lookUpEvaluations = getStoredEvaluation()
-      const filteredEnumWithSelectedValuesOnly: FacetWithSelection[] = []
-      facets.forEach(facet => {
-        const columnModel = columnModels.find(
-          model => model.name === facet.columnName,
-        )
-        facet.facetValues.forEach(facetValue => {
-          if (facetValue.isSelected) {
-            let displayValue = facetValue.value
-            switch (columnModel?.columnType) {
-              case ColumnType.ENTITYID:
-              case ColumnType.ENTITYID_LIST:
-                displayValue = getDisplayValueForEntityColumn(
-                  lookUpEntityHeaders,
-                  facetValue.value,
-                )
-                break
-              case ColumnType.USERID:
-              case ColumnType.USERID_LIST:
-                displayValue = getDisplayValueUserIdColumn(
-                  lookUpUserProfiles,
-                  facetValue.value,
-                )
-                break
-              case ColumnType.EVALUATIONID:
-                displayValue = getDisplayValueEvaluationIdColumn(
-                  lookUpEvaluations,
-                  facetValue.value,
-                )
-                break
-              default:
-                displayValue = facetValue.value
-                break
-            }
-            filteredEnumWithSelectedValuesOnly.push({
-              facet,
-              displayValue,
-              selectedValue: facetValue,
-            })
-          }
-        })
-      })
-      return filteredEnumWithSelectedValuesOnly
-    },
-    [],
-  )
-
-  useEffect(() => {
-    if (data) {
-      const rangeFacetsWithSelections = getRangeFacetsWithSelections(
-        data.facets!,
-      )
-      const enumFacetsWithSelections = getEnumFacetsWithSelections(data.facets!)
-      const rangeFacetsForDisplay = rangeFacetsWithSelections.map(facet => ({
-        facet,
-      }))
-      const enumFacetsForDisplay = transformEnumFacetsForSelectionDisplay(
-        enumFacetsWithSelections,
-        data.columnModels!,
-      )
-
-      setFacetsWithSelection([
-        ...rangeFacetsForDisplay,
-        ...enumFacetsForDisplay,
-      ])
-    }
-  }, [data, transformEnumFacetsForSelectionDisplay])
-
-  const removeFacetSelection = (facetWithSelection: FacetWithSelection) => {
-    const { facet, selectedValue } = facetWithSelection
-    if (facet.facetType === 'enumeration') {
-      applyChangesToValuesColumn(
-        getLastQueryRequest(),
-        facet,
-        applyChanges,
-        selectedValue?.value,
-        false,
-      )
-    } else {
-      applyChangesToRangeColumn(getLastQueryRequest(), facet, applyChanges, [
-        RadioValuesEnum.ANY,
-        RadioValuesEnum.ANY,
-      ])
-    }
-  }
-
-  const removeColumnSearchQuerySelection = (
-    columnName: string,
-    value: string,
-  ) => {
-    const cloneLastQueryRequest = cloneDeep(getLastQueryRequest())
-    if (!cloneLastQueryRequest.query.additionalFilters) {
-      return
-    }
-    cloneLastQueryRequest.query.additionalFilters =
-      cloneLastQueryRequest.query.additionalFilters?.reduce(function (
-        filtered: QueryFilter[],
-        el: QueryFilter,
-      ) {
-        if (
-          isColumnSingleValueQueryFilter(el) ||
-          isColumnMultiValueFunctionQueryFilter(el)
-        ) {
-          // For column-specific QueryFilters, filter out matching values on the matching column
-          const newElement = {
-            columnName: el.columnName,
-            values:
-              el.columnName === columnName
-                ? el.values.filter(el => el !== value)
-                : el.values,
-            operator: isColumnSingleValueQueryFilter(el)
-              ? el.operator
-              : undefined,
-            function: isColumnMultiValueFunctionQueryFilter(el)
-              ? el.function
-              : undefined,
-            concreteType: el.concreteType,
-          }
-
-          // Drop this QueryFilter if it has no more values
-          if (newElement.values.length > 0) {
-            filtered.push(newElement)
-          }
-        } else {
-          // Don't alter/drop non-column-specific QueryFilters
-          filtered.push(el)
-        }
-        return filtered
-      },
-      [])
-
-    executeQueryRequest(cloneLastQueryRequest)
-  }
-
-  const removeTextMatchesQueryFilter = (
-    queryFilter: TextMatchesQueryFilter,
-  ) => {
-    const cloneLastQueryRequest = cloneDeep(getLastQueryRequest())
-    if (!cloneLastQueryRequest.query.additionalFilters) {
-      return
-    }
-    cloneLastQueryRequest.query.additionalFilters =
-      cloneLastQueryRequest.query.additionalFilters.filter(
-        el =>
-          !(
-            isTextMatchesQueryFilter(el) &&
-            el.searchExpression === queryFilter.searchExpression
-          ),
-      )
-    executeQueryRequest(cloneLastQueryRequest)
-  }
-
-  const clearAll = () => {
-    const initQueryRequest = cloneDeep(getInitQueryRequest())
-    initQueryRequest.query.additionalFilters = []
-    executeQueryRequest(initQueryRequest)
-  }
-
-  const searchSelectionCriteriaPillProps:
-    | (SelectionCriteriaPillProps & {
-        key: string
-      })[]
-    | undefined = getLastQueryRequest().query.additionalFilters?.reduce(
-    (
-      pillProps: (SelectionCriteriaPillProps & {
-        key: string
-      })[],
-      el: QueryFilter,
-    ) => {
-      if (isTextMatchesQueryFilter(el)) {
-        pillProps.push({
-          key: `fulltextsearch-${el.searchExpression}`,
-          filter: {
-            value: el.searchExpression,
-          },
-          onRemove: () => removeTextMatchesQueryFilter(el),
-        })
-      } else if (
-        isColumnSingleValueQueryFilter(el) ||
-        isColumnMultiValueFunctionQueryFilter(el)
-      ) {
-        const { columnName } = el
-        el.values.forEach(value => {
-          pillProps.push({
-            key: `columnsearch-${value}`,
-            filter: {
-              columnName,
-              value,
-            },
-            onRemove: () =>
-              removeColumnSearchQuerySelection(el.columnName, value),
-          })
-        })
-      } else {
-        console.warn('Encountered unexpected QueryFilter: ', el)
-      }
-      return pillProps
-    },
-    [],
-  )
   const showFacetFilter = topLevelControlsState?.showFacetFilter
-  const hasFilters =
-    facetsWithSelection.length > 0 ||
-    (searchSelectionCriteriaPillProps &&
-      searchSelectionCriteriaPillProps.length > 0)
+
+  const showClearAll = hasResettableFilters
   if (error) {
     return <></>
   }
@@ -358,24 +40,22 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
         showFacetFilter
           ? QUERY_FILTERS_EXPANDED_CSS
           : QUERY_FILTERS_COLLAPSED_CSS
-      } ${hasFilters ? 'hasFilters' : ''}`}
+      } ${hasResettableFilters ? 'hasFilters' : ''}`}
       style={style}
     >
       {isLoadingNewBundle ? (
         <SkeletonInlineBlock width={100} />
       ) : (
         <>
-          {(hasFilters || !hideIfUnfiltered) && (
+          {(hasResettableFilters || !hideIfUnfiltered) && (
             <div className="TotalQueryResults__topbar">
               <span className="SRC-boldText">
                 {frontText} {total?.toLocaleString()} {unitDescription}{' '}
                 {endText}
               </span>
-              {(facetsWithSelection.length > 0 ||
-                (searchSelectionCriteriaPillProps &&
-                  searchSelectionCriteriaPillProps.length > 2)) && (
+              {showClearAll && (
                 <a
-                  onClick={clearAll}
+                  onClick={resetQuery}
                   className="TotalQueryResults__topbar__clearall"
                 >
                   <IconSvg options={{ icon: 'deleteSweep' }} />
@@ -385,21 +65,7 @@ const TotalQueryResults: FunctionComponent<TotalQueryResultsProps> = ({
             </div>
           )}
           <div className="TotalQueryResults__selections">
-            {searchSelectionCriteriaPillProps &&
-              searchSelectionCriteriaPillProps.map(props => (
-                <SelectionCriteriaPill {...props} key={props.key} />
-              ))}
-            {facetsWithSelection.map((selectedFacet, index) => (
-              <SelectionCriteriaPill
-                key={`facets-${
-                  selectedFacet.selectedValue?.value ??
-                  selectedFacet.displayValue ??
-                  index
-                }`}
-                facetWithSelection={selectedFacet}
-                onRemove={() => removeFacetSelection(selectedFacet)}
-              />
-            ))}
+            <SelectionCriteriaPills />
           </div>
         </>
       )}

--- a/src/lib/containers/table/TopLevelControls.tsx
+++ b/src/lib/containers/table/TopLevelControls.tsx
@@ -221,7 +221,6 @@ const TopLevelControls = (props: TopLevelControlsProps) => {
             }
             return (
               <ElementWithTooltip
-                idForToolTip={key}
                 tooltipText={tooltipText}
                 key={key}
                 callbackFn={() => setControlState(key)}

--- a/src/lib/containers/table/table-top/ColumnSelection.tsx
+++ b/src/lib/containers/table/table-top/ColumnSelection.tsx
@@ -54,7 +54,6 @@ export const ColumnSelection: React.FunctionComponent<ColumnSelectionProps> = (
       drop="down"
     >
       <ElementWithTooltip
-        idForToolTip={tooltipColumnSelectionId}
         tooltipText={'Show/Hide Columns'}
         icon={darkTheme ? 'columnsdark' : 'columns'}
         darkTheme={darkTheme}

--- a/src/lib/containers/table/table-top/DownloadOptions.tsx
+++ b/src/lib/containers/table/table-top/DownloadOptions.tsx
@@ -21,7 +21,6 @@ export type DownloadOptionsProps = {
 }
 
 export const DOWNLOAD_FILES_MENU_TEXT = 'Add To Download Cart'
-const tooltipDownloadId = 'download'
 
 export const DownloadOptions: React.FunctionComponent<
   DownloadOptionsProps
@@ -50,7 +49,6 @@ export const DownloadOptions: React.FunctionComponent<
     <React.Fragment>
       <Dropdown as="span">
         <ElementWithTooltip
-          idForToolTip={tooltipDownloadId}
           tooltipText={'Download Options'}
           size="lg"
           darkTheme={darkTheme}

--- a/src/lib/containers/useImmutableTableQuery.ts
+++ b/src/lib/containers/useImmutableTableQuery.ts
@@ -1,9 +1,18 @@
-import { useCallback, useEffect, useState } from 'react'
-import { QueryBundleRequest } from '../utils/synapseTypes/Table/QueryBundleRequest'
-import { cloneDeep } from 'lodash-es'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  FacetColumnRequest,
+  isFacetColumnValuesRequest,
+  QueryBundleRequest,
+} from '../utils/synapseTypes'
+import { cloneDeep, isEqual } from 'lodash-es'
 import * as DeepLinkingUtils from '../utils/functions/deepLinkingUtils'
 import { DEFAULT_PAGE_SIZE } from '../utils/SynapseConstants'
 import { parseEntityIdAndVersionFromSqlStatement } from '../utils/functions/sqlFunctions'
+import {
+  isColumnMultiValueFunctionQueryFilter,
+  isColumnSingleValueQueryFilter,
+  QueryFilter,
+} from '../utils/synapseTypes/Table/QueryFilter'
 
 export type ImmutableTableQueryResult = {
   /** The ID of the table parsed from the SQL query */
@@ -23,6 +32,19 @@ export type ImmutableTableQueryResult = {
   setPageSize: (pageSize: number) => void
   /** pageNumber is 1-indexed */
   goToPage: (pageNumber: number) => void
+  /** Resets the query to the initial state, clearing all user-specified filters */
+  resetQuery: () => void
+  /** Removes a particular selected facet from the query */
+  removeSelectedFacet: (facet: FacetColumnRequest) => void
+  /** Removes a particular value from a selected facet. If the value is the last value in the FacetColumnRequest, the selected facet will be removed. */
+  removeValueFromSelectedFacet: (
+    facet: FacetColumnRequest,
+    value: string,
+  ) => void
+  /** Removes a particular QueryFilter from the query */
+  removeQueryFilter: (filter: QueryFilter) => void
+  /** Removes a particular value from a QueryFilter. If the value is the last value in the filter, the filter will be removed. */
+  removeValueFromQueryFilter: (filter: QueryFilter, value: string) => void
 
   /**
    * TODO: This hook could handle all potential query transformations, such as
@@ -88,74 +110,189 @@ export default function useImmutableTableQuery(
   }, [lastQueryRequest])
 
   /**
-   * Pass down a deep clone (so no side affects on the child's part) of the
+   * Pass down a deep clone (so no side effects on the child's part) of the
    * first query request made
    *
    * @returns
    * @memberof QueryWrapper
    */
-  function getInitQueryRequest(): QueryBundleRequest {
+  const getInitQueryRequest = useCallback((): QueryBundleRequest => {
     return cloneDeep(initQueryRequest)
-  }
+  }, [initQueryRequest])
 
   /**
-   * Execute the given query request, updating all of the data in the QueryContext to match the new query
+   * Execute the given query request, updating all the data in the QueryContext to match the new query
    * @param {*} queryRequest Query request as specified by
    *                         https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/table/Query.html
    */
-  function setQuery(
-    queryRequest:
-      | QueryBundleRequest
-      | ((lastQueryRequest: QueryBundleRequest) => QueryBundleRequest),
-  ): void {
-    let newQueryRequest: QueryBundleRequest
-    if (typeof queryRequest === 'function') {
-      newQueryRequest = queryRequest(getLastQueryRequest())
-    } else {
-      newQueryRequest = queryRequest
-    }
-
-    // Clone the query request before storing it in state, in case the original is mutated
-    const clonedQueryRequest = cloneDeep(newQueryRequest)
-    setLastQueryRequest(clonedQueryRequest)
-
-    if (clonedQueryRequest.query) {
-      const clonedQueryJson = JSON.stringify(clonedQueryRequest.query)
-      if (shouldDeepLink) {
-        const encodedQuery = encodeURIComponent(clonedQueryJson)
-        DeepLinkingUtils.updateUrlWithNewSearchParam(
-          'QueryWrapper',
-          componentIndex,
-          encodedQuery,
-        )
+  const setQuery = useCallback(
+    (
+      queryRequest:
+        | QueryBundleRequest
+        | ((lastQueryRequest: QueryBundleRequest) => QueryBundleRequest),
+    ): void => {
+      let newQueryRequest: QueryBundleRequest
+      if (typeof queryRequest === 'function') {
+        newQueryRequest = queryRequest(getLastQueryRequest())
+      } else {
+        newQueryRequest = queryRequest
       }
-      if (onQueryChange) {
-        onQueryChange(clonedQueryJson)
-      }
-    }
-  }
 
-  const { entityId, versionNumber } = parseEntityIdAndVersionFromSqlStatement(
-    lastQueryRequest.query.sql,
-  )!
+      // Clone the query request before storing it in state, in case the original is mutated
+      const clonedQueryRequest = cloneDeep(newQueryRequest)
+      setLastQueryRequest(clonedQueryRequest)
+
+      if (clonedQueryRequest.query) {
+        const clonedQueryJson = JSON.stringify(clonedQueryRequest.query)
+        if (shouldDeepLink) {
+          const encodedQuery = encodeURIComponent(clonedQueryJson)
+          DeepLinkingUtils.updateUrlWithNewSearchParam(
+            'QueryWrapper',
+            componentIndex,
+            encodedQuery,
+          )
+        }
+        if (onQueryChange) {
+          onQueryChange(clonedQueryJson)
+        }
+      }
+    },
+    [componentIndex, getLastQueryRequest, onQueryChange, shouldDeepLink],
+  )
+
+  const { entityId, versionNumber } = useMemo(
+    () => parseEntityIdAndVersionFromSqlStatement(lastQueryRequest.query.sql)!,
+    [lastQueryRequest.query.sql],
+  )
 
   const pageSize = lastQueryRequest.query.limit ?? DEFAULT_PAGE_SIZE
   const currentPage = Math.ceil(
     ((lastQueryRequest.query.offset ?? 0) + Number(pageSize)) / pageSize,
   )
-  function setPageSize(pageSize: number) {
-    setQuery(currentQuery => {
-      currentQuery.query.limit = pageSize
-      return currentQuery
-    })
-  }
 
-  function goToPage(pageNumber: number) {
-    setQuery(currentQuery => {
-      currentQuery.query.offset = (pageNumber - 1) * pageSize
-      return currentQuery
-    })
-  }
+  const setPageSize = useCallback(
+    (pageSize: number) => {
+      setQuery(currentQuery => {
+        currentQuery.query.limit = pageSize
+        return currentQuery
+      })
+    },
+    [setQuery],
+  )
+
+  const goToPage = useCallback(
+    (pageNumber: number) => {
+      setQuery(currentQuery => {
+        currentQuery.query.offset = (pageNumber - 1) * pageSize
+        return currentQuery
+      })
+    },
+    [pageSize, setQuery],
+  )
+
+  const resetQuery = useCallback(() => {
+    setQuery(initQueryRequest)
+  }, [initQueryRequest, setQuery])
+
+  const removeSelectedFacet = useCallback(
+    (facetColumnRequest: FacetColumnRequest) => {
+      setQuery(currentQuery => {
+        currentQuery.query.selectedFacets = (
+          currentQuery.query.selectedFacets ?? []
+        ).filter(facet => {
+          // Use lodash for deep comparison
+          return !isEqual(facet, facetColumnRequest)
+        })
+        return currentQuery
+      })
+    },
+    [setQuery],
+  )
+
+  const removeValueFromSelectedFacet = useCallback(
+    (facet: FacetColumnRequest, value: string) => {
+      setQuery(currentQuery => {
+        currentQuery.query.selectedFacets = (
+          currentQuery.query.selectedFacets ?? []
+        )
+          // Modify the requested filter
+          .map(facetColumnRequest => {
+            if (
+              isFacetColumnValuesRequest(facetColumnRequest) &&
+              isEqual(facetColumnRequest, facet)
+            ) {
+              // Remove the value from the filter
+              facetColumnRequest.facetValues =
+                facetColumnRequest.facetValues.filter(v => v !== value)
+            }
+            return facetColumnRequest
+          })
+          // Remove filters that have no values
+          .filter(facetColumnRequest => {
+            if (isFacetColumnValuesRequest(facetColumnRequest)) {
+              // Remove the value from the filter
+              return (
+                Array.isArray(facetColumnRequest.facetValues) &&
+                facetColumnRequest.facetValues.length > 0
+              )
+            }
+            return true
+          })
+        return currentQuery
+      })
+    },
+    [setQuery],
+  )
+
+  const removeQueryFilter = useCallback(
+    (queryFilter: QueryFilter) => {
+      setQuery(currentQuery => {
+        currentQuery.query.additionalFilters = (
+          currentQuery.query.additionalFilters ?? []
+        ).filter(qf => {
+          // Use lodash for deep comparison
+          return !isEqual(qf, queryFilter)
+        })
+        return currentQuery
+      })
+    },
+    [setQuery],
+  )
+
+  const removeValueFromQueryFilter = useCallback(
+    (queryFilter: QueryFilter, value: string) => {
+      setQuery(currentQuery => {
+        currentQuery.query.additionalFilters = (
+          currentQuery.query.additionalFilters ?? []
+        )
+          // Modify the requested filter
+          .map(qf => {
+            if (
+              (isColumnSingleValueQueryFilter(qf) ||
+                isColumnMultiValueFunctionQueryFilter(qf)) &&
+              isEqual(qf, queryFilter)
+            ) {
+              // Remove the value from the filter
+              qf.values = qf.values.filter(v => v !== value)
+            }
+            return qf
+          })
+          // Remove filters that have no values
+          .filter(qf => {
+            if (
+              isColumnSingleValueQueryFilter(qf) ||
+              isColumnMultiValueFunctionQueryFilter(qf)
+            ) {
+              // Remove the value from the filter
+              return Array.isArray(qf.values) && qf.values.length > 0
+            }
+            return true
+          })
+        return currentQuery
+      })
+    },
+    [setQuery],
+  )
 
   return {
     entityId,
@@ -167,5 +304,10 @@ export default function useImmutableTableQuery(
     currentPage,
     setPageSize,
     goToPage,
+    resetQuery,
+    removeSelectedFacet,
+    removeValueFromSelectedFacet,
+    removeQueryFilter,
+    removeValueFromQueryFilter,
   }
 }

--- a/src/lib/containers/widgets/ElementWithTooltip.tsx
+++ b/src/lib/containers/widgets/ElementWithTooltip.tsx
@@ -28,7 +28,6 @@ export type TooltipVisualProps = {
 type ElementWithTooltipProps = React.PropsWithChildren<{
   image?: IconSvgOptions | CustomImageProps
   imageColor?: string
-  idForToolTip: string
   tooltipText: string
   callbackFn?: () => void
   className?: string
@@ -52,7 +51,6 @@ function getTooltipTriggerContents(
 
 export const ElementWithTooltip = ({
   image,
-  idForToolTip,
   callbackFn,
   tooltipText,
   className = '',
@@ -78,7 +76,6 @@ export const ElementWithTooltip = ({
     tooltipTrigger = callbackFn ? (
       <button
         tabIndex={0}
-        id={idForToolTip}
         className={`ElementWithTooltip SRC-hand-cursor SRC-grey-background-hover ${className} ${
           darkTheme ? 'dark-theme' : ''
         } `}

--- a/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
@@ -310,7 +310,6 @@ export function FacetPlotLegend(props: FacetPlotLegendProps) {
         const labelDisplay = truncate(label, maxLegendLength)
         return (
           <ElementWithTooltip
-            idForToolTip={facetValue.label}
             tooltipText={facetValue.label}
             key={facetValue.label}
           >
@@ -485,7 +484,6 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
                   containerAs="Dropdown"
                 />
                 <ElementWithTooltip
-                  idForToolTip="expandGraph"
                   tooltipText="Expand to large graph"
                   key="expandGraph"
                   callbackFn={() => setShowModal(true)}
@@ -494,7 +492,6 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
                   icon={'expand'}
                 />
                 <ElementWithTooltip
-                  idForToolTip="hideGraph"
                   tooltipText="Hide graph under Show More"
                   key="hideGraph"
                   callbackFn={() => onHide()}

--- a/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.stories.tsx
+++ b/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import SelectionCriteriaPill from './SelectionCriteriaPill'
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: 'Explore/Tokens/SelectionCriteriaPill',
+  component: SelectionCriteriaPill,
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+  argTypes: {},
+} as ComponentMeta<typeof SelectionCriteriaPill>
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template: ComponentStory<typeof SelectionCriteriaPill> = args => (
+  <SelectionCriteriaPill {...args} />
+)
+
+export const Pill = Template.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+Pill.args = {
+  innerText: 'Facet Value: ABC',
+  tooltipText: 'You can add tooltip text too.',
+}

--- a/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
+++ b/src/lib/containers/widgets/facet-nav/SelectionCriteriaPill.tsx
@@ -1,94 +1,28 @@
 import { Close } from '@material-ui/icons'
 import React from 'react'
-import { FunctionComponent } from 'react'
-import { SynapseConstants } from '../../../utils'
-import {
-  FacetColumnResult,
-  FacetColumnResultRange,
-  FacetColumnResultValueCount,
-} from '../../../utils/synapseTypes'
 import { ElementWithTooltip } from '../ElementWithTooltip'
-import { useQueryVisualizationContext } from '../../QueryVisualizationWrapper'
 
-export type FacetWithSelection = {
-  facet: FacetColumnResult
-  selectedValue?: FacetColumnResultValueCount
-  displayValue?: string
+export type SelectionCriteriaPillProps = {
+  readonly key: string
+  readonly innerText: string
+  readonly tooltipText: string
+  readonly onRemoveFilter: () => void
 }
 
-export type SelectionCriteriaPillProps = (
-  | { readonly facetWithSelection: FacetWithSelection }
-  | {
-      filter: {
-        columnName?: string
-        value: string
-      }
-    }
-) & {
-  onRemove: () => void
-}
+/**
+ * Renders a pill or chicklet to represent a Synapse Table Query filter/selection criterion.
+ * @param props
+ * @constructor
+ */
+function SelectionCriteriaPill(props: SelectionCriteriaPillProps) {
+  const { innerText, tooltipText, onRemoveFilter } = props
 
-const SelectionCriteriaPill: FunctionComponent<
-  SelectionCriteriaPillProps
-> = props => {
-  const { getColumnDisplayName } = useQueryVisualizationContext()
-  let innerText,
-    tooltipText: string | null = ''
-  if ('facetWithSelection' in props) {
-    const { facetWithSelection } = props
-    if (facetWithSelection.facet.facetType === 'enumeration') {
-      innerText =
-        facetWithSelection.displayValue === SynapseConstants.VALUE_NOT_SET
-          ? SynapseConstants.FRIENDLY_VALUE_NOT_SET
-          : facetWithSelection.displayValue
-    } else {
-      innerText = `${(facetWithSelection.facet as FacetColumnResultRange)
-        .selectedMin!} 
-        - ${(facetWithSelection.facet as FacetColumnResultRange).selectedMax!}`
-    }
-    tooltipText = `${getColumnDisplayName(
-      facetWithSelection.facet.columnName,
-    )}: ${innerText}`
-  } else if ('filter' in props) {
-    const { filter } = props
-    let filterValue = filter.value
-    if (filterValue?.startsWith('%') && filterValue?.endsWith('%')) {
-      // strip '%' wildcard character when using a LIKE condition
-      filterValue = filterValue.substring(1, filterValue.length - 1)
-    }
-
-    // For full-text search, set the pill text and tooltip text
-    innerText = filterValue
-    tooltipText = `Text matches: "${filterValue}"`
-
-    // If searching in a specific column, use different inner/tooltip text
-    if (filter.columnName) {
-      innerText = `"${filterValue}" in ${getColumnDisplayName(
-        filter?.columnName,
-      )}`
-      tooltipText = `${getColumnDisplayName(
-        filter?.columnName,
-      )}: ${filterValue}`
-    }
-  } else {
-    console.warn(
-      'Expected either facetWithSelection or filter in SelectionCriteriaPill but got neither',
-    )
-  }
-  const key = encodeURIComponent(tooltipText)
   return (
-    <ElementWithTooltip
-      idForToolTip={`selectionCriteria_${key}`}
-      tooltipText={tooltipText}
-      callbackFn={() => {}}
-    >
-      <div
-        className="SelectionCriteriaPill"
-        key={`SelectionCriteriaPill ${key}`}
-      >
+    <ElementWithTooltip tooltipText={tooltipText} callbackFn={() => {}}>
+      <div className="SelectionCriteriaPill">
         <span>{innerText}</span>
         <button
-          onClick={() => props.onRemove()}
+          onClick={onRemoveFilter}
           className="SelectionCriteriaPill__btnRemove"
           title="deselect"
         >

--- a/src/lib/containers/widgets/facet-nav/SelectionCriteriaPills.tsx
+++ b/src/lib/containers/widgets/facet-nav/SelectionCriteriaPills.tsx
@@ -1,0 +1,174 @@
+import React from 'react'
+import { QueryContextType, useQueryContext } from '../../QueryContext'
+import {
+  ColumnMultiValueFunctionQueryFilter,
+  ColumnSingleValueQueryFilter,
+  isColumnMultiValueFunctionQueryFilter,
+  isColumnSingleValueQueryFilter,
+  isTextMatchesQueryFilter,
+  QueryFilter,
+  TextMatchesQueryFilter,
+} from '../../../utils/synapseTypes/Table/QueryFilter'
+import SelectionCriteriaPill, {
+  SelectionCriteriaPillProps,
+} from './SelectionCriteriaPill'
+import {
+  FacetColumnRequest,
+  isFacetColumnRangeRequest,
+  isFacetColumnValuesRequest,
+} from '../../../utils/synapseTypes'
+import {
+  QueryVisualizationContextType,
+  useQueryVisualizationContext,
+} from '../../QueryVisualizationWrapper'
+
+function getPillPropsFromColumnQueryFilter(
+  queryFilter:
+    | ColumnSingleValueQueryFilter
+    | ColumnMultiValueFunctionQueryFilter,
+  queryContext: QueryContextType,
+  queryVisualizationContext: QueryVisualizationContextType,
+): SelectionCriteriaPillProps[] {
+  // ColumnSingleValueQueryFilter and ColumnMultiValueQueryFilter both allow for a list of values
+  // We want to render 1 pill per value, so we expand
+  const columnModel = queryContext.getColumnModel(queryFilter.columnName)!
+  return queryFilter.values.map(value => {
+    let filterValue = value
+
+    if (value?.startsWith('%') && value?.endsWith('%')) {
+      // strip '%' wildcard character when using a LIKE condition
+      filterValue = filterValue.substring(1, filterValue.length - 1)
+    }
+    filterValue = queryVisualizationContext.getDisplayValue(
+      filterValue,
+      columnModel.columnType,
+    )
+    const text = `${queryFilter.columnName}: ${filterValue}`
+    return {
+      key: `queryFilter-${queryFilter.concreteType}-${queryFilter.columnName}-${value}`,
+      innerText: text,
+      tooltipText: text,
+      onRemoveFilter: () => {
+        queryContext.removeValueFromQueryFilter(queryFilter, value)
+      },
+    }
+  })
+}
+
+function getPillPropsFromTextMatchesQueryFilter(
+  queryFilter: TextMatchesQueryFilter,
+  queryContext: QueryContextType,
+): SelectionCriteriaPillProps {
+  return {
+    key: `queryFilter-${queryFilter.concreteType}-${queryFilter.searchExpression}`,
+    innerText: queryFilter.searchExpression,
+    tooltipText: `Text matches: "${queryFilter.searchExpression}"`,
+    onRemoveFilter: () => {
+      queryContext.removeQueryFilter(queryFilter)
+    },
+  }
+}
+
+function getPillPropsFromQueryFilter(
+  queryFilter: QueryFilter,
+  queryContext: QueryContextType,
+  queryVisualizationContext: QueryVisualizationContextType,
+): SelectionCriteriaPillProps[] {
+  if (
+    isColumnSingleValueQueryFilter(queryFilter) ||
+    isColumnMultiValueFunctionQueryFilter(queryFilter)
+  ) {
+    if (queryFilter.columnName === queryContext.lockedColumn?.columnName) {
+      return []
+    }
+    return getPillPropsFromColumnQueryFilter(
+      queryFilter,
+      queryContext,
+      queryVisualizationContext,
+    )
+  } else if (isTextMatchesQueryFilter(queryFilter)) {
+    return [getPillPropsFromTextMatchesQueryFilter(queryFilter, queryContext)]
+  } else {
+    console.log('Unknown query filter type', queryFilter.concreteType)
+    return []
+  }
+}
+
+function getPillPropsFromFacet(
+  selectedFacet: FacetColumnRequest,
+  queryContext: QueryContextType,
+  queryVisualizationContext: QueryVisualizationContextType,
+): SelectionCriteriaPillProps[] {
+  if (selectedFacet.columnName === queryContext.lockedColumn?.columnName) {
+    return []
+  }
+  const columnModel = queryContext.getColumnModel(selectedFacet.columnName)!
+  const { getColumnDisplayName, getDisplayValue } = queryVisualizationContext
+  if (isFacetColumnValuesRequest(selectedFacet)) {
+    return selectedFacet.facetValues.map(facetValue => {
+      const innerText = getDisplayValue(facetValue, columnModel.columnType)
+      return {
+        key: `facet-${selectedFacet.concreteType}-${selectedFacet.columnName}-${facetValue}`,
+        innerText: innerText,
+        tooltipText: `${getColumnDisplayName(
+          selectedFacet.columnName,
+        )}: ${innerText}`,
+        onRemoveFilter: () => {
+          queryContext.removeValueFromSelectedFacet(selectedFacet, facetValue)
+        },
+      }
+    })
+  } else if (isFacetColumnRangeRequest(selectedFacet)) {
+    const innerText = `${selectedFacet.min} - ${selectedFacet.max}`
+    return [
+      {
+        key: `facet-${selectedFacet.concreteType}-${selectedFacet.columnName}-${selectedFacet.min}-${selectedFacet.max}`,
+        innerText: innerText,
+        tooltipText: `${getColumnDisplayName(
+          selectedFacet.columnName,
+        )}: ${innerText}`,
+        onRemoveFilter: () => {
+          queryContext.removeSelectedFacet(selectedFacet)
+        },
+      },
+    ]
+  } else {
+    console.log(
+      'Unknown facet type',
+      (selectedFacet as unknown as FacetColumnRequest).concreteType,
+    )
+    return []
+  }
+}
+
+function SelectionCriteriaPills() {
+  const queryContext = useQueryContext()
+  const queryVisualizationContext = useQueryVisualizationContext()
+  const { getLastQueryRequest } = queryContext
+  const lastQueryRequest = getLastQueryRequest()
+
+  const queryFilterPillProps = (
+    lastQueryRequest.query?.additionalFilters ?? []
+  ).flatMap(qf =>
+    getPillPropsFromQueryFilter(qf, queryContext, queryVisualizationContext),
+  )
+
+  const facetPillProps = (lastQueryRequest.query.selectedFacets ?? []).flatMap(
+    facet =>
+      getPillPropsFromFacet(facet, queryContext, queryVisualizationContext),
+  )
+
+  const allPills = [...queryFilterPillProps, ...facetPillProps]
+
+  return (
+    <>
+      {allPills.map(pillProps => {
+        // Encode the key because the facet may include an illegal character
+        const key = encodeURIComponent(pillProps.key)
+        return <SelectionCriteriaPill {...pillProps} key={key} />
+      })}
+    </>
+  )
+}
+
+export default SelectionCriteriaPills

--- a/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
+++ b/src/lib/containers/widgets/query-filter/EnumFacetFilter.tsx
@@ -342,7 +342,6 @@ export const EnumFacetFilter: React.FunctionComponent<EnumFacetFilterProps> = ({
           onToggle={onToggle}
         >
           <ElementWithTooltip
-            idForToolTip="facetFilterTooltip"
             tooltipText="Filter by specific facet"
             key="facetFilterTooltip"
             darkTheme={false}

--- a/src/lib/containers/widgets/themes-plot/ThemesPlot.tsx
+++ b/src/lib/containers/widgets/themes-plot/ThemesPlot.tsx
@@ -317,7 +317,6 @@ const ThemesPlot: FunctionComponent<ThemesPlotProps> = ({
                 >
                   <div className="ThemesPlot__dotPlot__barColumn">
                     <ElementWithTooltip
-                      idForToolTip={`plotDiv1_${+i}`}
                       tooltipText={`${getTooltip(dotPlotQueryData, label)} `}
                       tooltipVisualProps={tooltipProps}
                       callbackFn={() => _.noop}

--- a/src/lib/utils/functions/getDataFromFromStorage.ts
+++ b/src/lib/utils/functions/getDataFromFromStorage.ts
@@ -1,7 +1,12 @@
-import { EntityHeader, Evaluation, UserProfile } from '../synapseTypes'
+import {
+  ColumnType,
+  EntityHeader,
+  Evaluation,
+  UserProfile,
+} from '../synapseTypes'
 import { SynapseConstants } from '..'
 
-export const getStoredEntityHeaders = (): EntityHeader[] => {
+const getStoredEntityHeaders = (): EntityHeader[] => {
   try {
     const lookUpEntityHeaders: EntityHeader[] = JSON.parse(
       sessionStorage.getItem(SynapseConstants.ENTITY_HEADER_STORAGE_KEY) || '',
@@ -12,7 +17,7 @@ export const getStoredEntityHeaders = (): EntityHeader[] => {
   }
 }
 
-export const getStoredUserProfiles = (): UserProfile[] => {
+const getStoredUserProfiles = (): UserProfile[] => {
   try {
     const lookUpUserIds: UserProfile[] = JSON.parse(
       sessionStorage.getItem(SynapseConstants.USER_PROFILE_STORAGE_KEY) || '',
@@ -23,7 +28,7 @@ export const getStoredUserProfiles = (): UserProfile[] => {
   }
 }
 
-export const getStoredEvaluation = (): Evaluation[] => {
+const getStoredEvaluation = (): Evaluation[] => {
   try {
     const lookUpEvaluations: UserProfile[] = JSON.parse(
       sessionStorage.getItem(SynapseConstants.EVALUATIONS_STORAGE_KEY) || '',
@@ -31,5 +36,43 @@ export const getStoredEvaluation = (): Evaluation[] => {
     return lookUpEvaluations
   } catch (e) {
     return []
+  }
+}
+
+export const getDisplayValueForEntityColumn = (value: string): string => {
+  const entity = getStoredEntityHeaders().find(item => item.id === value)
+  return entity?.name ?? value
+}
+
+export const getDisplayValueEvaluationIdColumn = (
+  facetValue: string,
+): string => {
+  const evaluation = getStoredEvaluation().find(item => item.id === facetValue)
+  return evaluation?.name || facetValue
+}
+
+export const getDisplayValueUserIdColumn = (facetValue: string): string => {
+  const userProfile = getStoredUserProfiles().find(
+    item => item.ownerId === facetValue,
+  )
+  return userProfile?.userName || facetValue
+}
+
+export const getDisplayValue = (value: string, columnType: ColumnType) => {
+  if (value === SynapseConstants.VALUE_NOT_SET) {
+    return SynapseConstants.FRIENDLY_VALUE_NOT_SET
+  }
+
+  switch (columnType) {
+    case ColumnType.ENTITYID:
+    case ColumnType.ENTITYID_LIST:
+      return getDisplayValueForEntityColumn(value)
+    case ColumnType.USERID:
+    case ColumnType.USERID_LIST:
+      return getDisplayValueUserIdColumn(value)
+    case ColumnType.EVALUATIONID:
+      return getDisplayValueEvaluationIdColumn(value)
+    default:
+      return value
   }
 }

--- a/src/lib/utils/functions/getDataFromFromStorage.ts
+++ b/src/lib/utils/functions/getDataFromFromStorage.ts
@@ -39,19 +39,17 @@ const getStoredEvaluation = (): Evaluation[] => {
   }
 }
 
-export const getDisplayValueForEntityColumn = (value: string): string => {
+const getDisplayValueForEntityColumn = (value: string): string => {
   const entity = getStoredEntityHeaders().find(item => item.id === value)
   return entity?.name ?? value
 }
 
-export const getDisplayValueEvaluationIdColumn = (
-  facetValue: string,
-): string => {
+const getDisplayValueEvaluationIdColumn = (facetValue: string): string => {
   const evaluation = getStoredEvaluation().find(item => item.id === facetValue)
   return evaluation?.name || facetValue
 }
 
-export const getDisplayValueUserIdColumn = (facetValue: string): string => {
+const getDisplayValueUserIdColumn = (facetValue: string): string => {
   const userProfile = getStoredUserProfiles().find(
     item => item.ownerId === facetValue,
   )


### PR DESCRIPTION
- Refactor TotalQueryResults and SelectionCriteriaPill
- Query modification (e.g. dropping facet selection) is managed by useImmutableTableQuery
- Displaying a column name is managed by QueryVisualizationWrapper
- Remove prop `idForTooltip` from ElementWithTooltip (no longer needed)