### PR TITLE
SWC-6321: Increase react-query stale time defaults

### DIFF
--- a/src/lib/utils/SynapseContext.tsx
+++ b/src/lib/utils/SynapseContext.tsx
@@ -11,7 +11,7 @@ import { ThemeOptions } from '@mui/material'
 export const defaultQueryClientConfig: QueryClientConfig = {
   defaultOptions: {
     queries: {
-      staleTime: 60 * 1000, // 60s
+      staleTime: 1000 * 60 * 5, // 5 min
       retry: false, // SynapseClient knows which queries to retry
     },
   },

--- a/src/lib/utils/SynapseContext.tsx
+++ b/src/lib/utils/SynapseContext.tsx
@@ -12,6 +12,7 @@ export const defaultQueryClientConfig: QueryClientConfig = {
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5, // 5 min
+      cacheTime: 1000 * 60 * 30, // 30 min
       retry: false, // SynapseClient knows which queries to retry
     },
   },

--- a/src/lib/utils/SynapseContext.tsx
+++ b/src/lib/utils/SynapseContext.tsx
@@ -14,6 +14,7 @@ export const defaultQueryClientConfig: QueryClientConfig = {
       staleTime: 1000 * 60 * 5, // 5 min
       cacheTime: 1000 * 60 * 30, // 30 min
       retry: false, // SynapseClient knows which queries to retry
+      refetchOnWindowFocus: true,
     },
   },
 }

--- a/src/lib/utils/SynapseContext.tsx
+++ b/src/lib/utils/SynapseContext.tsx
@@ -14,7 +14,7 @@ export const defaultQueryClientConfig: QueryClientConfig = {
       staleTime: 1000 * 60 * 5, // 5 min
       cacheTime: 1000 * 60 * 30, // 30 min
       retry: false, // SynapseClient knows which queries to retry
-      refetchOnWindowFocus: true,
+      refetchOnWindowFocus: false,
     },
   },
 }

--- a/src/lib/utils/hooks/SynapseAPI/entity/useGetQueryResultBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/entity/useGetQueryResultBundle.ts
@@ -24,7 +24,6 @@ import { entityQueryKeys } from './queryKeys'
 
 const sharedQueryDefaults = {
   staleTime: 1000 * 60 * 30, // 30 minutes
-  refetchOnWindowFocus: false,
 }
 
 /**

--- a/src/lib/utils/hooks/SynapseAPI/entity/useGetQueryResultBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/entity/useGetQueryResultBundle.ts
@@ -23,6 +23,7 @@ import {
 import { entityQueryKeys } from './queryKeys'
 
 const sharedQueryDefaults = {
+  staleTime: 1000 * 60 * 30, // 30 minutes
   refetchOnWindowFocus: false,
 }
 


### PR DESCRIPTION
- react-query default stale time increased from 1m to 5m
- Table query stale time set to 30m
- default cacheTime increased from 5m to 30m.