### PR TITLE
SWC-6362 and SWC-6369: Entity Title Bar design tweaks

### DIFF
--- a/src/lib/containers/entity/page/title_bar/EntityPageTitleBar.tsx
+++ b/src/lib/containers/entity/page/title_bar/EntityPageTitleBar.tsx
@@ -44,7 +44,7 @@ export default function EntityPageTitleBar(props: EntityPageTitleBarProps) {
     <div>
       <Box
         sx={{
-          padding: '30px 40px',
+          padding: '20px 40px',
           backgroundColor: 'grey.100',
         }}
       >

--- a/src/lib/containers/entity/page/title_bar/TitleBarProperties.tsx
+++ b/src/lib/containers/entity/page/title_bar/TitleBarProperties.tsx
@@ -114,14 +114,16 @@ export default function TitleBarProperties(props: TitleBarPropertiesProps) {
         />
       </Stack>
       {showAllProperties && (
-        <table>
-          <tbody>
-            {/* Show the remaining properties. */}
-            {properties.slice(4, Infinity).map(p => {
-              return <Property key={p.key} title={p.title} value={p.value} />
-            })}
-          </tbody>
-        </table>
+        <Box sx={{ pt: '20px' }}>
+          <table>
+            <tbody>
+              {/* Show the remaining properties. */}
+              {properties.slice(4, Infinity).map(p => {
+                return <Property key={p.key} title={p.title} value={p.value} />
+              })}
+            </tbody>
+          </table>
+        </Box>
       )}
       {bundle?.entity?.description && isInExperimentalMode && (
         <Box sx={{ marginTop: '10px', maxWidth: '720px' }}>

--- a/src/lib/containers/menu/DropdownMenu.tsx
+++ b/src/lib/containers/menu/DropdownMenu.tsx
@@ -207,13 +207,19 @@ export function DropdownMenu(props: DropdownMenuProps) {
                                 }
                               }}
                             >
-                              <ListItemIcon>
+                              <ListItemIcon
+                                style={{
+                                  // MUI has specified a more specific minWidth for ListItemIcon inside a MenuList than
+                                  // we can create with sx, so apply an inline style for this property only.
+                                  minWidth: '30px',
+                                }}
+                              >
                                 {item.icon && (
                                   <IconSvg
                                     icon={item.icon}
                                     sx={{
-                                      width: '16px',
-                                      height: '16px',
+                                      width: '17px',
+                                      height: '17px',
                                       ...item.iconSx,
                                     }}
                                     wrap={false}

--- a/src/lib/utils/theme/DefaultTheme.ts
+++ b/src/lib/utils/theme/DefaultTheme.ts
@@ -80,7 +80,8 @@ const defaultMuiTheme: ThemeOptions = {
       styleOverrides: {
         root: {
           height: '38px',
-          px: '12px',
+          paddingLeft: '12px',
+          paddingRight: '12px',
         },
       },
     },

--- a/src/lib/utils/theme/DefaultTheme.ts
+++ b/src/lib/utils/theme/DefaultTheme.ts
@@ -76,6 +76,14 @@ const defaultMuiTheme: ThemeOptions = {
         }),
       },
     },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          height: '38px',
+          px: '12px',
+        },
+      },
+    },
     MuiTooltip: {
       defaultProps: {
         arrow: true,


### PR DESCRIPTION
- Adjust padding values in EntityPageTitleBar, TitleBarProperties per design
- Adjust height, sizing values in DropdownMenu per design


Ex. 1 - Top padding is now 20px

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/17580037/212935207-5db9c345-d5dc-44dd-8d1b-2d374d2f2360.png">

Ex. 2 - Padding above extra properties is now 20px

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/17580037/212935398-f96e4ce6-04b8-43a0-9043-5671e865b410.png">

Ex. 3 - Height of dropdown menu items is now 38px (26px + 2*6px padding), less side padding (now 12px, was 16px)

<img width="312" alt="image" src="https://user-images.githubusercontent.com/17580037/212937518-c40bf3ff-8ce7-491e-bbad-3f3e27b94941.png">

Ex. 4 - Less space between icon and text (container has width of 30px, down from 36px). Also bumped icon size up 1px in height and width

<img width="312" alt="image" src="https://user-images.githubusercontent.com/17580037/212937662-e4efbe9e-2b1d-4348-99f3-390379551972.png">
