### PR TITLE
PORTALS-2441: Fix flaky test

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.1",
+    "jest-fail-on-console": "^3.0.2",
     "jest-mock-promise": "^1.1.10",
     "jest-when": "^3.5.1",
     "jsdom": "^20.0.0",

--- a/src/__tests__/lib/containers/SynapseTable.test.tsx
+++ b/src/__tests__/lib/containers/SynapseTable.test.tsx
@@ -232,7 +232,7 @@ server.use(
 )
 
 describe('SynapseTable tests', () => {
-  // failOnConsole()
+  failOnConsole()
 
   beforeAll(() => {
     server.listen()

--- a/yarn.lock
+++ b/yarn.lock
@@ -10928,6 +10928,13 @@ jest-environment-node@^28.1.3:
     jest-mock "^28.1.3"
     jest-util "^28.1.3"
 
+jest-fail-on-console@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jest-fail-on-console/-/jest-fail-on-console-3.0.2.tgz#4ab3c5f1986702c1dfa099cbf303767818f6d916"
+  integrity sha512-8vpH03d9n41jKCF/rcQz/nf0ksK2hlnOXTY5VUMqliPHPfT9F7L9CYOyhFNSQ+o6Aszsuja0GAXt1jz6sfDM8w==
+  dependencies:
+    chalk "^4.1.0"
+
 jest-get-type@^28.0.2:
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-28.0.2.tgz#34622e628e4fdcd793d46db8a242227901fcf203"


### PR DESCRIPTION
Change SynapseTable.test.tsx so it doesn't log errors
Add `jest-fail-on-console` and use it in SynapseTable to prevent future issues. We should try to add this to as many tests as possible (or setupFilesOnEnv)