### PR TITLE
PORTALS-2430

### DIFF
--- a/src/lib/containers/CardContainer.tsx
+++ b/src/lib/containers/CardContainer.tsx
@@ -111,8 +111,7 @@ export const CardContainer = (props: CardContainerProps) => {
       )
     }
     const listIds = data.queryResult!.queryResults.rows.map(
-      el =>
-        el.values.filter((id): id is string => id !== null)[userIdColumnIndex],
+      el => el.values[userIdColumnIndex],
     )
     cards = <UserCardList data={data} list={listIds} size={MEDIUM_USER_CARD} />
   } else {

--- a/src/mocks/msw/handlers/userProfileHandlers.ts
+++ b/src/mocks/msw/handlers/userProfileHandlers.ts
@@ -25,6 +25,7 @@ import {
   mockUserProfileData,
 } from '../../user/mock_user_profile'
 import { SynapseApiResponse } from '../handlers'
+import { UserProfileList } from '../../../lib/utils/SynapseClient'
 
 export const getUserProfileHandlers = (backendOrigin: string) => [
   /**
@@ -101,6 +102,22 @@ export const getUserProfileHandlers = (backendOrigin: string) => [
       return res(ctx.status(200), ctx.json(responsePage))
     },
   ),
+
+  /**
+   * Get a batch of user profiles
+   */
+  rest.post(`${backendOrigin}${USER_PROFILE}`, async (req, res, ctx) => {
+    const requestedList = (await req.json()).list as string[]
+    const responsePage: UserProfileList = {
+      list: mockUserData
+        .filter(userData => requestedList.includes(userData.id.toString()))
+        .map(userData => userData.userProfile)
+        .filter(
+          (userProfile): userProfile is UserProfile => userProfile != null,
+        ),
+    }
+    return res(ctx.status(200), ctx.json(responsePage))
+  }),
 
   /**
    * Get userGroupHeaders by prefix

--- a/src/mocks/query/mockUserCardTableQueryResultBundle.ts
+++ b/src/mocks/query/mockUserCardTableQueryResultBundle.ts
@@ -1,0 +1,67 @@
+import { QueryResultBundle } from '../../lib/utils/synapseTypes'
+import { MOCK_USER_ID } from '../user/mock_user_profile'
+
+const queryResultBundle: QueryResultBundle = {
+  concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
+  queryResult: {
+    concreteType: 'org.sagebionetworks.repo.model.table.QueryResult',
+    queryResults: {
+      concreteType: 'org.sagebionetworks.repo.model.table.RowSet',
+      tableId: 'syn13897207',
+      etag: '593afe35-0e97-436d-b7f3-ad00289b0ac0',
+      headers: [
+        {
+          name: 'firstName',
+          columnType: 'STRING',
+          id: '124219',
+        },
+        {
+          name: 'lastName',
+          columnType: 'STRING',
+          id: '124220',
+        },
+        {
+          name: 'institution',
+          columnType: 'STRING',
+          id: '124221',
+        },
+        {
+          name: 'ownerID',
+          columnType: 'USERID',
+          id: '124214',
+        },
+        {
+          name: 'Program',
+          columnType: 'STRING_LIST',
+          id: '151844',
+        },
+      ],
+      rows: [
+        {
+          rowId: 262,
+          versionNumber: 406,
+          values: [
+            'John',
+            'Doe',
+            'Sage Bionetworks',
+            MOCK_USER_ID.toString(),
+            '["My-program"]',
+          ],
+        },
+        {
+          rowId: 508,
+          versionNumber: 541,
+          values: [
+            'FakeFirst',
+            'FakeLast',
+            'Fake institution',
+            null,
+            '["Extra-data"]',
+          ],
+        },
+      ],
+    },
+  },
+}
+
+export default queryResultBundle


### PR DESCRIPTION
- Fix case where a bad filter would cause us to mis-index a USERID column, and make a malformed request to the backend
- Add mock data and test to verify that users with/out fake data are not filtered
- Pass null fake userProfile ID instead of empty string, so we don't make further invalid calls to the backend