### PR TITLE
SWC-6327: allow to right click paste for user search

### DIFF
--- a/src/lib/containers/UserSearchBoxV2.tsx
+++ b/src/lib/containers/UserSearchBoxV2.tsx
@@ -152,6 +152,12 @@ const UserSearchBoxV2: React.FC<UserSearchBoxProps> = props => {
       styles={{
         // Bootstrap's form-control class overrides the display value, manually set to flex (the default without Bootstrap)
         control: styles => ({ ...styles, display: 'flex !important' }),
+        input: provided => ({
+          ...provided,
+          input: {
+            gridArea: '1 / 2 / 4 / 4 !important',
+          },
+        }),
       }}
       components={customSelectComponents}
       onChange={option => {

--- a/src/lib/containers/dataaccess/AccessRequirementSearchBox.tsx
+++ b/src/lib/containers/dataaccess/AccessRequirementSearchBox.tsx
@@ -122,6 +122,12 @@ export default function AccessRequirementSearchBox(
       styles={{
         // Bootstrap's form-control class overrides the display value, manually set to flex (the default without Bootstrap)
         control: styles => ({ ...styles, display: 'flex !important' }),
+        input: provided => ({
+          ...provided,
+          input: {
+            gridArea: '1 / 2 / 4 / 4 !important',
+          },
+        }),
       }}
       components={customSelectComponents}
       loadOptions={loadOptions}


### PR DESCRIPTION
Expand the input within react-select in order to easily right click the input which gives the option to paste.