### PR TITLE
SWC-6356: RejectDataAccessRequestModal

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -43,6 +43,18 @@ export const parameters = {
 }
 
 export const globalTypes = {
+  showReactQueryDevtools: {
+    name: 'React Query Devtools',
+    defaultValue: false,
+    toolbar: {
+      icon: 'wrench',
+      showName: true,
+      items: [
+        { value: false, title: 'Hide React Query Devtools' },
+        { value: true, title: 'Show React Query Devtools' },
+      ],
+    },
+  },
   stack: {
     name: 'Stack',
     title: 'Stack Changer',

--- a/src/__tests__/lib/containers/dataaccess/SubmissionPage.test.tsx
+++ b/src/__tests__/lib/containers/dataaccess/SubmissionPage.test.tsx
@@ -241,7 +241,6 @@ describe('Submission Page tests', () => {
       {
         open: false,
         submissionId: SUBMITTED_SUBMISSION_ID,
-        tableId: 'syn50683097',
         onClose: expect.anything(),
       },
       expect.anything(),
@@ -256,7 +255,6 @@ describe('Submission Page tests', () => {
       {
         open: true, // !
         submissionId: SUBMITTED_SUBMISSION_ID,
-        tableId: 'syn50683097',
         onClose: expect.anything(),
       },
       expect.anything(),

--- a/src/__tests__/lib/containers/dataaccess/SubmissionPage.test.tsx
+++ b/src/__tests__/lib/containers/dataaccess/SubmissionPage.test.tsx
@@ -19,6 +19,7 @@ import {
   AccessControlList,
   ACCESS_TYPE,
   SubmissionState,
+  FileHandleAssociation,
 } from '../../../../lib/utils/synapseTypes'
 import {
   mockApprovedSubmission,
@@ -33,6 +34,8 @@ import {
   MOCK_USER_NAME,
   MOCK_USER_NAME_2,
 } from '../../../../mocks/user/mock_user_profile'
+import * as RejectDataAccessRequestModalModule from '../../../../lib/containers/dataaccess/RejectDataAccessRequestModal'
+import failOnConsoleError from 'jest-fail-on-console'
 
 function renderComponent(props: SubmissionPageProps) {
   render(<SubmissionPage {...props} />, {
@@ -44,12 +47,15 @@ const SUBMITTED_SUBMISSION_ID = mockSubmittedSubmission.id
 const APPROVED_SUBMISSION_ID = mockApprovedSubmission.id
 const REJECTED_SUBMISSION_ID = mockRejectedSubmission.id
 
-const onServerRecievedUpdate = jest.fn()
-const onRejectCallbackFn = jest.fn()
+const onServerReceivedUpdate = jest.fn()
 
 // Mock links to file handles
 jest.mock('../../../../lib/containers/widgets/FileHandleLink', () => ({
-  FileHandleLink: ({ fileHandleAssociation }) => (
+  FileHandleLink: ({
+    fileHandleAssociation,
+  }: {
+    fileHandleAssociation: FileHandleAssociation
+  }) => (
     <div data-testid="FileHandleLink">
       {JSON.stringify(fileHandleAssociation)}
     </div>
@@ -62,7 +68,13 @@ jest.mock('../../../../lib/containers/markdown/MarkdownSynapse', () => ({
   default: () => <div>Wiki Contents...</div>,
 }))
 
+// Mock the reject submission modal
+const mockRejectDataAccessRequestModal = jest
+  .spyOn(RejectDataAccessRequestModalModule, 'default')
+  .mockImplementation(() => <div data-testid="RejectDataAccessRequestModal" />)
+
 describe('Submission Page tests', () => {
+  failOnConsoleError()
   beforeAll(() => {
     server.listen()
 
@@ -124,7 +136,7 @@ describe('Submission Page tests', () => {
           BackendDestinationEnum.REPO_ENDPOINT,
         )}${DATA_ACCESS_SUBMISSION_BY_ID(':id')}`,
         async (req, res, ctx) => {
-          onServerRecievedUpdate(req.body)
+          onServerReceivedUpdate(await req.json())
           return res(ctx.status(200))
         },
       ),
@@ -139,7 +151,6 @@ describe('Submission Page tests', () => {
   it('Renders all fields', async () => {
     renderComponent({
       submissionId: SUBMITTED_SUBMISSION_ID,
-      onRejectClicked: onRejectCallbackFn,
     })
 
     await screen.findByText('Status')
@@ -194,7 +205,6 @@ describe('Submission Page tests', () => {
   it('Allows approving a SUBMITTED submission', async () => {
     renderComponent({
       submissionId: SUBMITTED_SUBMISSION_ID,
-      onRejectClicked: onRejectCallbackFn,
     })
 
     const approveButton = await screen.findByRole('button', { name: 'Approve' })
@@ -210,7 +220,7 @@ describe('Submission Page tests', () => {
     await userEvent.click(approveConfirmButton)
 
     await waitFor(() =>
-      expect(onServerRecievedUpdate).toBeCalledWith(
+      expect(onServerReceivedUpdate).toBeCalledWith(
         expect.objectContaining({
           newState: SubmissionState.APPROVED,
         }),
@@ -218,24 +228,44 @@ describe('Submission Page tests', () => {
     )
   })
 
-  it('Invokes a callback when rejecting a SUBMITTED submission', async () => {
+  it('Shows the rejection modal', async () => {
     renderComponent({
       submissionId: SUBMITTED_SUBMISSION_ID,
-      onRejectClicked: onRejectCallbackFn,
     })
 
-    const approveButton = await screen.findByRole('button', { name: 'Reject' })
+    // The modal is rendered but not shown
+    expect(
+      screen.queryByTestId('RejectDataAccessRequestModal'),
+    ).toBeInTheDocument()
+    expect(mockRejectDataAccessRequestModal).toHaveBeenLastCalledWith(
+      {
+        open: false,
+        submissionId: SUBMITTED_SUBMISSION_ID,
+        tableId: 'syn50683097',
+        onClose: expect.anything(),
+      },
+      expect.anything(),
+    )
 
-    await userEvent.click(approveButton)
+    // Click the reject button
+    const rejectButton = await screen.findByRole('button', { name: 'Reject' })
+    await userEvent.click(rejectButton)
 
-    await waitFor(() => expect(onRejectCallbackFn).toBeCalled())
-    expect(onServerRecievedUpdate).not.toHaveBeenCalled()
+    // The modal should be shown
+    expect(mockRejectDataAccessRequestModal).toHaveBeenLastCalledWith(
+      {
+        open: true, // !
+        submissionId: SUBMITTED_SUBMISSION_ID,
+        tableId: 'syn50683097',
+        onClose: expect.anything(),
+      },
+      expect.anything(),
+    )
   })
 
   it('Does not render action buttons for an APPROVED submission', () => {
     renderComponent({
       submissionId: APPROVED_SUBMISSION_ID,
-      onRejectClicked: onRejectCallbackFn,
     })
 
     expect(
@@ -249,7 +279,6 @@ describe('Submission Page tests', () => {
   it('Does not render action buttons for a REJECTED submission', () => {
     renderComponent({
       submissionId: REJECTED_SUBMISSION_ID,
-      onRejectClicked: onRejectCallbackFn,
     })
 
     expect(
@@ -286,7 +315,6 @@ describe('Submission Page tests', () => {
 
     renderComponent({
       submissionId: SUBMITTED_SUBMISSION_ID,
-      onRejectClicked: onRejectCallbackFn,
     })
 
     // When an ACL exists, don't show the ACT as the reviewer

--- a/src/lib/containers/StorybookComponentWrapper.tsx
+++ b/src/lib/containers/StorybookComponentWrapper.tsx
@@ -143,7 +143,9 @@ export function StorybookComponentWrapper(props: {
       }}
     >
       <MemoryRouter>
-        <ReactQueryDevtools />
+        {storybookContext.globals.showReactQueryDevtools && (
+          <ReactQueryDevtools />
+        )}
         <SynapseToastContainer />
         <main>{props.children}</main>
       </MemoryRouter>

--- a/src/lib/containers/dataaccess/RejectDataAccessRequestModal.stories.tsx
+++ b/src/lib/containers/dataaccess/RejectDataAccessRequestModal.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import RejectDataAccessRequestModal from './RejectDataAccessRequestModal'
+import { getHandlersForTableQuery } from '../../../mocks/msw/handlers/tableQueryHandlers'
+import mockRejectionReasonsTableQueryResultBundle from '../../../mocks/query/mockRejectionReasonsTableQueryResultBundle'
+import { MOCK_REPO_ORIGIN } from '../../utils/functions/getEndpoint'
+
+export default {
+  title: 'Governance/RejectDataAccessRequestModal',
+  component: RejectDataAccessRequestModal,
+  argTypes: {},
+} as ComponentMeta<typeof RejectDataAccessRequestModal>
+
+const Template: ComponentStory<typeof RejectDataAccessRequestModal> = args => (
+  <RejectDataAccessRequestModal {...args} />
+)
+
+export const Demo = Template.bind({})
+Demo.parameters = {
+  msw: {
+    handlers: [
+      ...getHandlersForTableQuery(
+        mockRejectionReasonsTableQueryResultBundle,
+        MOCK_REPO_ORIGIN,
+      ),
+    ],
+  },
+}
+Demo.args = { open: true, tableId: 'syn50683097' }

--- a/src/lib/containers/dataaccess/RejectDataAccessRequestModal.test.tsx
+++ b/src/lib/containers/dataaccess/RejectDataAccessRequestModal.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { createWrapper } from '../../testutils/TestingLibraryUtils'
+import RejectDataAccessRequestModal, {
+  RejectDataAccessRequestModalProps,
+} from './RejectDataAccessRequestModal'
+import { rest, server } from '../../../mocks/msw/server'
+import { getHandlersForTableQuery } from '../../../mocks/msw/handlers/tableQueryHandlers'
+import mockRejectionReasonsTableQueryResultBundle from '../../../mocks/query/mockRejectionReasonsTableQueryResultBundle'
+import userEvent from '@testing-library/user-event'
+import { mockSubmittedSubmission } from '../../../mocks/dataaccess/MockSubmission'
+import {
+  BackendDestinationEnum,
+  getEndpoint,
+} from '../../utils/functions/getEndpoint'
+import { DATA_ACCESS_SUBMISSION_BY_ID } from '../../utils/APIConstants'
+import { SubmissionState } from '../../utils/synapseTypes'
+import failOnConsoleError from 'jest-fail-on-console'
+
+const props: RejectDataAccessRequestModalProps = {
+  submissionId: mockSubmittedSubmission.id,
+  tableId: 'syn50683097',
+  open: true,
+  onClose: jest.fn(),
+}
+
+const onServerReceivedUpdate = jest.fn()
+
+function renderComponent() {
+  return render(<RejectDataAccessRequestModal {...props} />, {
+    wrapper: createWrapper(),
+  })
+}
+
+describe('RejectDataAccessRequestModal', () => {
+  failOnConsoleError()
+  beforeAll(() => {
+    server.listen()
+    server.use(
+      ...getHandlersForTableQuery(mockRejectionReasonsTableQueryResultBundle),
+      rest.put(
+        `${getEndpoint(
+          BackendDestinationEnum.REPO_ENDPOINT,
+        )}${DATA_ACCESS_SUBMISSION_BY_ID(':id')}`,
+        async (req, res, ctx) => {
+          onServerReceivedUpdate(await req.json())
+          return res(ctx.status(200))
+        },
+      ),
+    )
+  })
+  afterEach(() => server.restoreHandlers())
+  afterAll(() => server.close())
+
+  it('Shows options, generates an email, then invokes a callback', async () => {
+    renderComponent()
+    const dialog = await screen.findByRole('dialog')
+    within(dialog).getByText('Reject Request?')
+
+    // The mock data has the following categories
+    const categoryHeaders = []
+    categoryHeaders.push(
+      await within(dialog).findByText(
+        'Issue with the Intended Data Use Statement',
+      ),
+      await within(dialog).findByText('Issue with Documentation'),
+      await within(dialog).findByText('Other Issue'),
+    )
+
+    // The reasons are collapsed, click each header to show them
+    for (const header of categoryHeaders) {
+      await userEvent.click(header)
+    }
+    // There is one checkbox to select each reason. There is one reason for each row in the mock data
+    const checkboxes = await screen.findAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(
+      mockRejectionReasonsTableQueryResultBundle.queryResult!.queryResults!.rows
+        .length,
+    )
+
+    // Select a couple of reasons and then generate the email
+    await userEvent.click(
+      screen.getByText(
+        'The user did not provide the first and last name of the Project Lead',
+      ),
+    )
+    await userEvent.click(
+      screen.getByText(
+        'The user did not provide the correct Synapse IDs for their team',
+      ),
+    )
+
+    // Go to the next page to see the email
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Generate Email' }),
+    )
+
+    const email =
+      'Thank you for submitting your data access request.\n\n' +
+      'The information you provided on the electronic data access request tool is incomplete or requires more information. Please address the following:\n\n' +
+      '* Provide the first and last name of your Project Lead.\n\n' +
+      'To access this data, please provide complete and/or current documentation. The following items are incomplete or need to be updated:\n\n' +
+      '* Please provide the correct Synapse usernames of the members of your research team (these must match exactly between the DUC and the electronic data access request tool).\n\n' +
+      'If you have questions, do not respond to this email address. Instead, reply to:\nact@sagebionetworks.org'
+
+    const textField = await screen.findByRole('textbox')
+    expect(textField).toHaveValue(email)
+
+    // Manually modify the email
+    const customAddition = '\nHere is some custom text entered by the user'
+    await userEvent.type(textField, customAddition)
+
+    // Click the send button
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Reject and Notify Requester' }),
+    )
+
+    // Verify that we send the rejection request to the server
+    const fullRejectionMessage = email + customAddition
+    await waitFor(() => expect(onServerReceivedUpdate).toHaveBeenCalledTimes(1))
+    expect(onServerReceivedUpdate).toHaveBeenCalledWith({
+      submissionId: mockSubmittedSubmission.id,
+      newState: SubmissionState.REJECTED,
+      rejectedReason: fullRejectionMessage,
+    })
+    await waitFor(() => expect(props.onClose).toHaveBeenCalled())
+  })
+})

--- a/src/lib/containers/dataaccess/RejectDataAccessRequestModal.tsx
+++ b/src/lib/containers/dataaccess/RejectDataAccessRequestModal.tsx
@@ -35,6 +35,7 @@ import { SynapseClientError } from '../../utils/SynapseClientError'
 import FullWidthAlert from '../FullWidthAlert'
 import { UseQueryResult } from 'react-query'
 import { ErrorBanner } from '../error/ErrorBanner'
+import { displayToast } from '../ToastMessage'
 
 const CATEGORY_COLUMN_NAME = 'category'
 const CATEGORY_SECTION_EMAIL_TEXT_COLUMN_NAME = 'category email prompt'
@@ -343,6 +344,10 @@ export default function RejectDataAccessRequestModal(
       {
         onSuccess: () => {
           setError(null)
+          displayToast(
+            'Submission rejected and message sent to requester',
+            'info',
+          )
           onClose()
         },
         onError: e => {

--- a/src/lib/containers/dataaccess/RejectDataAccessRequestModal.tsx
+++ b/src/lib/containers/dataaccess/RejectDataAccessRequestModal.tsx
@@ -1,0 +1,417 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Box,
+  Button,
+  Checkbox,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material'
+import IconSvg from '../IconSvg'
+import {
+  useGetFullTableQueryResults,
+  useUpdateDataAccessSubmissionState,
+} from '../../utils/hooks/SynapseAPI'
+import {
+  BUNDLE_MASK_QUERY_RESULTS,
+  REJECT_SUBMISSION_CANNED_RESPONSES_TABLE,
+} from '../../utils/SynapseConstants'
+import { Set } from 'immutable'
+import {
+  QueryResultBundle,
+  Row,
+  SubmissionState,
+} from '../../utils/synapseTypes'
+import { SynapseSpinner } from '../LoadingScreen'
+import { SynapseClientError } from '../../utils/SynapseClientError'
+import FullWidthAlert from '../FullWidthAlert'
+import { UseQueryResult } from 'react-query'
+import { ErrorBanner } from '../error/ErrorBanner'
+
+const CATEGORY_COLUMN_NAME = 'category'
+const CATEGORY_SECTION_EMAIL_TEXT_COLUMN_NAME = 'category email prompt'
+const REJECTION_REASON_FORM_TEXT_COLUMN_NAME = 'rejection reason'
+const REJECTION_REASON_EMAIL_TEXT_COLUMN_NAME = 'email text'
+
+export type RejectDataAccessRequestModalProps = {
+  /* ID of the submission for which a rejection should be drafted/sent */
+  submissionId: string | number
+  /* SynID of the table which contains the email responses which should populate this modal. Defaults to syn50683097, which is in production Synapse */
+  tableId?: string
+  open: boolean
+  onClose: () => void
+}
+
+type RejectionCategoryProps = {
+  category: string
+  rows: Row[]
+  rejectionReasonFormTextIndex: number
+  selectedRowIds: Set<number>
+  setSelectedRowIds: React.Dispatch<React.SetStateAction<Set<number>>>
+}
+
+type SelectRejectionReasonsFormProps = {
+  tableQuery: UseQueryResult<QueryResultBundle, SynapseClientError>
+  selectedRowIds: Set<number>
+  setSelectedRowIds: React.Dispatch<React.SetStateAction<Set<number>>>
+}
+
+const DEFAULT_MESSAGE_PREPEND =
+  'Thank you for submitting your data access request.\n'
+const DEFAULT_MESSAGE_APPEND =
+  '\nIf you have questions, do not respond to this email address. Instead, reply to:\nact@sagebionetworks.org'
+
+/**
+ * Renders a rejection reason category and checkboxes for each reason in the category
+ */
+function RejectionCategory(props: RejectionCategoryProps) {
+  const {
+    category,
+    rows,
+    selectedRowIds,
+    setSelectedRowIds,
+    rejectionReasonFormTextIndex,
+  } = props
+  const [isExpanded, setIsExpanded] = React.useState(false)
+
+  return (
+    <>
+      <Typography
+        variant="body1"
+        onClick={() => setIsExpanded(!isExpanded)}
+        sx={{ fontWeight: 700, cursor: 'pointer', my: 1 }}
+      >
+        <IconSvg
+          icon={isExpanded ? 'expandMore' : 'chevronRight'}
+          sx={{ color: 'grey.700' }}
+          wrap={false}
+        />
+        {category}
+      </Typography>
+      <Collapse in={isExpanded}>
+        <Stack sx={{ ml: 3 }}>
+          {(rows ?? []).map(row => (
+            <FormControlLabel
+              key={row.rowId}
+              control={
+                <Checkbox
+                  checked={selectedRowIds.has(row.rowId!)}
+                  size={'small'}
+                  onChange={event => {
+                    if (event.target.checked) {
+                      setSelectedRowIds(selectedRowIds.add(row.rowId!))
+                    } else {
+                      setSelectedRowIds(selectedRowIds.remove(row.rowId!))
+                    }
+                  }}
+                />
+              }
+              label={
+                <Typography variant={'smallText1'}>
+                  {row.values[rejectionReasonFormTextIndex]}
+                </Typography>
+              }
+            />
+          ))}
+        </Stack>
+      </Collapse>
+    </>
+  )
+}
+
+/**
+ * Renders a form for selecting individual rejection reasons grouped by category.
+ * The rejection reason data comes from the table whose data is fetched in the tableQuery prop.
+ */
+function SelectRejectionReasonsForm(props: SelectRejectionReasonsFormProps) {
+  const { tableQuery, selectedRowIds, setSelectedRowIds } = props
+  const { data: tableData, isLoading, error } = tableQuery
+  const categoryIndex = tableData?.queryResult?.queryResults.headers.findIndex(
+    header => header.name.toLowerCase() === CATEGORY_COLUMN_NAME,
+  )
+  const rejectionReasonFormTextIndex =
+    tableData?.queryResult?.queryResults.headers.findIndex(
+      header =>
+        header.name.toLowerCase() === REJECTION_REASON_FORM_TEXT_COLUMN_NAME,
+    )
+
+  const rowsGroupedByCategory =
+    tableData &&
+    tableData.queryResult &&
+    tableData.queryResult.queryResults.rows.reduce(
+      (acc: Record<string, Row[]>, row) => {
+        const category: string = row.values[categoryIndex!]!
+        acc[category] = [...(acc[category] || []), row]
+        return acc
+      },
+      {},
+    )
+  return (
+    <>
+      <Typography variant="headline3" gutterBottom>
+        Reasons for rejecting
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        You may wish to reject the user&apos;s data access request for a
+        specific reason. The list below contains some common rejection reasons.
+        You will have a chance to edit the response before submitting it,
+        including adding any rejection reason(s) not listed here.
+      </Typography>
+      {isLoading && (
+        <Stack sx={{ my: 2 }}>
+          <SynapseSpinner size={30} />
+        </Stack>
+      )}
+      {error && <ErrorBanner error={error} />}
+      {rowsGroupedByCategory && (
+        <FormControl>
+          {Object.keys(rowsGroupedByCategory).map(category => (
+            <RejectionCategory
+              key={category}
+              category={category}
+              rows={rowsGroupedByCategory[category]}
+              selectedRowIds={selectedRowIds}
+              setSelectedRowIds={setSelectedRowIds}
+              rejectionReasonFormTextIndex={rejectionReasonFormTextIndex!}
+            />
+          ))}
+        </FormControl>
+      )}
+      <Typography variant="headline3" sx={{ mt: 1 }} gutterBottom>
+        We’ll generate a response email message based on your selections.
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        If your reasons for rejecting are not shown here, that’s okay! You can
+        edit the complete text of the message on the next screen before sending
+        it.
+      </Typography>
+    </>
+  )
+}
+
+type DraftRejectionMessageProps = {
+  emailText: string
+  setEmailText: React.Dispatch<React.SetStateAction<string>>
+}
+
+/**
+ * Presents a text field form that can be used to directly modify the rejection message.
+ */
+function DraftRejectionMessage(props: DraftRejectionMessageProps) {
+  const { emailText, setEmailText } = props
+  return (
+    <>
+      <Typography variant="headline3" gutterBottom>
+        Edit the text of the rejection message
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        This message will be sent to the data requester. You may edit it, or add
+        custom text to the message.
+      </Typography>
+      <TextField
+        multiline
+        fullWidth
+        rows={15}
+        value={emailText}
+        onChange={event => {
+          setEmailText(event.target.value)
+        }}
+      />
+    </>
+  )
+}
+type RejectionMessageObject = {
+  [category: string]: {
+    sectionText: string
+    reasons: string[]
+  }
+}
+
+/**
+ * Modal component presented to a data access submission reviewer when they decide to reject a request.
+ * The modal contains a form for selecting rejection reasons and a text field for editing the rejection message.
+ * After crafting a message, the user can reject the submission and send the message to the requester.
+ */
+export default function RejectDataAccessRequestModal(
+  props: RejectDataAccessRequestModalProps,
+) {
+  const {
+    open,
+    tableId = REJECT_SUBMISSION_CANNED_RESPONSES_TABLE,
+    onClose,
+    submissionId,
+  } = props
+
+  const [step, setStep] = React.useState<1 | 2>(1)
+  const [error, setError] = React.useState<SynapseClientError | null>(null)
+  // selectedRowIds are the row IDs of the canned responses the user selected:
+  const [emailText, setEmailText] = useState('')
+  const [selectedRowIds, setSelectedRowIds] = useState(Set<number>())
+
+  // Fetch the table data
+  const tableQuery = useGetFullTableQueryResults({
+    entityId: tableId,
+    query: {
+      sql: `SELECT * FROM ${tableId}`,
+    },
+    partMask: BUNDLE_MASK_QUERY_RESULTS,
+    concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
+  })
+
+  const { data } = tableQuery
+
+  const categoryIndex = data?.queryResult?.queryResults.headers.findIndex(
+    header => header.name.toLowerCase() === CATEGORY_COLUMN_NAME,
+  )
+  const categorySectionEmailTextIndex =
+    data?.queryResult?.queryResults.headers.findIndex(
+      header =>
+        header.name.toLowerCase() === CATEGORY_SECTION_EMAIL_TEXT_COLUMN_NAME,
+    )
+
+  const reasonEmailTextIndex =
+    data?.queryResult?.queryResults.headers.findIndex(
+      header =>
+        header.name.toLowerCase() === REJECTION_REASON_EMAIL_TEXT_COLUMN_NAME,
+    )
+
+  // Transform the selected rejection reasons into an object that can be easily transformed into an email
+  const defaultEmailMessageObject: RejectionMessageObject | undefined =
+    data &&
+    data.queryResult &&
+    selectedRowIds.reduce((messageObject: RejectionMessageObject, rowId) => {
+      const row = data.queryResult!.queryResults.rows.find(
+        row => row.rowId === rowId,
+      )!
+      const category = row.values[categoryIndex!]!
+      const sectionText = row.values[categorySectionEmailTextIndex!]!
+      const reasonText = row.values[reasonEmailTextIndex!]!
+      if (messageObject[category]) {
+        messageObject[category].reasons = [
+          ...messageObject[category].reasons,
+          reasonText,
+        ]
+      } else {
+        messageObject[category] = {
+          sectionText: sectionText,
+          reasons: [reasonText],
+        }
+      }
+      return messageObject
+    }, {})
+
+  // Using the rejection message object, create the email template.
+  const defaultEmailMessage =
+    defaultEmailMessageObject &&
+    DEFAULT_MESSAGE_PREPEND +
+      Object.keys(defaultEmailMessageObject).reduce((message, key) => {
+        const sectionText = defaultEmailMessageObject[key].sectionText
+        message += '\n' + sectionText + '\n'
+        for (const reason of defaultEmailMessageObject[key].reasons) {
+          message += '\n* ' + reason + '\n'
+        }
+        return message
+      }, '') +
+      DEFAULT_MESSAGE_APPEND
+
+  /* If the selected rows change, then reset the email text. */
+  useEffect(() => {
+    if (defaultEmailMessage) {
+      setEmailText(defaultEmailMessage)
+    }
+    // Specifically fire on update to just selectedRowIds
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedRowIds])
+
+  const { mutate } = useUpdateDataAccessSubmissionState()
+
+  function rejectSubmission(reason: string) {
+    mutate(
+      {
+        submissionId: submissionId.toString(),
+        newState: SubmissionState.REJECTED,
+        rejectedReason: reason,
+      },
+      {
+        onSuccess: () => {
+          setError(null)
+          onClose()
+        },
+        onError: e => {
+          setError(e)
+        },
+      },
+    )
+  }
+
+  // If fetching/processing the table fails, gracefully fall back to just show the email template
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth={'md'} fullWidth>
+      <DialogTitle>
+        <Stack direction="row" alignItems={'center'} gap={'5px'}>
+          Reject Request?
+          <Box sx={{ flexGrow: 1 }} />
+          <IconButton onClick={onClose}>
+            <IconSvg icon={'close'} wrap={false} sx={{ color: 'grey.700' }} />
+          </IconButton>
+        </Stack>
+      </DialogTitle>
+      <DialogContent>
+        {step === 1 && (
+          <SelectRejectionReasonsForm
+            tableQuery={tableQuery}
+            selectedRowIds={selectedRowIds}
+            setSelectedRowIds={setSelectedRowIds}
+          />
+        )}
+        {step === 2 && (
+          <DraftRejectionMessage
+            emailText={emailText}
+            setEmailText={setEmailText}
+          />
+        )}
+        {error && (
+          <FullWidthAlert
+            variant={'danger'}
+            description={error.reason}
+            isGlobal={false}
+          />
+        )}
+      </DialogContent>
+      <DialogActions>
+        {step === 2 && (
+          <Button variant="outlined" onClick={() => setStep(1)}>
+            Back
+          </Button>
+        )}
+        <Box sx={{ flexGrow: 1 }} />
+        <Button variant="outlined" onClick={onClose}>
+          Cancel
+        </Button>
+        {step === 1 && (
+          <Button variant="contained" onClick={() => setStep(2)}>
+            Generate Email
+          </Button>
+        )}
+        {step === 2 && (
+          <Button
+            variant="contained"
+            onClick={() => {
+              rejectSubmission(emailText)
+            }}
+          >
+            Reject and Notify Requester
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/lib/containers/dataaccess/ReviewerDashboard.tsx
+++ b/src/lib/containers/dataaccess/ReviewerDashboard.tsx
@@ -43,15 +43,12 @@ type ReviewerDashboardProps = {
   routerBaseName?: string
   /** If true use a MemoryRouter, which prevents the browser URL from updating. For demo purposes only. */
   useMemoryRouter?: boolean
-  /** Used to show the reject submission dialog */
-  onRejectSubmissionClicked: (onReject: (reason: string) => void) => void
 }
 
 export function ReviewerDashboard(props: ReviewerDashboardProps) {
   const {
     routerBaseName = '#!DataAccessManagement:default',
     useMemoryRouter = false,
-    onRejectSubmissionClicked,
   } = props
 
   const { data: userBundle, isLoading } = useGetCurrentUserBundle()
@@ -109,9 +106,7 @@ export function ReviewerDashboard(props: ReviewerDashboardProps) {
                 </Route>,
 
                 <Route path="/Submissions/:id" key="/Submissions/:id">
-                  <SubmissionPageRouteRenderer
-                    onRejectSubmissionClicked={onRejectSubmissionClicked}
-                  />
+                  <SubmissionPageRouteRenderer />
                 </Route>,
               ]}
               {
@@ -127,16 +122,9 @@ export function ReviewerDashboard(props: ReviewerDashboardProps) {
   )
 }
 
-function SubmissionPageRouteRenderer(props: {
-  onRejectSubmissionClicked: (onReject: (reason: string) => void) => void
-}) {
+function SubmissionPageRouteRenderer() {
   const { id } = useParams<{ id: string }>()
-  return (
-    <SubmissionPage
-      submissionId={id}
-      onRejectClicked={props.onRejectSubmissionClicked}
-    />
-  )
+  return <SubmissionPage submissionId={id} />
 }
 
 export default ReviewerDashboard

--- a/src/lib/containers/dataaccess/SubmissionPage.stories.tsx
+++ b/src/lib/containers/dataaccess/SubmissionPage.stories.tsx
@@ -11,6 +11,8 @@ import { mockSubmissions } from '../../../mocks/dataaccess/MockSubmission'
 import { mockManagedACTAccessRequirement } from '../../../mocks/mockAccessRequirements'
 import { SynapseErrorBoundary } from '../error/ErrorBanner'
 import { MOCK_REPO_ORIGIN } from '../../utils/functions/getEndpoint'
+import { getHandlersForTableQuery } from '../../../mocks/msw/handlers/tableQueryHandlers'
+import mockRejectionReasonsTableQueryResultBundle from '../../../mocks/query/mockRejectionReasonsTableQueryResultBundle'
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -87,6 +89,14 @@ Demo.parameters = {
               ],
             }),
           )
+        },
+      ),
+      ...getHandlersForTableQuery(mockRejectionReasonsTableQueryResultBundle),
+      rest.put(
+        `${MOCK_REPO_ORIGIN}${DATA_ACCESS_SUBMISSION_BY_ID(':id')}`,
+
+        async (req, res, ctx) => {
+          return res(ctx.status(201), ctx.json(await req.json()))
         },
       ),
     ],

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -729,8 +729,6 @@ export const getQueryTableResults = async (
  *     }
  * @param {*} queryBundleRequest
  * @param {*} [accessToken=undefined]
- * @param {boolean} [onlyGetFacets=false] Specify if the query only needs facets and no
- * data-- (internally this limits the row count to 1 on the request)
  * @returns Full dataset from synapse table query
  */
 

--- a/src/lib/utils/SynapseConstants.ts
+++ b/src/lib/utils/SynapseConstants.ts
@@ -130,3 +130,6 @@ export const BASE = 1024,
 
 export const NETWORK_UNAVAILABLE_MESSAGE =
   'This site cannot be reached. Either a connection is unavailable, or your network administrator has blocked you from accessing this site.'
+
+/* The ID of the table in production that contains the canned responses for the submission rejection form. */
+export const REJECT_SUBMISSION_CANNED_RESPONSES_TABLE = 'syn50683097'

--- a/src/lib/utils/hooks/SynapseAPI/entity/queryKeys.ts
+++ b/src/lib/utils/hooks/SynapseAPI/entity/queryKeys.ts
@@ -94,6 +94,14 @@ export const entityQueryKeys = {
     },
   ],
 
+  fullTableQueryResult: (queryBundleRequest: QueryBundleRequest) => [
+    {
+      ...entityQueryKeys.entity(queryBundleRequest.entityId)[0],
+      scope: 'fullTableQueryResult',
+      tableQueryBundleRequest: queryBundleRequest,
+    },
+  ],
+
   boundJSONSchema: (id: string) => [
     {
       ...entityQueryKeys.entity(id)[0],

--- a/src/lib/utils/hooks/SynapseAPI/entity/useGetQueryResultBundle.ts
+++ b/src/lib/utils/hooks/SynapseAPI/entity/useGetQueryResultBundle.ts
@@ -7,6 +7,7 @@ import {
   UseInfiniteQueryOptions,
   useQuery,
   UseQueryOptions,
+  UseQueryResult,
 } from 'react-query'
 import { SynapseClient } from '../../..'
 import { SynapseClientError } from '../../../SynapseClientError'
@@ -292,6 +293,26 @@ export function useInfiniteQueryResultBundle(
           ? (request.query.offset ?? 0) + pageSize
           : undefined
       },
+    },
+  )
+}
+
+/**
+ * Fetches all rows for a table query. Only use this request if you require all rows in a table at once.
+ */
+export function useGetFullTableQueryResults(
+  queryBundleRequest: QueryBundleRequest,
+  options?: UseQueryOptions<QueryResultBundle, SynapseClientError>,
+): UseQueryResult<QueryResultBundle, SynapseClientError> {
+  const { accessToken } = useSynapseContext()
+
+  return useQuery<QueryResultBundle, SynapseClientError>(
+    entityQueryKeys.fullTableQueryResult(queryBundleRequest),
+    () =>
+      SynapseClient.getFullQueryTableResults(queryBundleRequest, accessToken),
+    {
+      ...sharedQueryDefaults,
+      ...options,
     },
   )
 }

--- a/src/lib/utils/theme/DefaultTheme.ts
+++ b/src/lib/utils/theme/DefaultTheme.ts
@@ -35,6 +35,11 @@ const defaultMuiTheme: ThemeOptions = {
         }),
       },
     },
+    MuiCheckbox: {
+      defaultProps: {
+        color: 'secondary',
+      },
+    },
     MuiDialog: {
       defaultProps: {
         PaperProps: {

--- a/src/mocks/msw/handlers/tableQueryHandlers.ts
+++ b/src/mocks/msw/handlers/tableQueryHandlers.ts
@@ -50,18 +50,16 @@ function removeBundleFieldsUsingMask(
   return result
 }
 
-export function getHandlersForTableQuery(response: QueryResultBundle) {
+export function getHandlersForTableQuery(
+  response: QueryResultBundle,
+  backendOrigin = getEndpoint(BackendDestinationEnum.REPO_ENDPOINT),
+) {
   const asyncJobId = uniqueId()
   let queryBundleRequest: QueryBundleRequest | undefined
 
   return [
-    /**
-     * Create a new entity
-     */
     rest.post(
-      `${getEndpoint(
-        BackendDestinationEnum.REPO_ENDPOINT,
-      )}${TABLE_QUERY_ASYNC_START(':id')}`,
+      `${backendOrigin}${TABLE_QUERY_ASYNC_START(':id')}`,
       async (req, res, ctx) => {
         queryBundleRequest = req.body as QueryBundleRequest
         return res(
@@ -74,9 +72,7 @@ export function getHandlersForTableQuery(response: QueryResultBundle) {
     ),
 
     rest.get(
-      `${getEndpoint(
-        BackendDestinationEnum.REPO_ENDPOINT,
-      )}${ASYNCHRONOUS_JOB_TOKEN(asyncJobId)}`,
+      `${backendOrigin}${ASYNCHRONOUS_JOB_TOKEN(asyncJobId)}`,
       async (req, res, ctx) => {
         const resultBundle = removeBundleFieldsUsingMask(
           response,
@@ -110,9 +106,7 @@ export function getHandlersForTableQuery(response: QueryResultBundle) {
     ),
 
     rest.get(
-      `${getEndpoint(
-        BackendDestinationEnum.REPO_ENDPOINT,
-      )}${TABLE_QUERY_ASYNC_GET(':id', asyncJobId)}`,
+      `${backendOrigin}${TABLE_QUERY_ASYNC_GET(':id', asyncJobId)}`,
       async (req, res, ctx) => {
         const resultBundle = removeBundleFieldsUsingMask(
           response,

--- a/src/mocks/query/mockRejectionReasonsTableQueryResultBundle.ts
+++ b/src/mocks/query/mockRejectionReasonsTableQueryResultBundle.ts
@@ -1,0 +1,131 @@
+import { QueryResultBundle } from '../../lib/utils/synapseTypes'
+
+/**
+ * Mock data for the RejectDataAccessRequestModal
+ */
+const mockRejectionReasons: QueryResultBundle = {
+  concreteType: 'org.sagebionetworks.repo.model.table.QueryResultBundle',
+  queryResult: {
+    concreteType: 'org.sagebionetworks.repo.model.table.QueryResult',
+    queryResults: {
+      concreteType: 'org.sagebionetworks.repo.model.table.RowSet',
+      tableId: 'syn50683097',
+      etag: 'DEFAULT',
+      headers: [
+        { name: 'Category', columnType: 'STRING', id: '189246' },
+        {
+          name: 'Category Email Prompt',
+          columnType: 'LARGETEXT',
+          id: '189249',
+        },
+        { name: 'Rejection Reason', columnType: 'STRING', id: '189247' },
+        { name: 'Email Text', columnType: 'LARGETEXT', id: '189248' },
+      ],
+      rows: [
+        {
+          rowId: 1,
+          versionNumber: 0,
+          values: [
+            'Issue with the Intended Data Use Statement',
+            'The information you provided on the electronic data access request tool is incomplete or requires more information. Please address the following:',
+            'The user did not provide the first and last name of the Project Lead',
+            'Provide the first and last name of your Project Lead.',
+          ],
+        },
+        {
+          rowId: 2,
+          versionNumber: 0,
+          values: [
+            'Issue with the Intended Data Use Statement',
+            'The information you provided on the electronic data access request tool is incomplete or requires more information. Please address the following:',
+            'The user did not provide the full, unabbreviated name of their institution',
+            'Provide the full, unabbreviated name of your institution.',
+          ],
+        },
+        {
+          rowId: 3,
+          versionNumber: 0,
+          values: [
+            'Issue with the Intended Data Use Statement',
+            'The information you provided on the electronic data access request tool is incomplete or requires more information. Please address the following:',
+            'The user did not provide enough information in their Intended Data Use (IDU) statement',
+            'Please add more information to your Intended Data Use statement. Your Intended Data Use statement should address the following points: What do you want to do? Why are you doing it? How do you want to do it?',
+          ],
+        },
+        {
+          rowId: 4,
+          versionNumber: 0,
+          values: [
+            'Issue with Documentation',
+            'To access this data, please provide complete and/or current documentation. The following items are incomplete or need to be updated:',
+            'The user submitted the wrong version of the DUC',
+            'You have submitted an older version of the data use certificate (DUC). Please download and execute the updated version of the DUC. The current version is embedded in the electronic data access request tool.',
+          ],
+        },
+        {
+          rowId: 5,
+          versionNumber: 0,
+          values: [
+            'Issue with Documentation',
+            'To access this data, please provide complete and/or current documentation. The following items are incomplete or need to be updated:',
+            'The DUC is not signed by the signing official',
+            'Please complete your data use certificate (DUC) with your signing official\u2019s details, including signature and date. (This should be an institutional representative with signing authority, e.g., Department Head).',
+          ],
+        },
+        {
+          rowId: 6,
+          versionNumber: 0,
+          values: [
+            'Issue with Documentation',
+            'To access this data, please provide complete and/or current documentation. The following items are incomplete or need to be updated:',
+            'The DUC is missing the PI\u2019s details and/or signature',
+            'Please complete your data use certificate (DUC) with your Principal Investigator\u2019s details, including signature and date',
+          ],
+        },
+        {
+          rowId: 7,
+          versionNumber: 0,
+          values: [
+            'Issue with Documentation',
+            'To access this data, please provide complete and/or current documentation. The following items are incomplete or need to be updated:',
+            'The user did not provide the correct Synapse IDs for their team',
+            'Please provide the correct Synapse usernames of the members of your research team (these must match exactly between the DUC and the electronic data access request tool).',
+          ],
+        },
+        {
+          rowId: 8,
+          versionNumber: 0,
+          values: [
+            'Issue with Documentation',
+            'To access this data, please provide complete and/or current documentation. The following items are incomplete or need to be updated:',
+            'The user\u2019s team did not sign the DUC',
+            'Please ensure all members of your research team sign and date the data use certificate (DUC).',
+          ],
+        },
+        {
+          rowId: 9,
+          versionNumber: 0,
+          values: [
+            'Issue with Documentation',
+            'To access this data, please provide complete and/or current documentation. The following items are incomplete or need to be updated:',
+            'The user did not submit the applicable IRB / IEC / ERC approval for their research',
+            'Please submit the applicable ethics committee approval letter (IRB/IEC/ERC) that indicates approval for your research using this dataset.',
+          ],
+        },
+        {
+          rowId: 10,
+          versionNumber: 0,
+          values: [
+            'Other Issue',
+            'Please note the following with your access request:',
+            'Other',
+            null,
+          ],
+        },
+      ],
+    },
+  },
+  maxRowsPerPage: 314,
+}
+
+export default mockRejectionReasons


### PR DESCRIPTION
- Add RejectDataAccessRequestModal
- Create useGetFullTableQueryResults hook to wrap SynapseClient.getFullQueryTableResults
- Show RejectDataAccessRequestModal when rejecting a submission from the SubmissionPage component
- Add Storybook control to show/hide React Query Devtools


https://user-images.githubusercontent.com/17580037/212126432-a7d2e14d-4976-450f-a289-bf377c80e734.mov

