### PR TITLE
SWC-6318: Add TitleBarProperties component

### DIFF
--- a/src/_tests_/lib/containers/entity/page/title_bar/TitleBarProperties.test.tsx
+++ b/src/_tests_/lib/containers/entity/page/title_bar/TitleBarProperties.test.tsx
@@ -1,0 +1,304 @@
+import React from 'react'
+import * as UseGetEntityPropertiesModule from '../../../../../../lib/containers/entity/page/title_bar/useGetEntityTitleBarProperties'
+import { render, screen } from '@testing-library/react'
+import TitleBarProperties, {
+  TitleBarPropertiesProps,
+} from '../../../../../../lib/containers/entity/page/title_bar/TitleBarProperties'
+import mockFileEntity from '../../../../../../mocks/entity/mockFileEntity'
+import { createWrapper } from '../../../../../../lib/testutils/TestingLibraryUtils'
+import userEvent from '@testing-library/user-event'
+import * as HasAccessModule from '../../../../../../lib/containers/access_requirements/HasAccessV2'
+import { mockFileHandle } from '../../../../../../mocks/mock_file_handle'
+import { calculateFriendlyFileSize } from '../../../../../../lib/utils/functions/calculateFriendlyFileSize'
+import { rest, server } from '../../../../../../mocks/msw/server'
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '../../../../../../lib/utils/functions/getEndpoint'
+import { ENTITY_BUNDLE_V2 } from '../../../../../../lib/utils/APIConstants'
+import {
+  EntityBundle,
+  EntityChildrenResponse,
+  EntityType,
+} from '../../../../../../lib/utils/synapseTypes'
+import mockDataset from '../../../../../../mocks/entity/mockDataset'
+import { mockFolderEntity } from '../../../../../../mocks/entity/mockEntity'
+import failOnConsole from 'jest-fail-on-console'
+
+const HAS_ACCESS_V2_DATA_TEST_ID = 'mock-has-access-v2'
+
+jest
+  .spyOn(HasAccessModule, 'HasAccessV2')
+  .mockImplementation(() => (
+    <span data-testid={HAS_ACCESS_V2_DATA_TEST_ID}></span>
+  ))
+
+const mockOnActClick = jest.fn()
+
+function useEntityBundleOverride(bundle: EntityBundle) {
+  server.use(
+    rest.post(
+      `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${ENTITY_BUNDLE_V2(
+        ':entityId',
+      )}`,
+
+      async (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(bundle))
+      },
+    ),
+  )
+}
+
+function renderComponent(propOverrides?: Partial<TitleBarPropertiesProps>) {
+  return render(
+    <TitleBarProperties
+      entityId={mockFileEntity.id}
+      onActMemberClickAddConditionsForUse={mockOnActClick}
+      {...propOverrides}
+    />,
+    { wrapper: createWrapper() },
+  )
+}
+
+async function expandPropertiesIfPossible() {
+  try {
+    await userEvent.click(await screen.findByText(/\d+ more properties/))
+  } catch (e) {}
+}
+
+describe('TitleBarProperties', () => {
+  failOnConsole()
+  beforeAll(() => server.listen())
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  describe('Show/Hide properties', () => {
+    it('Shows all properties if there are 6 or less', async () => {
+      // Mock useGetEntityTitleBarProperties to return 6 properties
+      jest
+        .spyOn(UseGetEntityPropertiesModule, 'useGetEntityTitleBarProperties')
+        .mockImplementation(() => {
+          const properties = []
+          for (let i = 1; i <= 6; i++) {
+            properties.push({
+              key: i.toString(),
+              title: `Property ${i}`,
+              value: `Value ${i}`,
+            })
+          }
+          return properties
+        })
+
+      renderComponent()
+
+      for (let i = 1; i <= 6; i++) {
+        await screen.findByText(`Property ${i}`)
+        await screen.findByText(`Value ${i}`)
+      }
+      expect(screen.queryByText(/\d+ more properties/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Hide properties/)).not.toBeInTheDocument()
+    })
+    it('Shows 4 properties and can expand to show more if there are > 6', async () => {
+      // Mock useGetEntityTitleBarProperties to return 8 properties
+      jest
+        .spyOn(UseGetEntityPropertiesModule, 'useGetEntityTitleBarProperties')
+        .mockImplementation(() => {
+          const properties = []
+          for (let i = 1; i <= 8; i++) {
+            properties.push({
+              key: i.toString(),
+              title: `Property ${i}`,
+              value: `Value ${i}`,
+            })
+          }
+          return properties
+        })
+
+      renderComponent()
+
+      // Properties 1-4 should be visible
+      for (let i = 1; i <= 4; i++) {
+        await screen.findByText(`Property ${i}`)
+        await screen.findByText(`Value ${i}`)
+      }
+
+      // Properties 5-8 should not be visible
+      for (let i = 5; i <= 8; i++) {
+        expect(screen.queryByText(`Property ${i}`)).not.toBeInTheDocument()
+        expect(screen.queryByText(`Value ${i}`)).not.toBeInTheDocument()
+      }
+
+      const showMore = await screen.findByText(/4 more properties/)
+      await userEvent.click(showMore)
+
+      // Properties 1-8 should be visible
+      for (let i = 1; i <= 8; i++) {
+        await screen.findByText(`Property ${i}`)
+        await screen.findByText(`Value ${i}`)
+      }
+
+      const hide = await screen.findByText('Hide properties')
+      await userEvent.click(hide)
+
+      // Once again, properties 1-4 should remain visible
+      for (let i = 1; i <= 4; i++) {
+        await screen.findByText(`Property ${i}`)
+        await screen.findByText(`Value ${i}`)
+      }
+
+      // ...and properties 5-8 should not be visible
+      for (let i = 5; i <= 8; i++) {
+        expect(screen.queryByText(`Property ${i}`)).not.toBeInTheDocument()
+        expect(screen.queryByText(`Value ${i}`)).not.toBeInTheDocument()
+      }
+    })
+  })
+  describe('Displays individual properties', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(UseGetEntityPropertiesModule, 'useGetEntityTitleBarProperties')
+        .mockRestore()
+    })
+    it('SynID', async () => {
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText(`SynID`)
+      await screen.findByText(mockFileEntity.id)
+    })
+    it('HasAccess', async () => {
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText(`Access`)
+      await screen.findByTestId(HAS_ACCESS_V2_DATA_TEST_ID)
+    })
+    it('File size', async () => {
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText(`Size`)
+      await screen.findByText(
+        calculateFriendlyFileSize(mockFileHandle.contentSize),
+      )
+    })
+    it('File handle storage location', async () => {
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText(`Storage Location`)
+      await screen.findByText('Synapse Storage')
+    })
+    it('File handle endpoint, bucket, key', async () => {
+      const endpointUrl = 'https://my-endpoint.fake'
+      const bucket = 'my-bucket'
+      const fileKey = 'my-key'
+      useEntityBundleOverride({
+        ...mockFileEntity.bundle,
+        fileHandles: [
+          {
+            ...mockFileHandle,
+            concreteType:
+              'org.sagebionetworks.repo.model.file.ExternalObjectStoreFileHandle',
+            endpointUrl,
+            bucket,
+            fileKey,
+          },
+        ],
+      })
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText('Endpoint')
+      await screen.findByText(endpointUrl)
+      await screen.findByText('Bucket')
+      await screen.findByText(bucket)
+      await screen.findByText('File Key')
+      await screen.findByText(fileKey)
+      expect(screen.queryByText(`Storage Location`)).not.toBeInTheDocument()
+    })
+    it('File handle md5', async () => {
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText(`MD5`)
+      await screen.findByText(mockFileHandle.contentMd5!)
+    })
+    it('File handle download alias', async () => {
+      const fileName = 'custom-file-name-not-matching-entity-name.tar.gz'
+      useEntityBundleOverride({
+        ...mockFileEntity.bundle,
+        fileName,
+      })
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText(`Alias`)
+      await screen.findByText('Name when downloaded will be:')
+      await screen.findByText(fileName)
+    })
+    it('Does not show file handle download alias if it matches the name', async () => {
+      useEntityBundleOverride({
+        ...mockFileEntity.bundle,
+        fileName: mockFileEntity.entity.name,
+      })
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      expect(screen.queryByText(`Alias`)).not.toBeInTheDocument()
+    })
+    it('DOI', async () => {
+      const doiUri = '10.7303/syn12345678'
+      useEntityBundleOverride({
+        ...mockFileEntity.bundle,
+        doiAssociation: {
+          doiUri,
+        },
+      })
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText(`DOI`)
+      await screen.findByText('https://doi.org/10.7303/syn12345678')
+    })
+    it('Container fields (Child count, upload destination)', async () => {
+      useEntityBundleOverride({
+        ...mockFileEntity.bundle,
+        entity: mockFolderEntity,
+        entityType: EntityType.FOLDER,
+      })
+
+      server.use(
+        rest.post(
+          `${getEndpoint(
+            BackendDestinationEnum.REPO_ENDPOINT,
+          )}/repo/v1/entity/children`,
+          async (req, res, ctx) => {
+            const response: EntityChildrenResponse = {
+              page: [],
+              totalChildCount: 55,
+            }
+            return res(ctx.status(200), ctx.json(response))
+          },
+        ),
+      )
+
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText(`Items`)
+      await screen.findByText((55).toLocaleString())
+
+      await screen.findByText('Storage Location')
+      await screen.findByText('Synapse Storage')
+    })
+    it('Dataset items', async () => {
+      useEntityBundleOverride(mockDataset.bundle)
+      renderComponent()
+      await expandPropertiesIfPossible()
+
+      await screen.findByText(`Items`)
+      await screen.findByText(mockDataset.entity.items!.length.toString())
+    })
+  })
+})

