### PR TITLE
SWC-6363: More gracefully handle error cases when rendering ENTITYID in tables

### DIFF
--- a/src/__tests__/lib/containers/SynapseTable.test.tsx
+++ b/src/__tests__/lib/containers/SynapseTable.test.tsx
@@ -513,7 +513,7 @@ describe('SynapseTable tests', () => {
       )
 
       await screen.findByTestId('EntityLink')
-      // Verify that the header is passed
+      // Verify that the ID is passed
       expect(mockEntityLink).toHaveBeenCalledWith(
         expect.objectContaining({
           entity: mockEntityLinkValue,

--- a/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
+++ b/src/lib/containers/synapse_table_functions/SynapseTableCell.tsx
@@ -99,36 +99,31 @@ export const SynapseTableCell: React.FC<SynapseTableCellProps> = ({
     rowVersionNumber
   ) {
     const synId = `syn${rowId.toString()}`
-    if (Object.prototype.hasOwnProperty.call(mapEntityIdToHeader, synId)) {
-      return (
-        <p>
-          <EntityLink
-            entity={mapEntityIdToHeader[synId]}
-            versionNumber={rowVersionNumber}
-            className={`${isBold}`}
-            showIcon={false}
-            displayTextField={columnName}
-          />
-        </p>
-      )
-    }
+    const entity = mapEntityIdToHeader[synId] ?? synId
+    return (
+      <p>
+        <EntityLink
+          entity={entity}
+          versionNumber={rowVersionNumber}
+          className={`${isBold}`}
+          showIcon={false}
+          displayTextField={columnName}
+        />
+      </p>
+    )
   }
 
   switch (columnType) {
     case ColumnType.ENTITYID:
-      if (
-        Object.prototype.hasOwnProperty.call(mapEntityIdToHeader, columnValue)
-      ) {
-        return (
-          <p>
-            <EntityLink
-              entity={mapEntityIdToHeader[columnValue]}
-              className={`${isBold}`}
-              displayTextField={'name'}
-            />
-          </p>
-        )
-      }
+      return (
+        <p>
+          <EntityLink
+            entity={mapEntityIdToHeader[columnValue] ?? columnValue}
+            className={`${isBold}`}
+            displayTextField={'name'}
+          />
+        </p>
+      )
       break
     case ColumnType.DATE_LIST: {
       const jsonData: number[] = JSON.parse(columnValue)

--- a/src/lib/containers/table/SynapseTable.tsx
+++ b/src/lib/containers/table/SynapseTable.tsx
@@ -52,20 +52,6 @@ import { TablePagination } from './TablePagination'
 import EntityIDColumnCopyIcon from './EntityIDColumnCopyIcon'
 import ExpandableTableDataCell from './ExpandableTableDataCell'
 
-export const EMPTY_HEADER: EntityHeader = {
-  id: '',
-  name: '',
-  type: 'org.sagebionetworks.repo.model.FileEntity',
-  versionNumber: -1,
-  versionLabel: '',
-  benefactorId: -1,
-  createdBy: '',
-  createdOn: '',
-  modifiedBy: '',
-  modifiedOn: '',
-  isLatestVersion: true,
-}
-
 type Direction = '' | 'ASC' | 'DESC'
 export const SORT_STATE: Direction[] = ['', 'DESC', 'ASC']
 export const DOWNLOAD_OPTIONS_CONTAINER_CLASS = 'SRC-download-options-container'
@@ -279,10 +265,6 @@ export default class SynapseTable extends React.Component<
         },
       )
       try {
-        // initialize mapEntityIdToHeader
-        referenceList.forEach(el => {
-          mapEntityIdToHeader[el.targetId] = EMPTY_HEADER
-        })
         const data = await SynapseClient.getEntityHeaders(
           referenceList,
           this.props.synapseContext.accessToken,


### PR DESCRIPTION
- SynapseTable: Don't create blank entity header if no header is fetched
- SynapseTableCell: pass ID to EntityLink component if no header was fetched.

<img width="410" alt="image" src="https://user-images.githubusercontent.com/17580037/214106112-8a97445b-8995-4107-af20-a3673f8bb3d7.png">
