### PR TITLE
Attempt to fix flaky tests: FacetNav

### DIFF
--- a/src/__tests__/lib/containers/widgets/facet-nav/FacetNav.test.tsx
+++ b/src/__tests__/lib/containers/widgets/facet-nav/FacetNav.test.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../../../lib/utils/synapseTypes'
 import testData from '../../../../../mocks/mockQueryResponseDataWithManyEnumFacets'
 import { server } from '../../../../../mocks/msw/server'
+import failOnConsole from 'jest-fail-on-console'
 
 const lastQueryRequest: QueryBundleRequest = {
   concreteType: 'org.sagebionetworks.repo.model.table.QueryBundleRequest',
@@ -93,6 +94,7 @@ function init(
 }
 
 describe('facets display hide/show', () => {
+  failOnConsole()
   beforeAll(() => server.listen())
   afterEach(() => server.restoreHandlers())
   afterAll(() => server.close())
@@ -100,14 +102,14 @@ describe('facets display hide/show', () => {
   it("should display 2 facets with 'show more' button", async () => {
     init()
     expect(await screen.findAllByRole('graphics-document')).toHaveLength(2)
-    screen.getByRole('button', { name: 'View All Charts' })
+    await screen.findByRole('button', { name: 'View All Charts' })
   })
 
   it('shows all facet plots when show more is clicked', async () => {
     init()
     expect(await screen.findAllByRole('graphics-document')).toHaveLength(2)
 
-    const showMoreButton = screen.getByRole('button', {
+    const showMoreButton = await screen.findByRole('button', {
       name: 'View All Charts',
     })
 
@@ -121,10 +123,10 @@ describe('facets display hide/show', () => {
       expectedLength,
     )
 
-    expect(() => screen.getByText('View All Charts')).toThrowError()
+    expect(screen.queryByText('View All Charts')).not.toBeInTheDocument()
   })
 
-  it('if there are only 2 facets show more button should not exist', async () => {
+  it('if there are only 2 facets, show more button should not exist', async () => {
     const data = cloneDeep(defaultQueryContext.data)
     data!.facets = [data!.facets[0], data!.facets[2]]
     init(undefined, {
@@ -132,7 +134,9 @@ describe('facets display hide/show', () => {
     })
     expect(await screen.findAllByRole('graphics-document')).toHaveLength(2)
 
-    expect(() => screen.getByText('View All Charts')).toThrowError()
+    await waitFor(() =>
+      expect(screen.queryByText('View All Charts')).not.toBeInTheDocument(),
+    )
   })
 
   it("should only show specified facets if 'facetsToPlot' are set", async () => {
@@ -142,7 +146,9 @@ describe('facets display hide/show', () => {
 
     // Only two plots are shown and the button is hidden
     expect(await screen.findAllByRole('graphics-document')).toHaveLength(2)
-    expect(() => screen.getByText('View All Charts')).toThrowError()
+    await waitFor(() =>
+      expect(screen.queryByText('View All Charts')).not.toBeInTheDocument(),
+    )
   })
 
   it('hiding facet should hide it from facet grid', async () => {

--- a/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
+++ b/src/lib/containers/widgets/facet-nav/FacetNavPanel.tsx
@@ -1,7 +1,7 @@
 import { InfoOutlined } from '@mui/icons-material'
 import * as PlotlyTyped from 'plotly.js'
 import Plotly from 'plotly.js-basic-dist'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Button, Dropdown, Modal } from 'react-bootstrap'
 import createPlotlyComponent from 'react-plotly.js/factory'
 import { SizeMe } from 'react-sizeme'
@@ -25,6 +25,7 @@ import {
   applyMultipleChangesToValuesColumn,
 } from '../query-filter/FacetFilterControls'
 import { Tooltip } from '@mui/material'
+import { useQuery } from 'react-query'
 
 const Plot = createPlotlyComponent(Plotly)
 
@@ -355,7 +356,6 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
 
   const { getColumnDisplayName } = useQueryVisualizationContext()
 
-  const [plotData, setPlotData] = useState<GraphData>()
   const [showModal, setShowModal] = useState(false)
 
   const plotTitle = getColumnDisplayName(facetToPlot.columnName)
@@ -368,27 +368,27 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
     [data, facetToPlot.columnName],
   )
 
-  useEffect(() => {
-    let isMounted = true
-    if (!facetToPlot) {
-      return
-    } else {
+  const { data: plotData } = useQuery(
+    [
+      'extractPlotDataArray',
+      facetToPlot,
+      getColumnType(),
+      index,
+      plotType,
+      accessToken,
+    ],
+    () =>
       extractPlotDataArray(
         facetToPlot,
         getColumnType(),
         index,
         plotType,
         accessToken,
-      ).then(plotData => {
-        if (isMounted) {
-          setPlotData(plotData)
-        }
-      })
-    }
-    return () => {
-      isMounted = false
-    }
-  }, [facetToPlot, data, index, plotType, accessToken, getColumnType])
+      ),
+    {
+      enabled: !!facetToPlot,
+    },
+  )
 
   /* rendering functions */
   const ChartSelectionToggle = (): JSX.Element => (
@@ -542,6 +542,7 @@ const FacetNavPanel: React.FunctionComponent<FacetNavPanelProps> = (
           )}
           <div
             className={`FacetNavPanel__body${isModalView ? '--expanded' : ''}`}
+            role="graphics-object"
           >
             <SizeMe monitorHeight>
               {({ size }) => (


### PR DESCRIPTION
Tests in FacetNav are failing for me in TravisCI, not entirely sure why. I'm refactoring the tests (and one component change) to get rid of error logs that are either triggering or obscuring the failure reason.

- Use react-query instead of useEffect in FacetNavPanel, mostly to prevent error logs in test
- Attempt to make tests less flaky by refactoring to avoid error and warning logs