--- a/src/_tests_/lib/utils/functions/FileHandleUtils.test.ts
+++ b/src/_tests_/lib/utils/functions/FileHandleUtils.test.ts
@@ -1,0 +1,304 @@
+import {
+  EntityBundle,
+  EntityType,
+  EXTERNAL_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  EXTERNAL_OBJECT_STORE_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  ExternalFileHandle,
+  ExternalObjectStoreFileHandle,
+  GOOGLE_CLOUD_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  GoogleCloudFileHandle,
+  PROXY_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  ProxyFileHandle,
+  S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  S3FileHandle,
+} from '../../../../lib/utils/synapseTypes'
+import {
+  ExternalGoogleCloudUploadDestination,
+  ExternalObjectStoreUploadDestination,
+  ExternalS3UploadDestination,
+  ExternalUploadDestination,
+  S3UploadDestination,
+  UploadType,
+} from '../../../../lib/utils/synapseTypes/File/UploadDestination'
+import { MOCK_USER_ID } from '../../../../mocks/user/mock_user_profile'
+import {
+  getDataFileHandle,
+  getFileHandleStorageInfo,
+  getStorageLocationName,
+  getUploadDestinationString,
+} from '../../../../lib/utils/functions/FileHandleUtils'
+
+describe('File Handle Utils', () => {
+  describe('getDataFileHandle', () => {
+    it('Returns the data file handle ID if it exists', () => {
+      const dataFileHandleId = '123'
+      const fileHandle = {
+        id: dataFileHandleId,
+      }
+      const entityBundle: EntityBundle = {
+        entity: {
+          dataFileHandleId: dataFileHandleId,
+        },
+        fileHandles: [fileHandle],
+        entityType: EntityType.FILE,
+      }
+
+      expect(getDataFileHandle(entityBundle)).toEqual(fileHandle)
+    })
+
+    it('Returns undefined if the bundle does not contain a data file handle', () => {
+      const dataFileHandleId = '123'
+      const entityBundle: EntityBundle = {
+        entity: {
+          dataFileHandleId: dataFileHandleId,
+        },
+        fileHandles: [],
+        entityType: EntityType.FILE,
+      }
+
+      expect(getDataFileHandle(entityBundle)).toBeUndefined()
+    })
+  })
+
+  describe('getFileHandleStorageInfo', () => {
+    it('Returns a URL for a ProxyFileHandle', () => {
+      const url = 'https://example.com'
+      const fileHandle: ProxyFileHandle = {
+        createdOn: '',
+        etag: '',
+        concreteType: PROXY_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+        filePath: url,
+        id: '123',
+        fileName: 'example.txt',
+        contentType: 'text/plain',
+        contentSize: 123,
+        createdBy: MOCK_USER_ID.toString(),
+      }
+      const result = getFileHandleStorageInfo(fileHandle)
+      expect(result).toEqual({ url: url })
+    })
+    it('Returns storage location information for an ExternalObjectStoreFileHandle', () => {
+      const endpoint = 'https://example.com'
+      const bucket = 'myBucket'
+      const fileKey = 'myFileKey'
+      const fileHandle: ExternalObjectStoreFileHandle = {
+        createdOn: '',
+        etag: '',
+        concreteType: EXTERNAL_OBJECT_STORE_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+        endpointUrl: endpoint,
+        bucket: bucket,
+        fileKey: fileKey,
+        id: '123',
+        fileName: 'example.txt',
+        contentType: 'text/plain',
+        contentSize: 123,
+        createdBy: MOCK_USER_ID.toString(),
+      }
+      const result = getFileHandleStorageInfo(fileHandle)
+      expect(result).toEqual({ endpoint, bucket, fileKey })
+    })
+
+    it('Returns a URL for an ExternalFileHandle', () => {
+      const url = 'https://example.com'
+      const fileHandle: ExternalFileHandle = {
+        createdOn: '',
+        etag: '',
+        concreteType: EXTERNAL_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+        externalURL: url,
+        id: '123',
+        fileName: 'example.txt',
+        contentType: 'text/plain',
+        contentSize: 123,
+        createdBy: MOCK_USER_ID.toString(),
+      }
+      const result = getFileHandleStorageInfo(fileHandle)
+      expect(result).toEqual({ url: url })
+    })
+
+    it('Returns Synapse Storage an S3FileHandle in the default Synapse StorageLocation', () => {
+      const synapseStorageLocationId = 1
+
+      const fileHandle: S3FileHandle = {
+        storageLocationId: synapseStorageLocationId,
+        createdOn: '',
+        etag: '',
+        concreteType: S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+        bucketName: 'myBucket',
+        key: 'myKey',
+        id: '123',
+        fileName: 'example.txt',
+        contentType: 'text/plain',
+        contentSize: 123,
+        createdBy: MOCK_USER_ID.toString(),
+      }
+      const result = getFileHandleStorageInfo(fileHandle)
+      expect(result).toEqual({
+        location: 'Synapse Storage',
+      })
+    })
+    it('Returns an S3 path for an S3FileHandle in a custom S3 storage location', () => {
+      const customStorageLocationId = 1243466
+
+      const fileHandle: S3FileHandle = {
+        storageLocationId: customStorageLocationId,
+        createdOn: '',
+        etag: '',
+        concreteType: S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+        bucketName: 'myBucket',
+        key: 'myKey',
+        id: '123',
+        fileName: 'example.txt',
+        contentType: 'text/plain',
+        contentSize: 123,
+        createdBy: MOCK_USER_ID.toString(),
+      }
+      const result = getFileHandleStorageInfo(fileHandle)
+      expect(result).toEqual({
+        location: 's3://myBucket',
+      })
+    })
+
+    it('Returns an gs path for a Google Cloud file handle', () => {
+      const customStorageLocationId = 1243466
+
+      const fileHandle: GoogleCloudFileHandle = {
+        storageLocationId: customStorageLocationId,
+        createdOn: '',
+        etag: '',
+        concreteType: GOOGLE_CLOUD_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+        bucketName: 'myBucket',
+        key: 'myKey',
+        id: '123',
+        fileName: 'example.txt',
+        contentType: 'text/plain',
+        contentSize: 123,
+        createdBy: MOCK_USER_ID.toString(),
+      }
+      const result = getFileHandleStorageInfo(fileHandle)
+      expect(result).toEqual({
+        location: 'gs://myBucket',
+      })
+    })
+  })
+  describe('getStorageLocationName', () => {
+    it("Returns 'Synapse Storage' for a file in  Synapse Storage", () => {
+      const storageLocationId = 1
+      const fileHandle: S3FileHandle = {
+        storageLocationId: storageLocationId,
+        concreteType: S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+      }
+      const result = getStorageLocationName(fileHandle)
+      expect(result).toEqual('Synapse Storage')
+    })
+
+    it('Returns an s3 path for an S3 file handle in a custom storage location', () => {
+      const storageLocationId = 1243466
+      const fileHandle: S3FileHandle = {
+        storageLocationId: storageLocationId,
+        bucketName: 'myBucket',
+        concreteType: S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+      }
+      const result = getStorageLocationName(fileHandle)
+      expect(result).toEqual('s3://myBucket')
+    })
+    it('Returns a gs path for an Google Cloud file handle in a custom storage location', () => {
+      const storageLocationId = 1243466
+      const fileHandle: GoogleCloudFileHandle = {
+        storageLocationId: storageLocationId,
+        bucketName: 'myBucket',
+        concreteType: GOOGLE_CLOUD_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+      }
+      const result = getStorageLocationName(fileHandle)
+      expect(result).toEqual('gs://myBucket')
+    })
+    it('Returns the file path for a ProxyFileHandle', () => {
+      const path = 'https://example.com'
+      const fileHandle: ProxyFileHandle = {
+        filePath: path,
+        concreteType: PROXY_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+      }
+      const result = getStorageLocationName(fileHandle)
+      expect(result).toEqual(path)
+    })
+
+    it('Returns the external url for an External File Handle', () => {
+      const url = 'https://example.com'
+      const fileHandle: ExternalFileHandle = {
+        externalURL: url,
+        concreteType: EXTERNAL_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+      }
+      const result = getStorageLocationName(fileHandle)
+      expect(result).toEqual(url)
+    })
+    it('Returns the bucket for an external object store file handle', () => {
+      const bucket = 'myExternalBucket'
+      const fileHandle: ExternalObjectStoreFileHandle = {
+        bucket: bucket,
+        concreteType: EXTERNAL_OBJECT_STORE_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+      }
+      const result = getStorageLocationName(fileHandle)
+      expect(result).toEqual(bucket)
+    })
+  })
+  describe('getUploadDestinationString', () => {
+    it("Returns 'Synapse Storage' the Synapse Storage upload destination", () => {
+      const uploadDestination: S3UploadDestination = {
+        concreteType: 'org.sagebionetworks.repo.model.file.S3UploadDestination',
+      }
+      const result = getUploadDestinationString(uploadDestination)
+      expect(result).toEqual('Synapse Storage')
+    })
+    it('Returns the URL for an ExternalUploadDestination', () => {
+      const uploadDestination: ExternalUploadDestination = {
+        concreteType:
+          'org.sagebionetworks.repo.model.file.ExternalUploadDestination',
+        uploadType: UploadType.HTTPS,
+        url: 'https://testUrl.com/abcdef',
+      }
+      const result = getUploadDestinationString(uploadDestination)
+      expect(result).toEqual('https://testUrl.com/abcdef')
+    })
+    it('Strips everything after the trailing slash for an ExternalUploadDestination with SFTP', () => {
+      const uploadDestination: ExternalUploadDestination = {
+        concreteType:
+          'org.sagebionetworks.repo.model.file.ExternalUploadDestination',
+        uploadType: UploadType.SFTP,
+        url: 'sftp://testUrl.com/abcdef',
+      }
+      const result = getUploadDestinationString(uploadDestination)
+      expect(result).toEqual('sftp://testUrl.com')
+    })
+    it('Returns an s3 path for an ExternalS3UploadDestination', () => {
+      const uploadDestination: ExternalS3UploadDestination = {
+        concreteType:
+          'org.sagebionetworks.repo.model.file.ExternalS3UploadDestination',
+        bucket: 'myBucket',
+        baseKey: 'myKey',
+      }
+      const result = getUploadDestinationString(uploadDestination)
+      expect(result).toEqual('s3://myBucket/myKey')
+    })
+
+    it('Returns a gs path for an ExternalGoogleCloudUploadDestination', () => {
+      const uploadDestination: ExternalGoogleCloudUploadDestination = {
+        concreteType:
+          'org.sagebionetworks.repo.model.file.ExternalGoogleCloudUploadDestination',
+        bucket: 'myBucket',
+        baseKey: 'myKey',
+      }
+      const result = getUploadDestinationString(uploadDestination)
+      expect(result).toEqual('gs://myBucket/myKey')
+    })
+
+    it('Returns a path for an ExternalObjectStoreUploadDestination', () => {
+      const uploadDestination: ExternalObjectStoreUploadDestination = {
+        concreteType:
+          'org.sagebionetworks.repo.model.file.ExternalObjectStoreUploadDestination',
+        endpointUrl: 'https://example.com',
+        bucket: 'myBucket',
+      }
+      const result = getUploadDestinationString(uploadDestination)
+      expect(result).toEqual('https://example.com/myBucket')
+    })
+  })
+})

