### PR TITLE
SWC-6323: Add generic ComplexMenu component

### DIFF
--- a/src/__tests__/lib/containers/menu/ComplexMenu.test.tsx
+++ b/src/__tests__/lib/containers/menu/ComplexMenu.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { createWrapper } from '../../../../lib/testutils/TestingLibraryUtils'
+import userEvent from '@testing-library/user-event'
+import {
+  ComplexMenu,
+  ComplexMenuProps,
+} from '../../../../lib/containers/menu/ComplexMenu'
+
+const DROPDOWN_BUTTON_TEXT = 'Open Dropdown Menu'
+const onClickFn = jest.fn()
+function createDropdownItemConfig(
+  text: string,
+  tooltipText: string | undefined = undefined,
+  disabled: boolean = false,
+) {
+  return {
+    text,
+    tooltipText,
+    disabled,
+    onClick: () => {
+      onClickFn(text)
+    },
+  }
+}
+
+const defaultProps: ComplexMenuProps = {
+  iconButtons: [
+    {
+      icon: 'article',
+      tooltipText: 'Icon button tooltip',
+      onClick: () => {
+        onClickFn('Icon Button 1')
+      },
+    },
+  ],
+  dropdownMenus: [
+    {
+      items: [
+        [
+          createDropdownItemConfig('Group 1 - Item 1'),
+          createDropdownItemConfig('Group 1 - Item 2'),
+        ],
+        [createDropdownItemConfig('Group 2 - Item 1')],
+      ],
+      dropdownButtonText: DROPDOWN_BUTTON_TEXT,
+    },
+  ],
+}
+
+function renderComponent(props: ComplexMenuProps) {
+  render(<ComplexMenu {...props} />, {
+    wrapper: createWrapper(),
+  })
+}
+
+describe('ComplexMenu Tests', function () {
+  afterEach(() => jest.clearAllMocks())
+  it('Renders an icon button', async () => {
+    renderComponent(defaultProps)
+    const iconButton = await screen.findByRole('button', {
+      name: 'Icon button tooltip',
+    })
+
+    await userEvent.click(iconButton)
+
+    await waitFor(() => expect(onClickFn).toHaveBeenCalledWith('Icon Button 1'))
+  })
+
+  it('Renders a dropdown menu', async () => {
+    renderComponent(defaultProps)
+    const dropdownButton = await screen.findByRole('button', {
+      name: DROPDOWN_BUTTON_TEXT,
+    })
+
+    await userEvent.click(dropdownButton)
+
+    const menuItems = await screen.findAllByRole('menuitem')
+    expect(menuItems).toHaveLength(3)
+
+    // There are two groups, so there should be one separator
+    await screen.findByRole('separator')
+
+    // Click an item
+    const firstItem = menuItems[0]
+    await userEvent.click(firstItem)
+    // Action should be invoked
+    await waitFor(() =>
+      expect(onClickFn).toHaveBeenCalledWith('Group 1 - Item 1'),
+    )
+    // Menu should close
+    await waitFor(() =>
+      expect(screen.queryByRole('menuitem')).not.toBeInTheDocument(),
+    )
+  })
+})

--- a/src/lib/containers/menu/ComplexMenu.stories.tsx
+++ b/src/lib/containers/menu/ComplexMenu.stories.tsx
@@ -1,0 +1,117 @@
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import IconSvg from '../IconSvg'
+import { ComplexMenu } from './ComplexMenu'
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: 'UI/ComplexMenu',
+  component: ComplexMenu,
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+  argTypes: {},
+} as ComponentMeta<typeof ComplexMenu>
+
+const onClickHandler = (item: any) => () => {
+  console.log('Item clicked', item)
+}
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const ComplexMenuTemplate: ComponentStory<typeof ComplexMenu> = args => (
+  <ComplexMenu {...args} />
+)
+
+export const Demo = ComplexMenuTemplate.bind({})
+
+Demo.args = {
+  iconButtons: [
+    {
+      icon: 'edit',
+      tooltipText: 'This is an icon button',
+      onClick: onClickHandler('edit icon'),
+    },
+    {
+      icon: 'label',
+      tooltipText: 'View annotations',
+      onClick: onClickHandler('label icon'),
+    },
+    {
+      icon: 'createVersion',
+      tooltipText: 'Create new version',
+      onClick: onClickHandler('createVersion icon'),
+    },
+  ],
+  dropdownMenus: [
+    {
+      dropdownButtonText: 'You can have...',
+      buttonProps: {
+        endIcon: <IconSvg icon="upload" wrap={false} />,
+      },
+      items: [
+        [
+          {
+            text: 'Do something cool',
+            onClick: onClickHandler(0),
+          },
+          {
+            text: 'This one has a tooltip',
+            tooltipText: 'Some more info',
+            onClick: onClickHandler(1),
+          },
+          {
+            text: 'This one is disabled',
+            disabled: true,
+            onClick: onClickHandler(3),
+          },
+          {
+            text: 'This one has both',
+            disabled: true,
+            tooltipText: "You can't do this for reasons",
+            onClick: onClickHandler(4),
+          },
+        ],
+        [
+          {
+            text: 'You can organize actions into groups',
+            onClick: onClickHandler(5),
+          },
+        ],
+      ],
+    },
+    {
+      dropdownButtonText: '...multiple dropdown menus!',
+      buttonProps: {
+        endIcon: <IconSvg icon="download" wrap={false} />,
+      },
+      items: [
+        [
+          {
+            text: 'Do something cool',
+            onClick: onClickHandler(0),
+          },
+          {
+            text: 'This one has a tooltip',
+            tooltipText: 'Some more info',
+            onClick: onClickHandler(1),
+          },
+          {
+            text: 'This one is disabled',
+            disabled: true,
+            onClick: onClickHandler(3),
+          },
+          {
+            text: 'This one has both',
+            disabled: true,
+            tooltipText: "You can't do this for reasons",
+            onClick: onClickHandler(4),
+          },
+        ],
+        [
+          {
+            text: 'You can organize actions into groups',
+            onClick: onClickHandler(5),
+          },
+        ],
+      ],
+    },
+  ],
+}

