### PR TITLE
SWC-6355: Handle case where caller does not have access to project in Entity Finder

### DIFF
--- a/src/lib/containers/entity_finder/SelectionPane.tsx
+++ b/src/lib/containers/entity_finder/SelectionPane.tsx
@@ -75,7 +75,8 @@ const EntityPathDisplay: React.FunctionComponent<{
 
   useEffect(() => {
     if (bundle?.path?.path) {
-      setEntityName(bundle.path.path[bundle.path.path.length - 1].name)
+      const header = bundle.path.path[bundle.path.path.length - 1]
+      setEntityName(header.name ?? header.id)
       const path = bundle.path.path.slice(1, bundle.path.path.length - 1) // drop the first element, which is always syn4489 "root"
       setFullPath(path.map(header => header.name).join('/'))
       if (path.length < 4) {

--- a/src/lib/utils/APIConstants.ts
+++ b/src/lib/utils/APIConstants.ts
@@ -33,6 +33,9 @@ export const ENTITY_BUNDLE_V2 = (
 export const ENTITY_ACCESS = (id: string | number) =>
   `${REPO}/entity/${id}/access`
 
+export const ENTITY_PATH = (id: string | number) => `${ENTITY_ID(id)}/path`
+export const ENTITY_HEADER_BY_ID = (id: string | number) =>
+  `${ENTITY_ID(id)}/type`
 export const ENTITY_HEADERS = `${REPO}/entity/header`
 
 export const ENTITY_JSON = (id: string | number) => `${REPO}/entity/${id}/json`
@@ -174,3 +177,5 @@ export const ACCESS_REQUIREMENT_RESEARCH_PROJECT_FOR_UPDATE = (
 
 export const FILE_HANDLE = `${FILE}/fileHandle`
 export const FILE_HANDLE_BATCH = `${FILE_HANDLE}/batch`
+
+export const PROJECTS = `${REPO}/projects`

--- a/src/lib/utils/SynapseClient.ts
+++ b/src/lib/utils/SynapseClient.ts
@@ -4,9 +4,13 @@ import UniversalCookies from 'universal-cookie'
 import { SynapseConstants } from '.'
 import { PROVIDERS } from '../containers/Login'
 import {
+  ACCESS_APPROVAL,
+  ACCESS_APPROVAL_BY_ID,
   ACCESS_REQUEST_SUBMISSION_SEARCH,
   ACCESS_REQUIREMENT_ACL,
   ACCESS_REQUIREMENT_BY_ID,
+  ACCESS_REQUIREMENT_DATA_ACCESS_REQUEST_FOR_UPDATE,
+  ACCESS_REQUIREMENT_RESEARCH_PROJECT_FOR_UPDATE,
   ACCESS_REQUIREMENT_SEARCH,
   ACCESS_REQUIREMENT_STATUS,
   ACCESS_REQUIREMENT_WIKI_PAGE_KEY,
@@ -14,25 +18,35 @@ import {
   ALIAS_AVAILABLE,
   APPROVED_SUBMISSION_INFO,
   ASYNCHRONOUS_JOB_TOKEN,
+  DATA_ACCESS_REQUEST,
+  DATA_ACCESS_REQUEST_SUBMISSION,
   DATA_ACCESS_SUBMISSION_BY_ID,
+  DOI_ASSOCIATION,
   ENTITY,
   ENTITY_ACCESS,
+  ENTITY_ACCESS_REQUIREMENTS,
   ENTITY_BUNDLE_V2,
+  ENTITY_HEADER_BY_ID,
   ENTITY_HEADERS,
   ENTITY_ID,
   ENTITY_JSON,
+  ENTITY_PATH,
   ENTITY_SCHEMA_BINDING,
   ENTITY_SCHEMA_VALIDATION,
   EVALUATION,
   EVALUATION_BY_ID,
   EVALUATIONS_BY_ID,
   FAVORITES,
+  FILE_HANDLE_BATCH,
+  FORUM,
   FORUM_THREAD,
   NOTIFICATION_EMAIL,
   PROFILE_IMAGE_PREVIEW,
-  REGISTERED_SCHEMA_ID,
+  PROJECTS,
   REGISTER_ACCOUNT_STEP_1,
   REGISTER_ACCOUNT_STEP_2,
+  REGISTERED_SCHEMA_ID,
+  RESEARCH_PROJECT,
   SCHEMA_VALIDATION_GET,
   SCHEMA_VALIDATION_START,
   SIGN_TERMS_OF_USE,
@@ -40,6 +54,8 @@ import {
   TABLE_QUERY_ASYNC_START,
   TEAM_ID_MEMBER_ID,
   TEAM_MEMBERS,
+  THREAD,
+  THREAD_ID,
   TRASHCAN_PURGE,
   TRASHCAN_RESTORE,
   TRASHCAN_VIEW,
@@ -50,19 +66,6 @@ import {
   USER_PROFILE,
   USER_PROFILE_ID,
   VERIFICATION_SUBMISSION,
-  FORUM,
-  THREAD,
-  THREAD_ID,
-  DOI_ASSOCIATION,
-  ENTITY_ACCESS_REQUIREMENTS,
-  ACCESS_APPROVAL_BY_ID,
-  ACCESS_APPROVAL,
-  ACCESS_REQUIREMENT_RESEARCH_PROJECT_FOR_UPDATE,
-  RESEARCH_PROJECT,
-  DATA_ACCESS_REQUEST,
-  ACCESS_REQUIREMENT_DATA_ACCESS_REQUEST_FOR_UPDATE,
-  DATA_ACCESS_REQUEST_SUBMISSION,
-  FILE_HANDLE_BATCH,
 } from './APIConstants'
 import { dispatchDownloadListChangeEvent } from './functions/dispatchDownloadListChangeEvent'
 import {
@@ -76,12 +79,12 @@ import {
   NETWORK_UNAVAILABLE_MESSAGE,
 } from './SynapseConstants'
 import {
+  ACCESS_TYPE,
   AccessApproval,
   AccessCodeResponse,
   AccessControlList,
   AccessRequirement,
   AccessRequirementStatus,
-  ACCESS_TYPE,
   ACTSubmissionStatus,
   AddPartResponse,
   AsynchronousJobStatus,
@@ -92,6 +95,7 @@ import {
   BatchPresignedUploadUrlResponse,
   BulkFileDownloadRequest,
   BulkFileDownloadResponse,
+  DoiAssociation,
   DownloadFromTableRequest,
   DownloadFromTableResult,
   DownloadList,
@@ -147,7 +151,6 @@ import {
   VerificationSubmission,
   WikiPage,
   WikiPageKey,
-  DoiAssociation,
 } from './synapseTypes/'
 import {
   CreateSubmissionRequest,
@@ -1159,7 +1162,7 @@ export const getEntityHeaders = (
  */
 export const getEntityHeader = (entityId: string, accessToken?: string) => {
   return doGet<EntityHeader>(
-    `/repo/v1/entity/${entityId}/type`,
+    ENTITY_HEADER_BY_ID(entityId),
     accessToken,
     BackendDestinationEnum.REPO_ENDPOINT,
   )
@@ -3000,7 +3003,7 @@ export const getMyProjects = (
     removeUndefined(params) as Record<string, string>,
   )
   return doGet<ProjectHeaderList>(
-    `/repo/v1/projects?${urlParams.toString()}`,
+    `${PROJECTS}?${urlParams.toString()}`,
     accessToken,
     BackendDestinationEnum.REPO_ENDPOINT,
   )
@@ -3025,7 +3028,7 @@ export const getUserProjects = (
 // https://rest-docs.synapse.org/rest/GET/entity/id/path.html
 export const getEntityPath = (entityId: string, accessToken?: string) => {
   return doGet<EntityPath>(
-    `/repo/v1/entity/${entityId}/path`,
+    ENTITY_PATH(entityId),
     accessToken,
     BackendDestinationEnum.REPO_ENDPOINT,
   )

--- a/src/lib/utils/hooks/SynapseAPI/entity/useGetEntityHeaders.ts
+++ b/src/lib/utils/hooks/SynapseAPI/entity/useGetEntityHeaders.ts
@@ -10,17 +10,26 @@ import {
 
 export function useGetEntityHeaders(
   references: ReferenceList,
-  options?: UseQueryOptions<
-    PaginatedResults<EntityHeader>,
-    SynapseClientError,
-    PaginatedResults<EntityHeader>
-  >,
+  options?: UseQueryOptions<PaginatedResults<EntityHeader>, SynapseClientError>,
 ) {
   const { accessToken } = useSynapseContext()
 
   return useQuery<PaginatedResults<EntityHeader>, SynapseClientError>(
     ['entityHeaders', accessToken, references],
     () => SynapseClient.getEntityHeaders(references, accessToken),
+    options,
+  )
+}
+
+export function useGetEntityHeader(
+  entityId: string,
+  options?: UseQueryOptions<EntityHeader, SynapseClientError>,
+) {
+  const { accessToken } = useSynapseContext()
+
+  return useQuery<EntityHeader, SynapseClientError>(
+    ['entityHeader', accessToken, entityId],
+    () => SynapseClient.getEntityHeader(entityId, accessToken),
     options,
   )
 }

--- a/src/lib/utils/synapseTypes/EntityHeader.ts
+++ b/src/lib/utils/synapseTypes/EntityHeader.ts
@@ -1,4 +1,5 @@
 import { ENTITY_CONCRETE_TYPE } from './Entity'
+import { Optional } from '../types/Optional'
 
 /**
  * [EntityHeader | Synapse REST Docs](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/EntityHeader.html)
@@ -36,5 +37,9 @@ export type EntityHeader = {
  * [EntityPath | Synapse REST Docs](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/EntityPath.html)
  */
 export type EntityPath = {
-  path: Pick<EntityHeader, 'name' | 'id' | 'type'>[] // The list of all entities in this entity's path. The first element is the root parent and the last element (n) is the entity.
+  /*
+   * The list of all entities in this entity's path. The first element is the root parent and the last element (n) is
+   * the entity. The name may be undefined for ancestors on which the caller does not have READ access.
+   */
+  path: Optional<Pick<EntityHeader, 'name' | 'id' | 'type'>, 'name'>[]
 }

--- a/src/lib/utils/types/Optional.ts
+++ b/src/lib/utils/types/Optional.ts
@@ -20,6 +20,8 @@
  * To make multiple properties optional, use a String Literal union:
  * type OptionalBarBaz = Optional<FooBarBaz, 'bar' | 'baz'>
  *
+ * To make all properties optional, use the built-in Partial type.
+ *
  * @see https://stackoverflow.com/a/54178819
  */
 export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>


### PR DESCRIPTION
- Handle case where caller may not have access to the project in the EntityFinder
- Refactor EntityTree.tsx to use React Query to fetch favorites, entity path, entity header. Replace related useEffect with useMemo
- Refactor EntityTree tests to use MSW instead of mocking react-query and SynapseClient
- Denote the `name` field as potentially missing in the Entity Path object, which is a likely outcome of PLFM-7654

https://user-images.githubusercontent.com/17580037/213007696-e5b148b9-0ab8-41b5-b77d-15fee6dd626b.mov