--- a/src/lib/containers/entity/metadata/MetadataTable.tsx
+++ b/src/lib/containers/entity/metadata/MetadataTable.tsx
@@ -1,14 +1,16 @@
 import dayjs from 'dayjs'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { formatDate } from '../../../utils/functions/DateFormatter'
 import {
   entityTypeToFriendlyName,
   getVersionDisplay,
   isVersionableEntity,
 } from '../../../utils/functions/EntityTypeUtils'
-import { getLocationName } from '../../../utils/functions/FileHandleUtils'
+import {
+  getDataFileHandle,
+  getStorageLocationName,
+} from '../../../utils/functions/FileHandleUtils'
 import useGetEntityBundle from '../../../utils/hooks/SynapseAPI/entity/useEntityBundle'
-import { EntityType, FileEntity } from '../../../utils/synapseTypes'
 import UserCard from '../../UserCard'
 
 export type MetadataTableProps = {
@@ -24,19 +26,14 @@ export const MetadataTable = ({
 
   const isVersionable = entityBundle && isVersionableEntity(entityBundle.entity)
 
-  const [fileLocationName, setFileLocationName] = useState<string>()
+  const dataFileHandle = entityBundle
+    ? getDataFileHandle(entityBundle)
+    : undefined
 
-  useEffect(() => {
-    if (entityBundle?.entityType === EntityType.FILE) {
-      const dataFileHandle = entityBundle.fileHandles.filter(
-        fh => fh.id === (entityBundle.entity as FileEntity).dataFileHandleId,
-      )[0]
-
-      if (dataFileHandle) {
-        setFileLocationName(getLocationName(dataFileHandle))
-      }
-    }
-  }, [entityBundle])
+  let fileLocationName = undefined
+  if (dataFileHandle) {
+    fileLocationName = getStorageLocationName(dataFileHandle)
+  }
 
   return entityBundle ? (
     <table className="MetadataTable">

--- a/src/lib/containers/entity/page/title_bar/TitleBarProperties.tsx
+++ b/src/lib/containers/entity/page/title_bar/TitleBarProperties.tsx
@@ -20,7 +20,7 @@ function Property(props: PropertyProps) {
   const { title, value } = props
   return (
     <tr>
-      <td style={{ paddingRight: '5px' }}>
+      <td style={{ paddingRight: '1em' }}>
         <Typography
           component={'span'}
           variant={'smallText1'}

--- a/src/lib/containers/entity/page/title_bar/TitleBarProperties.tsx
+++ b/src/lib/containers/entity/page/title_bar/TitleBarProperties.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react'
+import { Box, Divider, Link, Stack, Typography } from '@mui/material'
+import { useGetEntityBundle } from '../../../../utils/hooks/SynapseAPI'
+import AddConditionsForUseButton from '../../../access_requirements/AddConditionsForUseButton'
+import { useSynapseContext } from '../../../../utils/SynapseContext'
+import { useGetEntityTitleBarProperties } from './useGetEntityTitleBarProperties'
+
+export type TitleBarPropertiesProps = {
+  entityId: string
+  versionNumber?: number
+  /* Callback invoked when an ACT member clicks "Add Conditions for Use". */
+  onActMemberClickAddConditionsForUse: () => void
+}
+
+type PropertyProps = {
+  title: string
+  value: React.ReactNode
+}
+function Property(props: PropertyProps) {
+  const { title, value } = props
+  return (
+    <tr>
+      <td style={{ paddingRight: '5px' }}>
+        <Typography
+          component={'span'}
+          variant={'smallText1'}
+          sx={{
+            fontWeight: 700,
+          }}
+        >
+          {title}
+        </Typography>
+      </td>
+      <td>
+        <Typography component={'span'} variant={'smallText1'}>
+          {value}
+        </Typography>
+      </td>
+    </tr>
+  )
+}
+
+export default function TitleBarProperties(props: TitleBarPropertiesProps) {
+  const { entityId, versionNumber, onActMemberClickAddConditionsForUse } = props
+  const { isInExperimentalMode } = useSynapseContext()
+  // We already fetch the bundle for the rest of the title bar and useGetEntityTitleBarProperties below, so the cache will be hot.
+  const { data: bundle } = useGetEntityBundle(entityId, versionNumber)
+
+  const [showAllProperties, setShowAllProperties] = useState(false)
+  const properties = useGetEntityTitleBarProperties(entityId, versionNumber)
+  return (
+    <Box sx={{ padding: '20px 40px' }}>
+      <Stack
+        direction={'row'}
+        justifyContent={'space-between'}
+        alignItems={'flex-start'}
+      >
+        <Stack
+          direction="row"
+          alignItems={'flex-start'}
+          divider={<Divider orientation="vertical" flexItem />}
+          spacing={2}
+        >
+          {/* Always show the first 4 properties*/}
+          <table>
+            <tbody>
+              {properties.slice(0, 2).map(p => {
+                return <Property key={p.key} title={p.title} value={p.value} />
+              })}
+            </tbody>
+          </table>
+          {properties.length > 2 && (
+            <table>
+              <tbody>
+                {properties.slice(2, 4).map(p => {
+                  return (
+                    <Property key={p.key} title={p.title} value={p.value} />
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+          {/* If there are 5 or 6 properties, show them in the last column */}
+          {(properties.length === 5 || properties.length === 6) && (
+            <table>
+              <tbody>
+                {properties.slice(4, 6).map(p => {
+                  return (
+                    <Property key={p.key} title={p.title} value={p.value} />
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+          {/* If there are more than 6 properties, then just show a button that toggles showing the rest */}
+          {properties.length > 6 && (
+            <Link onClick={() => setShowAllProperties(v => !v)}>
+              {showAllProperties
+                ? 'Hide properties'
+                : `${properties.length - 4} more properties`}
+            </Link>
+          )}
+        </Stack>
+        <AddConditionsForUseButton
+          entityId={entityId}
+          onACTMemberClick={onActMemberClickAddConditionsForUse}
+        />
+      </Stack>
+      {showAllProperties && (
+        <table>
+          <tbody>
+            {/* Show the remaining properties. */}
+            {properties.slice(4, Infinity).map(p => {
+              return <Property key={p.key} title={p.title} value={p.value} />
+            })}
+          </tbody>
+        </table>
+      )}
+      {bundle?.entity?.description && isInExperimentalMode && (
+        <Box sx={{ marginTop: '10px', maxWidth: '720px' }}>
+          {bundle?.entity?.description}
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/src/lib/containers/entity/page/title_bar/TitleBarProperties.tsx
+++ b/src/lib/containers/entity/page/title_bar/TitleBarProperties.tsx
@@ -40,14 +40,21 @@ function Property(props: PropertyProps) {
   )
 }
 
+/**
+ * The TitleBarProperties component displays a tabular view of the entity metadata on the Entity page.
+ */
 export default function TitleBarProperties(props: TitleBarPropertiesProps) {
   const { entityId, versionNumber, onActMemberClickAddConditionsForUse } = props
   const { isInExperimentalMode } = useSynapseContext()
-  // We already fetch the bundle for the rest of the title bar and useGetEntityTitleBarProperties below, so the cache will be hot.
+
+  // We don't need the entire bundle, but it's fetched for the rest of the title bar and useGetEntityTitleBarProperties below, so the cache will be hot.
   const { data: bundle } = useGetEntityBundle(entityId, versionNumber)
 
-  const [showAllProperties, setShowAllProperties] = useState(false)
+  // Actual entity data is fetched and transformed in this custom hook
   const properties = useGetEntityTitleBarProperties(entityId, versionNumber)
+
+  const [showAllProperties, setShowAllProperties] = useState(false)
+
   return (
     <Box sx={{ padding: '20px 40px' }}>
       <Stack

--- a/src/lib/containers/entity/page/title_bar/useGetEntityTitleBarProperties.tsx
+++ b/src/lib/containers/entity/page/title_bar/useGetEntityTitleBarProperties.tsx
@@ -140,11 +140,6 @@ export function useGetEntityTitleBarProperties(
       title: 'Items',
       value: datasetItems.toLocaleString(),
     },
-    md5 && {
-      key: 'fileMd5',
-      title: 'MD5',
-      value: <CopyToClipboardString value={md5} />,
-    },
     doi && {
       key: 'doi',
       title: 'DOI',
@@ -153,6 +148,11 @@ export function useGetEntityTitleBarProperties(
           {doi}
         </Link>
       ),
+    },
+    md5 && {
+      key: 'fileMd5',
+      title: 'MD5',
+      value: <CopyToClipboardString value={md5} />,
     },
     storageLocation && {
       key: 'fileStorageLocation',

--- a/src/lib/containers/entity/page/title_bar/useGetEntityTitleBarProperties.tsx
+++ b/src/lib/containers/entity/page/title_bar/useGetEntityTitleBarProperties.tsx
@@ -1,0 +1,158 @@
+import React from 'react'
+import {
+  useGetEntityBundle,
+  useGetEntityChildren,
+} from '../../../../utils/hooks/SynapseAPI'
+import {
+  EntityRefCollectionView,
+  EntityType,
+} from '../../../../utils/synapseTypes'
+import {
+  isContainerType,
+  isEntityRefCollectionView,
+} from '../../../../utils/functions/EntityTypeUtils'
+import { useGetDefaultUploadDestination } from '../../../../utils/hooks/SynapseAPI/file/useUploadDestination'
+import {
+  getDataFileHandle,
+  getFileHandleStorageInfo,
+  getUploadDestinationString,
+} from '../../../../utils/functions/FileHandleUtils'
+import { calculateFriendlyFileSize } from '../../../../utils/functions/calculateFriendlyFileSize'
+import { Box, Link } from '@mui/material'
+import { HasAccessV2 } from '../../../access_requirements/HasAccessV2'
+import CopyToClipboardString from '../../../CopyToClipboardString'
+
+export type EntityProperty = {
+  key: string
+  title: string
+  value: React.ReactNode
+}
+
+export function useGetEntityTitleBarProperties(
+  entityId: string,
+  versionNumber?: number,
+): EntityProperty[] {
+  const { data: bundle } = useGetEntityBundle(entityId, versionNumber)
+
+  const { data: entityChildrenResponse } = useGetEntityChildren(
+    {
+      parentId: entityId,
+      includeTypes: Object.values(EntityType),
+      includeTotalChildCount: true,
+    },
+    { enabled: !!(bundle?.entityType && isContainerType(bundle.entityType)) },
+  )
+
+  const { data: uploadDestination } = useGetDefaultUploadDestination(entityId, {
+    enabled: !!(bundle?.entityType && isContainerType(bundle.entityType)),
+  })
+
+  const dataFileHandle = bundle && getDataFileHandle(bundle)
+
+  const size =
+    dataFileHandle?.contentSize &&
+    calculateFriendlyFileSize(dataFileHandle.contentSize)
+  const fileHandleStorageInfo =
+    dataFileHandle && getFileHandleStorageInfo(dataFileHandle)
+  const storageLocation =
+    fileHandleStorageInfo &&
+    'location' in fileHandleStorageInfo &&
+    fileHandleStorageInfo.location
+  const endpoint =
+    fileHandleStorageInfo &&
+    'endpoint' in fileHandleStorageInfo &&
+    fileHandleStorageInfo.endpoint
+  const bucket =
+    fileHandleStorageInfo &&
+    'bucket' in fileHandleStorageInfo &&
+    fileHandleStorageInfo.bucket
+  const fileKey =
+    fileHandleStorageInfo &&
+    'fileKey' in fileHandleStorageInfo &&
+    fileHandleStorageInfo.fileKey
+
+  const md5 = dataFileHandle?.contentMd5
+  const downloadAlias =
+    bundle?.entity.name != bundle?.fileName && bundle?.fileName
+
+  const uploadDestinationString =
+    uploadDestination && getUploadDestinationString(uploadDestination)
+
+  const doi =
+    bundle?.doiAssociation?.doiUri &&
+    `https://doi.org/${bundle?.doiAssociation?.doiUri}`
+
+  const containerItems = entityChildrenResponse?.totalChildCount
+
+  const datasetItems =
+    bundle?.entity && isEntityRefCollectionView(bundle.entity)
+      ? ((bundle?.entity as EntityRefCollectionView).items ?? []).length
+      : null
+
+  return [
+    {
+      key: 'id',
+      title: 'SynID',
+      value: <CopyToClipboardString value={entityId} />,
+    },
+    {
+      key: 'access',
+      title: 'Access',
+      value: <HasAccessV2 entityId={entityId} />,
+    },
+    size && { key: 'fileSize', title: 'Size', value: size },
+    containerItems != null && {
+      key: 'containerItems',
+      title: 'Items',
+      value: containerItems.toLocaleString(),
+    },
+    datasetItems != null && {
+      key: 'entityRefCollectionItems',
+      title: 'Items',
+      value: datasetItems.toLocaleString(),
+    },
+    md5 && {
+      key: 'fileMd5',
+      title: 'MD5',
+      value: <CopyToClipboardString value={md5} />,
+    },
+    doi && {
+      key: 'doi',
+      title: 'DOI',
+      value: (
+        <Link href={doi} rel={'noopener noreferrer'} target={'_blank'}>
+          {doi}
+        </Link>
+      ),
+    },
+    storageLocation && {
+      key: 'fileStorageLocation',
+      title: 'Storage Location',
+      value: storageLocation,
+    },
+    uploadDestinationString && {
+      key: 'uploadDestination',
+      title: 'Storage Location',
+      value: uploadDestinationString,
+    },
+    endpoint && {
+      key: 'externalFileEndpoint',
+      title: 'Endpoint',
+      value: endpoint,
+    },
+    bucket && { key: 'externalFileBucket', title: 'Bucket', value: bucket },
+    fileKey && { key: 'externalFileKey', title: 'File Key', value: fileKey },
+    downloadAlias && {
+      key: 'fileAlias',
+      title: 'Alias',
+      value: (
+        <>
+          {'Name when downloaded will be: '}
+          <Box sx={{ display: 'inline', fontFamily: 'monospace' }}>
+            {downloadAlias}
+          </Box>
+        </>
+      ),
+    },
+  ].filter(item => !!item) as EntityProperty[]
+}

--- a/src/lib/containers/entity/page/title_bar/useGetEntityTitleBarProperties.tsx
+++ b/src/lib/containers/entity/page/title_bar/useGetEntityTitleBarProperties.tsx
@@ -30,6 +30,12 @@ export type EntityProperty = {
   value: React.ReactNode
 }
 
+/**
+ * This hook fetches all the entity metadata shown on the Entity page, and transforms the data into an ordered list of
+ * render-able key-value pairs.
+ * @param entityId
+ * @param versionNumber
+ */
 export function useGetEntityTitleBarProperties(
   entityId: string,
   versionNumber?: number,

--- a/src/lib/containers/widgets/RadioGroup.tsx
+++ b/src/lib/containers/widgets/RadioGroup.tsx
@@ -1,27 +1,27 @@
 import React, { useState } from 'react'
 import { uniqueId as _uniqueId } from 'lodash-es'
 
-export type RadioGroupProps = {
-  options: { label: string; value: string }[]
+export type RadioGroupProps<T extends string | boolean | number = string> = {
+  options: { label: string; value: T }[]
   id: string
   className?: string
-  value?: string
-  onChange: (value: string) => void
+  value?: T
+  onChange: (value: T) => void
 }
 
-export const RadioGroup: React.FunctionComponent<RadioGroupProps> = (
-  props: RadioGroupProps,
-) => {
+export function RadioGroup<T extends string | boolean | number = string>(
+  props: RadioGroupProps<T>,
+) {
   const className = props.className
     ? `radiogroup ${props.className}`
     : `radiogroup`
 
   return (
     <div className={className} role="radiogroup">
-      {props.options.map(option => (
-        <RadioOption
+      {props.options.map((option, index) => (
+        <RadioOption<T>
+          key={index.toString()}
           groupId={props.id}
-          key={option.value}
           label={option.label}
           value={option.value}
           currentValue={props.value}
@@ -32,17 +32,17 @@ export const RadioGroup: React.FunctionComponent<RadioGroupProps> = (
   )
 }
 
-type RadioOptionProps = {
+type RadioOptionProps<T extends string | boolean | number = string> = {
   groupId: string
   label: string
-  value: string
-  currentValue?: string
-  onChange: (value: string) => void
+  value: T
+  currentValue?: T
+  onChange: (value: T) => void
 }
 
-const RadioOption: React.FunctionComponent<RadioOptionProps> = (
-  props: RadioOptionProps,
-) => {
+function RadioOption<T extends string | boolean | number = string>(
+  props: RadioOptionProps<T>,
+) {
   const [uniqueId] = useState(_uniqueId('src-radio-'))
   return (
     <div onClick={() => props.onChange(props.value)}>
@@ -53,7 +53,7 @@ const RadioOption: React.FunctionComponent<RadioOptionProps> = (
           // no-op -- change is handled by the div
         }}
         checked={props.currentValue === props.value}
-        value={props.value}
+        value={props.value.toString()}
       />
       <label htmlFor={uniqueId}>{props.label}</label>
     </div>

--- a/src/lib/utils/APIConstants.ts
+++ b/src/lib/utils/APIConstants.ts
@@ -141,3 +141,6 @@ export const FORUM_THREAD = (id: string) => `${FORUM}/${id}/threads`
 export const THREAD = `${REPO}/thread`
 export const THREAD_ID = (id: string) => `${THREAD}/${id}`
 export const THREAD_REPLIES = (id: string) => `${THREAD_ID(id)}/replies`
+
+export const DOI = `${REPO}/doi`
+export const DOI_ASSOCIATION = `${DOI}/association`

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -269,6 +269,7 @@ import {
 } from './synapseTypes/Subscription'
 import { calculateFriendlyFileSize } from './functions/calculateFriendlyFileSize'
 import { PaginatedIds } from './synapseTypes/PaginatedIds'
+import { UploadDestination } from './synapseTypes/File/UploadDestination'
 
 const cookies = new UniversalCookies()
 
@@ -4254,6 +4255,29 @@ export function postSubscriptionList(
   return doPost<SubscriptionPagedResults>(
     '/repo/v1/subscription/list',
     request,
+    accessToken,
+    BackendDestinationEnum.REPO_ENDPOINT,
+  )
+}
+
+/**
+ * Get the default upload destination for the entity with the given id. The id might refer to the parent container
+ * (e.g. a folder or a project) where a file needs to be uploaded.
+ *
+ * The upload destination is generated according to the default StorageLocationSetting for the project where the entity
+ * resides. If the project does not contain any custom StorageLocationSetting the default synapse storage location is
+ * used to generate an upload destination.
+ *
+ * https://rest-docs.synapse.org/rest/GET/entity/id/uploadDestination.html
+ * @param containerEntityId
+ * @param accessToken
+ */
+export function getDefaultUploadDestination(
+  containerEntityId: string,
+  accessToken: string | undefined,
+): Promise<UploadDestination> {
+  return doGet<UploadDestination>(
+    `/file/v1/entity/${containerEntityId}/uploadDestination`,
     accessToken,
     BackendDestinationEnum.REPO_ENDPOINT,
   )

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -53,6 +53,7 @@ import {
   FORUM,
   THREAD,
   THREAD_ID,
+  DOI_ASSOCIATION,
 } from './APIConstants'
 import { dispatchDownloadListChangeEvent } from './functions/dispatchDownloadListChangeEvent'
 import {
@@ -134,6 +135,7 @@ import {
   VerificationSubmission,
   WikiPage,
   WikiPageKey,
+  DoiAssociation,
 } from './synapseTypes/'
 import {
   CreateSubmissionRequest,
@@ -4280,5 +4282,33 @@ export function getDefaultUploadDestination(
     `/file/v1/entity/${containerEntityId}/uploadDestination`,
     accessToken,
     BackendDestinationEnum.REPO_ENDPOINT,
+  )
+}
+
+/**
+ * Retrieves the DOI for the object. Note: this call only retrieves the DOI association, if it exists.
+ * To retrieve the metadata for the object, see GET /doi
+ *
+ * https://rest-docs.synapse.org/rest/GET/doi/association.html
+ */
+export function getDOIAssociation(
+  accessToken: string | undefined,
+  objectId: string,
+  objectVersion?: number,
+  objectType = 'ENTITY',
+): Promise<DoiAssociation | null> {
+  const params = new URLSearchParams()
+  params.set('type', objectType)
+  params.set('id', objectId)
+  if (objectVersion) {
+    params.set('type', objectVersion.toString())
+  }
+
+  return allowNotFoundError(() =>
+    doGet<DoiAssociation>(
+      `${DOI_ASSOCIATION}?${params.toString()}`,
+      accessToken,
+      BackendDestinationEnum.REPO_ENDPOINT,
+    ),
   )
 }

--- a/src/lib/utils/functions/FileHandleUtils.ts
+++ b/src/lib/utils/functions/FileHandleUtils.ts
@@ -1,16 +1,70 @@
 import {
+  EntityBundle,
+  EntityType,
+  EXTERNAL_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  EXTERNAL_OBJECT_STORE_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   ExternalFileHandle,
   ExternalObjectStoreFileHandle,
+  FileEntity,
   FileHandle,
-  ProxyFileHandle,
-  GoogleCloudFileHandle,
-  S3FileHandle,
-  PROXY_FILE_HANDLE_CONCRETE_TYPE_VALUE,
-  EXTERNAL_OBJECT_STORE_FILE_HANDLE_CONCRETE_TYPE_VALUE,
-  EXTERNAL_FILE_HANDLE_CONCRETE_TYPE_VALUE,
-  S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
   GOOGLE_CLOUD_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  GoogleCloudFileHandle,
+  PROXY_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  ProxyFileHandle,
+  S3_FILE_HANDLE_CONCRETE_TYPE_VALUE,
+  S3FileHandle,
 } from '../synapseTypes'
+import {
+  ExternalGoogleCloudUploadDestination,
+  ExternalObjectStoreUploadDestination,
+  ExternalS3UploadDestination,
+  ExternalUploadDestination,
+  UploadDestination,
+  UploadType,
+} from '../synapseTypes/File/UploadDestination'
+
+const SYNAPSE_STORAGE = 'Synapse Storage'
+const SYNAPSE_STORAGE_LOCATION_ID = 1
+
+type FileHandleStorageInfo =
+  | {
+      endpoint: string
+      bucket: string
+      fileKey: string
+    }
+  | { url: string }
+  | { location: string }
+
+/**
+ * Returns storage location information for a particular file handle, where the format of the information depends on the type of file handle.
+ * @param fileHandle
+ */
+export function getFileHandleStorageInfo(
+  fileHandle: FileHandle,
+): FileHandleStorageInfo {
+  switch (fileHandle.concreteType) {
+    case EXTERNAL_OBJECT_STORE_FILE_HANDLE_CONCRETE_TYPE_VALUE:
+      return {
+        endpoint: (fileHandle as ExternalObjectStoreFileHandle).endpointUrl,
+        bucket: (fileHandle as ExternalObjectStoreFileHandle).bucket,
+        fileKey: (fileHandle as ExternalObjectStoreFileHandle).fileKey,
+      }
+    case PROXY_FILE_HANDLE_CONCRETE_TYPE_VALUE:
+    case EXTERNAL_FILE_HANDLE_CONCRETE_TYPE_VALUE:
+      return { url: getStorageLocationName(fileHandle) }
+    case S3_FILE_HANDLE_CONCRETE_TYPE_VALUE:
+    case GOOGLE_CLOUD_FILE_HANDLE_CONCRETE_TYPE_VALUE:
+      return {
+        location: getStorageLocationName(fileHandle),
+      }
+    default:
+      throw new Error(
+        `Couldn't determine location name for file handle: ${JSON.stringify(
+          fileHandle,
+        )}`,
+      )
+  }
+}
 
 /**
  * Gets the friendly name of a bucket/storage location using the file handle.
@@ -18,7 +72,7 @@ import {
  * @param fileHandle
  * @returns
  */
-export function getLocationName(fileHandle: FileHandle) {
+export function getStorageLocationName(fileHandle: FileHandle) {
   switch (fileHandle.concreteType) {
     case PROXY_FILE_HANDLE_CONCRETE_TYPE_VALUE:
       return (fileHandle as ProxyFileHandle).filePath
@@ -27,8 +81,14 @@ export function getLocationName(fileHandle: FileHandle) {
     case EXTERNAL_FILE_HANDLE_CONCRETE_TYPE_VALUE:
       return (fileHandle as ExternalFileHandle).externalURL
     case S3_FILE_HANDLE_CONCRETE_TYPE_VALUE:
-      if ((fileHandle as S3FileHandle).storageLocationId === 1) {
-        return 'Synapse Storage'
+      // Uploads to Synapse Storage often do not get their storage location field back-filled,
+      // so null also indicates a Synapse-Stored file
+      if (
+        [null, SYNAPSE_STORAGE_LOCATION_ID].includes(
+          (fileHandle as S3FileHandle).storageLocationId,
+        )
+      ) {
+        return SYNAPSE_STORAGE
       } else {
         return `s3://${(fileHandle as S3FileHandle).bucketName}`
       }
@@ -41,4 +101,83 @@ export function getLocationName(fileHandle: FileHandle) {
         )}`,
       )
   }
+}
+
+/**
+ * Gets the data file handle from an entity bundle.
+ * Returns undefined if the entity does not have a data file handle that is visible to the caller.
+ * @param entityBundle
+ */
+export function getDataFileHandle(
+  entityBundle: EntityBundle,
+): FileHandle | undefined {
+  let dataFileHandle = undefined
+  if (entityBundle.entityType === EntityType.FILE) {
+    dataFileHandle = entityBundle.fileHandles.filter(
+      fh => fh.id === (entityBundle.entity as FileEntity).dataFileHandleId,
+    )[0]
+  }
+  return dataFileHandle
+}
+
+export function getUploadDestinationString(
+  uploadDestination: UploadDestination,
+) {
+  let uploadDestinationString = null
+  if (uploadDestination) {
+    switch (uploadDestination.concreteType) {
+      case 'org.sagebionetworks.repo.model.file.S3UploadDestination':
+        uploadDestinationString = SYNAPSE_STORAGE
+        break
+      case 'org.sagebionetworks.repo.model.file.ExternalUploadDestination':
+        uploadDestinationString = (
+          uploadDestination as ExternalUploadDestination
+        ).url
+        if (uploadDestination.uploadType === UploadType.SFTP) {
+          const indexOfLastSlash = uploadDestinationString.lastIndexOf('/')
+          if (indexOfLastSlash) {
+            uploadDestinationString = uploadDestinationString.substring(
+              0,
+              indexOfLastSlash,
+            )
+          }
+        }
+        break
+      case 'org.sagebionetworks.repo.model.file.ExternalS3UploadDestination':
+        uploadDestinationString =
+          's3://' +
+          (uploadDestination as ExternalS3UploadDestination).bucket +
+          '/'
+        if (
+          (uploadDestination as ExternalS3UploadDestination).baseKey != null
+        ) {
+          uploadDestinationString += (
+            uploadDestination as ExternalS3UploadDestination
+          ).baseKey
+        }
+        break
+      case 'org.sagebionetworks.repo.model.file.ExternalGoogleCloudUploadDestination':
+        uploadDestinationString =
+          'gs://' +
+          (uploadDestination as ExternalGoogleCloudUploadDestination).bucket +
+          '/'
+        if (
+          (uploadDestination as ExternalGoogleCloudUploadDestination).baseKey !=
+          null
+        ) {
+          uploadDestinationString += (
+            uploadDestination as ExternalGoogleCloudUploadDestination
+          ).baseKey
+        }
+        break
+      case 'org.sagebionetworks.repo.model.file.ExternalObjectStoreUploadDestination':
+        uploadDestinationString =
+          (uploadDestination as ExternalObjectStoreUploadDestination)
+            .endpointUrl +
+          '/' +
+          (uploadDestination as ExternalObjectStoreUploadDestination).bucket
+        break
+    }
+  }
+  return uploadDestinationString
 }

--- a/src/lib/utils/hooks/SynapseAPI/doi/useDOI.ts
+++ b/src/lib/utils/hooks/SynapseAPI/doi/useDOI.ts
@@ -1,0 +1,25 @@
+import { DoiAssociation } from '../../../synapseTypes'
+import { useQuery, UseQueryOptions } from 'react-query'
+import { SynapseClientError } from '../../../SynapseClientError'
+import { useSynapseContext } from '../../../SynapseContext'
+import { SynapseClient } from '../../../index'
+
+export function useGetDOIAssociation(
+  objectId: string,
+  versionNumber?: number,
+  objectType = 'ENTITY',
+  options?: UseQueryOptions<DoiAssociation | null, SynapseClientError>,
+) {
+  const { accessToken } = useSynapseContext()
+  return useQuery<DoiAssociation | null, SynapseClientError>(
+    ['doi', 'association', objectType, objectId, versionNumber],
+    () =>
+      SynapseClient.getDOIAssociation(
+        accessToken,
+        objectId,
+        versionNumber,
+        objectType,
+      ),
+    options,
+  )
+}

--- a/src/lib/utils/hooks/SynapseAPI/file/useUploadDestination.ts
+++ b/src/lib/utils/hooks/SynapseAPI/file/useUploadDestination.ts
@@ -1,0 +1,20 @@
+import { UseQueryOptions, useQuery } from 'react-query'
+import { SynapseClientError } from '../../../SynapseClientError'
+import { useSynapseContext } from '../../../SynapseContext'
+import { UploadDestination } from '../../../synapseTypes/File/UploadDestination'
+import { getDefaultUploadDestination } from '../../../SynapseClient'
+
+export function useGetDefaultUploadDestination(
+  containerEntityId: string,
+  options?: UseQueryOptions<UploadDestination, SynapseClientError>,
+) {
+  const { accessToken } = useSynapseContext()
+
+  return useQuery<UploadDestination, SynapseClientError>(
+    ['uploadDestination', 'default', containerEntityId],
+    () => getDefaultUploadDestination(containerEntityId, accessToken),
+    {
+      ...options,
+    },
+  )
+}

--- a/src/mocks/entity/mockFileEntity.ts
+++ b/src/mocks/entity/mockFileEntity.ts
@@ -143,6 +143,7 @@ const mockFileEntityBundle: EntityBundle = {
     },
   },
   rootWikiId: MOCK_WIKI_ID,
+  fileName: mockFileEntity.name,
   benefactorAcl: {
     id: parentId,
     creationDate: '2020-11-18T20:05:06.540Z',

--- a/src/mocks/msw/handlers/entityHandlers.ts
+++ b/src/mocks/msw/handlers/entityHandlers.ts
@@ -28,6 +28,10 @@ import mockEntities from '../../entity'
 import { MOCK_INVALID_PROJECT_NAME } from '../../entity/mockEntity'
 import { mockSchemaBinding } from '../../mockSchema'
 import { SynapseApiResponse } from '../handlers'
+import {
+  UploadDestination,
+  UploadType,
+} from '../../../lib/utils/synapseTypes/File/UploadDestination'
 
 export const getEntityHandlers = (backendOrigin: string) => [
   /**
@@ -240,6 +244,21 @@ export const getEntityHandlers = (backendOrigin: string) => [
       }
 
       return res(ctx.status(status), ctx.json(response))
+    },
+  ),
+
+  rest.get(
+    `${getEndpoint(
+      BackendDestinationEnum.REPO_ENDPOINT,
+    )}/file/v1/entity/:id/uploadDestination`,
+    async (req, res, ctx) => {
+      const response: UploadDestination = {
+        banner: '',
+        storageLocationId: 1,
+        uploadType: UploadType.S3,
+        concreteType: 'org.sagebionetworks.repo.model.file.S3UploadDestination',
+      }
+      return res(ctx.status(200), ctx.json(response))
     },
   ),
 ]

--- a/src/mocks/msw/handlers/userProfileHandlers.ts
+++ b/src/mocks/msw/handlers/userProfileHandlers.ts
@@ -3,6 +3,7 @@ import {
   FAVORITES,
   NOTIFICATION_EMAIL,
   PROFILE_IMAGE_PREVIEW,
+  USER_BUNDLE,
   USER_GROUP_HEADERS,
   USER_GROUP_HEADERS_BATCH,
   USER_ID_BUNDLE,
@@ -58,6 +59,17 @@ export const getUserProfileHandlers = (backendOrigin: string) => [
     const status = 200
     return res(ctx.status(status), ctx.json(response))
   }),
+
+  /**
+   * Get the caller's user bundle
+   */
+  rest.get(
+    `${getEndpoint(BackendDestinationEnum.REPO_ENDPOINT)}${USER_BUNDLE}`,
+    async (req, res, ctx) => {
+      const result: UserBundle = mockUserBundle
+      return res(ctx.status(200), ctx.json(result))
+    },
+  ),
 
   /**
    * Get a user bundle by ID


### PR DESCRIPTION
- Add TitleBarProperties component to handle rendering Entity property data
- Add useGetEntityTitleBarProperties hook to handle getting Entity property data
- Extract utilities from MetadataTable and move to FileHandleUtils to reuse
- Default mock handlers for upload destination, current user bundle


https://user-images.githubusercontent.com/17580037/210395280-3807affe-a0d5-4045-acd5-0d4d691f5a71.mov