--- a/src/lib/containers/menu/ComplexMenu.tsx
+++ b/src/lib/containers/menu/ComplexMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { IconButton, Tooltip } from '@mui/material'
+import { Box, IconButton, Tooltip } from '@mui/material'
 import IconSvg, { Icon } from '../IconSvg'
 import { DropdownMenu, DropdownMenuProps } from './DropdownMenu'
 
@@ -34,7 +34,7 @@ export function ComplexMenu(props: ComplexMenuProps) {
   const { iconButtons = [], dropdownMenus = [] } = props
 
   return (
-    <div style={{ display: 'flex', gap: '10px' }}>
+    <Box sx={{ display: 'flex', gap: '10px' }}>
       {iconButtons.map(iconButton => {
         return (
           <Tooltip key={iconButton.tooltipText} title={iconButton.tooltipText}>
@@ -47,6 +47,6 @@ export function ComplexMenu(props: ComplexMenuProps) {
       {dropdownMenus.map((menuProps, index) => {
         return <DropdownMenu key={index} {...menuProps} />
       })}
-    </div>
+    </Box>
   )
 }

--- a/src/lib/containers/menu/ComplexMenu.tsx
+++ b/src/lib/containers/menu/ComplexMenu.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { IconButton, Tooltip } from '@mui/material'
+import IconSvg, { Icon } from '../IconSvg'
+import { DropdownMenu, DropdownMenuProps } from './DropdownMenu'
+
+/**
+ * Configuration for an IconButton inside the ComplexMenu
+ */
+export type IconButtonConfiguration = {
+  icon: Icon
+  tooltipText: string
+  onClick: (e: React.MouseEvent) => void
+}
+
+export type ComplexMenuProps = {
+  /*
+   * Configuration for IconButtons. Each entry corresponds to one button.
+   * See the IconButtonConfiguration type for more info.
+   */
+  iconButtons?: IconButtonConfiguration[]
+  /*
+   * Configuration for DropdownMenus. Each entry corresponds to one dropdown menu button, which
+   * itself can contain multiple groups of items.
+   * See the DropdownMenuProps type for more info.
+   */
+  dropdownMenus?: DropdownMenuProps[]
+}
+
+/**
+ * The ComplexMenu component allows you to create a generic menu with
+ * icon buttons and multiple dropdown menus that contain groups of items.
+ */
+export function ComplexMenu(props: ComplexMenuProps) {
+  const { iconButtons = [], dropdownMenus = [] } = props
+
+  return (
+    <div style={{ display: 'flex', gap: '10px' }}>
+      {iconButtons.map(iconButton => {
+        return (
+          <Tooltip key={iconButton.tooltipText} title={iconButton.tooltipText}>
+            <IconButton color="primary" onClick={iconButton.onClick}>
+              <IconSvg icon={iconButton.icon} wrap={false} />
+            </IconButton>
+          </Tooltip>
+        )
+      })}
+      {dropdownMenus.map((menuProps, index) => {
+        return <DropdownMenu key={index} {...menuProps} />
+      })}
+    </div>
+  )
+}

--- a/src/lib/utils/theme/DefaultTheme.ts
+++ b/src/lib/utils/theme/DefaultTheme.ts
@@ -9,12 +9,15 @@ const defaultMuiTheme: ThemeOptions = {
   palette: palette,
   components: {
     MuiLink: linkTheme,
-    MuiButton: {
+    MuiButtonBase: {
       defaultProps: {
         disableRipple: true,
       },
+    },
+    MuiButton: {
       styleOverrides: {
         root: {
+          padding: '6px 12px',
           borderRadius: '0px',
           textTransform: 'none',
           '&:hover': {
@@ -29,10 +32,10 @@ const defaultMuiTheme: ThemeOptions = {
         TransitionComponent: Fade,
       },
       styleOverrides: {
-        arrow: ({ ownerState, theme }) => ({
+        arrow: ({ theme }) => ({
           color: theme.palette.common.black,
         }),
-        tooltip: ({ ownerState, theme }) => ({
+        tooltip: ({ theme }) => ({
           fontSize: '14px',
           borderRadius: '2px',
           backgroundColor: theme.palette.common.black,


### PR DESCRIPTION
- Add ComplexMenu component used to combine multiple icon buttons and dropdown menus
- Update theme to disable ripple on all MUI button types, including IconButton



https://user-images.githubusercontent.com/17580037/204293516-7845791e-4798-4c17-b4d9-9da501ed765e.mov

